### PR TITLE
Added CRC Driver

### DIFF
--- a/os/hal/hal.mk
+++ b/os/hal/hal.mk
@@ -3,6 +3,7 @@ include ${CHIBIOS}/os/hal/hal.mk
 HALSRC += ${CHIBIOS}/community/os/hal/src/hal_community.c \
           ${CHIBIOS}/community/os/hal/src/nand.c \
           ${CHIBIOS}/community/os/hal/src/onewire.c \
-          ${CHIBIOS}/community/os/hal/src/eicu.c
+          ${CHIBIOS}/community/os/hal/src/eicu.c \
+          ${CHIBIOS}/community/os/hal/src/crc.c
 
 HALINC += ${CHIBIOS}/community/os/hal/include

--- a/os/hal/include/crc.h
+++ b/os/hal/include/crc.h
@@ -1,0 +1,216 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+/*
+   Rewritten by Emil Fresk (1/5 - 2014) for extended input capture
+   functionality. And fix for spurious callbacks in the interrupt handler.
+*/
+/*
+   Improved by Uladzimir Pylinsky aka barthess (1/3 - 2015) for support of
+   32-bit timers and timers with single capture/compare channels.
+*/
+
+#ifndef _CRC_H_
+#define _CRC_H_
+
+#if HAL_USE_CRC || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   CRC1 software driver enable switch.
+ * @details If set to @p TRUE the support for CRC1 is included.
+ * @note    The default is @p TRUE
+ */
+#if !defined(CRCSW_USE_CRC1) || defined(__DOXYGEN__)
+#define CRCSW_USE_CRC1                  FALSE
+#endif
+
+/**
+ * @brief   Enables the @p crcAcquireBus() and @p crcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(CRC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define CRC_USE_MUTUAL_EXCLUSION        TRUE
+#endif
+
+/**
+ * @brief Enables software CRC32
+ */
+#if !defined(CRCSW_CRC32) || defined(__DOXYGEN__)
+#define CRCSW_CRC32                     FALSE
+#endif
+
+/**
+ * @brief Enables software CRC16
+ */
+#if !defined(CRCSW_CRC16) || defined(__DOXYGEN__)
+#define CRCSW_CRC16                     FALSE
+#endif
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if CRCSW_USE_CRC1
+#if (CRCSW_CRC32 == FALSE) && (CRCSW_CRC16 == FALSE)
+#error "At least one of CRCSW_CRC32 or CRCSw_CRC16 must be defined"
+#endif
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver state machine possible states.
+ */
+typedef enum {
+  CRC_UNINIT,                /* Not initialized.                           */
+  CRC_STOP,                  /* Stopped.                                   */
+  CRC_READY,                 /* Ready.                                     */
+  CRC_WAITING,               /* Waiting for first edge.                    */
+  CRC_ACTIVE,                /* Active cycle phase.                        */
+  CRC_IDLE                   /* Idle cycle phase.                          */
+} crcstate_t;
+
+#if CRCSW_USE_CRC1 && !defined(__DOXYGEN__)
+/**
+ * @brief   Type of a structure representing an CRC driver.
+ */
+typedef struct CRCDriver CRCDriver;
+
+/**
+ * @brief   Driver configuration structure.
+ */
+typedef struct {
+
+  /**
+   * @brief The size of polynomial to be used for CRC.
+   */
+  uint32_t                 poly_size;
+  /**
+   * @brief The coefficients of the polynomial to be used for CRC.
+   */
+  uint32_t                 poly;
+  /**
+   * @brief The inital value
+   */
+  uint32_t                 initial_val;
+  /**
+   * @brief The final XOR value
+   */
+  uint32_t                 final_val;
+  /* End of the mandatory fields.*/
+  /**
+   * @brief The crc lookup table to use when calculating CRC.
+   */
+  const uint32_t           *table;
+} CRCConfig;
+
+
+/**
+ * @brief   Structure representing an CRC driver.
+ */
+struct CRCDriver {
+  /**
+   * @brief Driver state.
+   */
+  crcstate_t                state;
+  /**
+   * @brief Current configuration data.
+   */
+  const CRCConfig           *config;
+#if CRC_USE_MUTUAL_EXCLUSION || defined(__DOXYGEN__)
+  /**
+   * @brief   Mutex protecting the peripheral.
+   */
+  mutex_t                   mutex;
+#endif /* CRC_USE_MUTUAL_EXCLUSION */
+  /* End of the mandatory fields.*/
+  /**
+   * @brief Current value of calculated CRC.
+   */
+  uint32_t                  crc;
+};
+
+#else 
+#include "crc_lld.h"
+#endif /* CRCSW_USE_CRC1 */
+
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+#if CRCSW_CRC32
+#define CRCSW_CRC32_CONFIG (&crcsw_crc32_config)
+#endif
+
+#if CRCSW_CRC16
+#define CRCSW_CRC16_CONFIG (&crcsw_crc16_config)
+#endif
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if CRCSW_USE_CRC1 && !defined(__DOXYGEN__)
+extern CRCDriver CRCD1;
+#endif
+
+#if CRCSW_CRC32
+extern const CRCConfig crcsw_crc32_config;
+#endif
+
+#if CRCSW_CRC16
+extern const CRCConfig crcsw_crc16_config;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void crcInit(void);
+  void crcObjectInit(CRCDriver *crcp);
+  void crcStart(CRCDriver *crcp, const CRCConfig *config);
+  void crcStop(CRCDriver *crcp);
+  void crcReset(CRCDriver *crcp);
+  uint32_t crcCalcByte(CRCDriver *crcp, uint8_t data);
+  uint32_t crcCalcHalfWord(CRCDriver *crcp, uint16_t data);
+  uint32_t crcCalcWord(CRCDriver *crcp, uint32_t data);
+  uint32_t crcCalc(CRCDriver *crcp, uint8_t *data, uint32_t size);
+#if CRC_USE_MUTUAL_EXCLUSION
+  void crcAcquireUnit(CRCDriver *crcp);
+  void crcReleaseUnit(CRCDriver *crcp);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_CRC */
+
+#endif /* _CRC_H_ */
+
+/** @} */

--- a/os/hal/include/hal_community.h
+++ b/os/hal/include/hal_community.h
@@ -35,6 +35,7 @@
 
 /* Complex drivers.*/
 #include "onewire.h"
+#include "crc.h"
 
 /*===========================================================================*/
 /* Driver constants.                                                         */

--- a/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+++ b/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
@@ -1,0 +1,204 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    STM32/CRCv1/crc_lld.c
+ * @brief   STM32 CRC subsystem low level driver source.
+ *
+ * @addtogroup CRC
+ * @{
+ */
+
+#include "hal.h"
+
+#if HAL_USE_CRC || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   CRC default configuration.
+ */
+static const CRCConfig default_config = {
+  .poly_size   = 32,
+  .poly        = 0x04C11DB7,
+  .initial_val = 0xFFFFFFFF,
+  .final_val   = 0xFFFFFFFF,
+  .cr          = CRC_CR_REV_IN_0 | CRC_CR_REV_OUT
+};
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/** @brief CRC1 driver identifier.*/
+#if STM32_CRC_USE_CRC1 || defined(__DOXYGEN__)
+CRCDriver CRCD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level CRC driver initialization.
+ *
+ * @notapi
+ */
+void crc_lld_init(void) {
+#if STM32_CRC_USE_CRC1
+  crcObjectInit(&CRCD1);
+  CRCD1.crc = CRC;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the CRC peripheral.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @notapi
+ */
+void crc_lld_start(CRCDriver *crcp) {
+  if (crcp->config == NULL)
+    crcp->config = &default_config;
+
+  rccEnableCRC(FALSE);
+
+  crcp->crc->CR = crcp->config->cr;
+
+  switch(crcp->config->poly_size) {
+    case 32:
+      break;
+    case 16:
+      crcp->crc->CR |= CRC_CR_POLYSIZE_0;
+      break;
+    case 8:
+      crcp->crc->CR |= CRC_CR_POLYSIZE_1;
+      break;
+    case 7:
+      crcp->crc->CR |= CRC_CR_POLYSIZE_1 | CRC_CR_POLYSIZE_0;
+      break;
+    default:
+      osalDbgAssert(false, "STM32 Hardware doesn't support polynomial");
+      break;
+  };
+
+  crcp->crc->INIT = crcp->config->initial_val;
+  crcp->crc->POL = crcp->config->poly;
+
+  crc_lld_reset(crcp);
+}
+  
+
+/**
+ * @brief   Deactivates the CRC peripheral.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @notapi
+ */
+void crc_lld_stop(CRCDriver *crcp) {
+  (void)crcp;
+  rccDisableCRC(FALSE);
+}
+
+/**
+ * @brief   Resets current CRC calculation.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @notapi
+ */
+void crc_lld_reset(CRCDriver *crcp) {
+  crcp->crc->CR |= CRC_CR_RESET;
+}
+
+/**
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ *
+ * @notapi
+ */
+uint32_t crc_lld_calc_byte(CRCDriver *crcp, uint8_t data) {
+  __IO uint8_t *crc8 = (__IO uint8_t*)&(crcp->crc->DR);
+  *crc8 = data;
+  return crcp->crc->DR ^ crcp->config->final_val;
+}
+
+/*
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ *
+ * @notapi
+ */
+uint32_t crc_lld_calc_halfword(CRCDriver *crcp, uint16_t data) {
+  __IO uint16_t *crc16 = (__IO uint16_t*)&(crcp->crc->DR);
+  *crc16 = data;
+  return crcp->crc->DR ^ crcp->config->final_val;
+}
+
+/*
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ *
+ * @notapi
+ */
+uint32_t crc_lld_calc_word(CRCDriver *crcp, uint32_t data) {
+  crcp->crc->DR = data;
+  return crcp->crc->DR ^ crcp->config->final_val;
+}
+
+/**
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ * @param[in] size      size of data to be added to crc
+ *
+ * @notapi
+ */
+uint32_t crc_lld_calc(CRCDriver *crcp, uint8_t *data, uint32_t size) {
+  uint32_t i;
+
+  for (i = 0; i < size; i++)
+    crc_lld_calc_byte(crcp, *(data+i));
+
+  return crcp->crc->DR ^ crcp->config->final_val;
+}
+
+#endif /* HAL_USE_CRC */
+
+/** @} */

--- a/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
+++ b/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
@@ -1,0 +1,156 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    STM32/CRCv1/crc_lld.h
+ * @brief   STM32 CRC subsystem low level driver header.
+ *
+ * @addtogroup CRC
+ * @{
+ */
+
+#ifndef _CRC_LLD_H_
+#define _CRC_LLD_H_
+
+#if HAL_USE_CRC || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   CRC1 driver enable switch.
+ * @details If set to @p TRUE the support for CRC1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(STM32_CRC_USE_CRC1) || defined(__DOXYGEN__)
+#define STM32_CRC_USE_CRC1                  FALSE
+#endif
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if defined(STM32_CRC_USE_CRC1) && CRCSW_USE_CRC1
+#error "Software CRC and STM32 CRC1 block conflict"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+#if STM32_CRC_USE_CRC1 && !defined(__DOXYGEN__)
+/**
+ * @brief   Type of a structure representing an CRC driver.
+ */
+typedef struct CRCDriver CRCDriver;
+
+/**
+ * @brief   Driver configuration structure.
+ */
+typedef struct {
+
+  /**
+   * @brief The size of polynomial to be used for CRC.
+   */
+  uint32_t                 poly_size;
+  /**
+   * @brief The coefficients of the polynomial to be used for CRC.
+   */
+  uint32_t                 poly;
+  /**
+   * @brief The inital value
+   */
+  uint32_t                 initial_val;
+  /**
+   * @brief The final XOR value
+   */
+  uint32_t                 final_val;
+  /* End of the mandatory fields.*/
+  /**
+   * @brief CRC CR register initialization data.
+   */
+  uint32_t                  cr;
+} CRCConfig;
+
+
+/**
+ * @brief   Structure representing an CRC driver.
+ */
+struct CRCDriver {
+  /**
+   * @brief Driver state.
+   */
+  crcstate_t                state;
+  /**
+   * @brief Current configuration data.
+   */
+  const CRCConfig           *config;
+#if CRC_USE_MUTUAL_EXCLUSION || defined(__DOXYGEN__)
+  /**
+   * @brief   Mutex protecting the peripheral.
+   */
+  mutex_t                   mutex;
+#endif /* CRC_USE_MUTUAL_EXCLUSION */
+  /* End of the mandatory fields.*/
+  /**
+   * @brief Pointer to the CRCx registers block.
+   */
+  CRC_TypeDef               *crc;
+};
+
+#endif
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if STM32_CRC_USE_CRC1 && !defined(__DOXYGEN__)
+extern CRCDriver CRCD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void crc_lld_init(void);
+  void crc_lld_start(CRCDriver *crcp);
+  void crc_lld_stop(CRCDriver *crcp);
+  void crc_lld_reset(CRCDriver *crcp);
+  uint32_t crc_lld_calc_byte(CRCDriver *crcp, uint8_t data);
+  uint32_t crc_lld_calc_halfword(CRCDriver *crcp, uint16_t data);
+  uint32_t crc_lld_calc_word(CRCDriver *crcp, uint32_t data);
+  uint32_t crc_lld_calc(CRCDriver *crcp, uint8_t *data, uint32_t size);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_CRC */
+
+#endif /* _CRC_LLD_H_ */
+
+/** @} */

--- a/os/hal/ports/STM32/STM32F0xx/platform.mk
+++ b/os/hal/ports/STM32/STM32F0xx/platform.mk
@@ -1,0 +1,6 @@
+include ${CHIBIOS}/os/hal/ports/STM32/STM32F0xx/platform.mk
+
+PLATFORMSRC += ${CHIBIOS}/community/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+
+PLATFORMINC += ${CHIBIOS}/community/os/hal/ports/STM32/LLD/CRCv1 \
+               ${CHIBIOS}/community/os/hal/ports/STM32/LLD

--- a/os/hal/src/crc.c
+++ b/os/hal/src/crc.c
@@ -1,0 +1,427 @@
+/*
+    ChibiOS/RT - Copyright (C) 2006-2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * Hardware Abstraction Layer for CRC Unit
+ */
+#include "hal.h"
+
+#if HAL_USE_CRC || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#if CRCSW_USE_CRC1 || defined(__DOXYGEN__)
+static void crc_lld_init(void);
+static void crc_lld_start(CRCDriver *crcp);
+static void crc_lld_stop(CRCDriver *crcp);
+static void crc_lld_reset(CRCDriver *crcp);
+static uint32_t crc_lld_calc_byte(CRCDriver *crcp, uint8_t data);
+static uint32_t crc_lld_calc_halfword(CRCDriver *crcp, uint16_t data);
+static uint32_t crc_lld_calc_word(CRCDriver *crcp, uint32_t data);
+static uint32_t crc_lld_calc(CRCDriver *crcp, uint8_t *data, uint32_t size);
+#endif
+
+#if CRCSW_CRC32
+static const uint32_t crc32_table[256] = {
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
+    0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
+    0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
+    0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de,
+    0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec,
+    0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5,
+    0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+    0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940,
+    0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116,
+    0x21b4f4b5, 0x56b3c423, 0xcfba9599, 0xb8bda50f,
+    0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,
+    0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a,
+    0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818,
+    0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+    0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457,
+    0x65b0d9c6, 0x12b7e950, 0x8bbeb8ea, 0xfcb9887c,
+    0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2,
+    0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb,
+    0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9,
+    0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086,
+    0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4,
+    0x59b33d17, 0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad,
+    0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683,
+    0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8,
+    0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe,
+    0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7,
+    0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+    0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252,
+    0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60,
+    0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79,
+    0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f,
+    0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04,
+    0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a,
+    0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+    0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21,
+    0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e,
+    0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c,
+    0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45,
+    0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
+    0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0,
+    0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6,
+    0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
+    0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+};
+#endif
+
+#if CRCSW_CRC16
+static const uint32_t crc16_table[256] = {
+  0x0000, 0xC0C1, 0xC181, 0x0140, 0xC301, 0x03C0, 0x0280, 0xC241,
+  0xC601, 0x06C0, 0x0780, 0xC741, 0x0500, 0xC5C1, 0xC481, 0x0440,
+  0xCC01, 0x0CC0, 0x0D80, 0xCD41, 0x0F00, 0xCFC1, 0xCE81, 0x0E40,
+  0x0A00, 0xCAC1, 0xCB81, 0x0B40, 0xC901, 0x09C0, 0x0880, 0xC841,
+  0xD801, 0x18C0, 0x1980, 0xD941, 0x1B00, 0xDBC1, 0xDA81, 0x1A40,
+  0x1E00, 0xDEC1, 0xDF81, 0x1F40, 0xDD01, 0x1DC0, 0x1C80, 0xDC41,
+  0x1400, 0xD4C1, 0xD581, 0x1540, 0xD701, 0x17C0, 0x1680, 0xD641,
+  0xD201, 0x12C0, 0x1380, 0xD341, 0x1100, 0xD1C1, 0xD081, 0x1040,
+  0xF001, 0x30C0, 0x3180, 0xF141, 0x3300, 0xF3C1, 0xF281, 0x3240,
+  0x3600, 0xF6C1, 0xF781, 0x3740, 0xF501, 0x35C0, 0x3480, 0xF441,
+  0x3C00, 0xFCC1, 0xFD81, 0x3D40, 0xFF01, 0x3FC0, 0x3E80, 0xFE41,
+  0xFA01, 0x3AC0, 0x3B80, 0xFB41, 0x3900, 0xF9C1, 0xF881, 0x3840,
+  0x2800, 0xE8C1, 0xE981, 0x2940, 0xEB01, 0x2BC0, 0x2A80, 0xEA41,
+  0xEE01, 0x2EC0, 0x2F80, 0xEF41, 0x2D00, 0xEDC1, 0xEC81, 0x2C40,
+  0xE401, 0x24C0, 0x2580, 0xE541, 0x2700, 0xE7C1, 0xE681, 0x2640,
+  0x2200, 0xE2C1, 0xE381, 0x2340, 0xE101, 0x21C0, 0x2080, 0xE041,
+  0xA001, 0x60C0, 0x6180, 0xA141, 0x6300, 0xA3C1, 0xA281, 0x6240,
+  0x6600, 0xA6C1, 0xA781, 0x6740, 0xA501, 0x65C0, 0x6480, 0xA441,
+  0x6C00, 0xACC1, 0xAD81, 0x6D40, 0xAF01, 0x6FC0, 0x6E80, 0xAE41,
+  0xAA01, 0x6AC0, 0x6B80, 0xAB41, 0x6900, 0xA9C1, 0xA881, 0x6840,
+  0x7800, 0xB8C1, 0xB981, 0x7940, 0xBB01, 0x7BC0, 0x7A80, 0xBA41,
+  0xBE01, 0x7EC0, 0x7F80, 0xBF41, 0x7D00, 0xBDC1, 0xBC81, 0x7C40,
+  0xB401, 0x74C0, 0x7580, 0xB541, 0x7700, 0xB7C1, 0xB681, 0x7640,
+  0x7200, 0xB2C1, 0xB381, 0x7340, 0xB101, 0x71C0, 0x7080, 0xB041,
+  0x5000, 0x90C1, 0x9181, 0x5140, 0x9301, 0x53C0, 0x5280, 0x9241,
+  0x9601, 0x56C0, 0x5780, 0x9741, 0x5500, 0x95C1, 0x9481, 0x5440,
+  0x9C01, 0x5CC0, 0x5D80, 0x9D41, 0x5F00, 0x9FC1, 0x9E81, 0x5E40,
+  0x5A00, 0x9AC1, 0x9B81, 0x5B40, 0x9901, 0x59C0, 0x5880, 0x9841,
+  0x8801, 0x48C0, 0x4980, 0x8941, 0x4B00, 0x8BC1, 0x8A81, 0x4A40,
+  0x4E00, 0x8EC1, 0x8F81, 0x4F40, 0x8D01, 0x4DC0, 0x4C80, 0x8C41,
+  0x4400, 0x84C1, 0x8581, 0x4540, 0x8701, 0x47C0, 0x4680, 0x8641,
+  0x8201, 0x42C0, 0x4380, 0x8341, 0x4100, 0x81C1, 0x8081, 0x4040
+};
+#endif
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+#if CRCSW_USE_CRC1 || defined(__DOXYGEN__)
+CRCDriver CRCD1;
+#endif
+
+#if CRCSW_CRC32 || defined(__DOXYGEN__)
+const CRCConfig crcsw_crc32_config = {
+  .poly_size    = 32,
+  .poly         = 0x04C11DB7,
+  .initial_val  = 0xFFFFFFFF,
+  .final_val    = 0xFFFFFFFF,
+  .table        = crc32_table
+};
+#endif
+
+#if CRCSW_CRC16 || defined(__DOXYGEN__)
+const CRCConfig crcsw_crc16_config = {
+  .poly_size    = 16,
+  .poly         = 0x8005,
+  .initial_val  = 0x0,
+  .final_val    = 0x0,
+  .table = crc16_table
+};
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+#if CRCSW_USE_CRC1
+
+/**
+ * @brief   Low level CRC software initialization.
+ *
+ * @notapi
+ */
+static void crc_lld_init(void) {
+  crcObjectInit(&CRCD1);
+}
+
+/**
+ * @brief   Configures and activates the CRC peripheral.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @notapi
+ */
+static void crc_lld_start(CRCDriver *crcp) {
+  osalDbgAssert(crcp->config != NULL, "Software CRC currently only support CRC32");
+  crc_lld_reset(crcp);
+}
+  
+
+/**
+ * @brief   Deactivates the CRC peripheral.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @notapi
+ */
+static void crc_lld_stop(CRCDriver *crcp) {
+  (void)crcp;
+}
+
+/**
+ * @brief   Resets current CRC calculation.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @notapi
+ */
+static void crc_lld_reset(CRCDriver *crcp) {
+  crcp->crc = crcp->config->initial_val;
+}
+
+/**
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ *
+ * @notapi
+ */
+static uint32_t crc_lld_calc_byte(CRCDriver *crcp, uint8_t data) {
+  uint8_t idx = (crcp->crc ^ data);
+  crcp->crc = (crcp->config->table[idx] ^ (crcp->crc >> 8));
+  return crcp->crc ^ crcp->config->final_val;
+}
+
+
+/*
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ *
+ * @notapi
+ */
+static uint32_t crc_lld_calc_halfword(CRCDriver *crcp, uint16_t data) {
+  crc_lld_calc_byte(crcp, ((data & 0xFF00) >> 8));
+  crc_lld_calc_byte(crcp, (data & 0x00FF));
+  return crcp->crc ^ crcp->config->final_val;
+}
+
+/*
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ *
+ * @notapi
+ */
+static uint32_t crc_lld_calc_word(CRCDriver *crcp, uint32_t data) {
+  crc_lld_calc_byte(crcp, ((data & 0xFF000000) >> 24));
+  crc_lld_calc_byte(crcp, ((data & 0x00FF0000) >> 16));
+  crc_lld_calc_byte(crcp, ((data & 0x0000FF00) >> 8));
+  crc_lld_calc_byte(crcp, (data & 0x0000000FF));
+  return crcp->crc ^ crcp->config->final_val;
+}
+
+/**
+ * @brief   Returns calculated CRC from last reset
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ * @param[in] data      data to be added to crc
+ * @param[in] size      size of data to be added to crc
+ *
+ * @notapi
+ */
+static uint32_t crc_lld_calc(CRCDriver *crcp, uint8_t *data, uint32_t size) {
+  uint32_t i;
+  for (i = 0; i < size; i++)
+    crc_lld_calc_byte(crcp, *(data+i));
+
+  return crcp->crc ^ crcp->config->final_val;
+}
+
+#endif /* CRCSW_USE_CRC1 */
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   CRC Driver initialization.
+ *
+ * @init
+ */
+void crcInit(void) {
+
+  crc_lld_init();
+}
+
+/**
+ * @brief   Initializes the standard part of a @p CRCDriver structure.
+ *
+ * @param[out] crcp    Pointer to the @p CRCDriver object
+ *
+ * @init
+ */
+void crcObjectInit(CRCDriver *crcp) {
+
+  crcp->state  = CRC_STOP;
+  crcp->config = NULL;
+#if CRC_USE_MUTUAL_EXCLUSION == TRUE
+  osalMutexObjectInit(&crcp->mutex);
+#endif
+}
+
+/**
+ * @brief   Configures and activates the CRC peripheral.
+ *
+ * @param[in] crcp     Pointer to the @p CRCDriver object
+ * @param[in] config    Pointer to the @p CRCConfig object
+ *                      @p NULL if the low level driver implementation
+ *                      supports a default configuration
+ *
+ * @api
+ */
+void crcStart(CRCDriver *crcp, const CRCConfig *config) {
+
+  osalDbgCheck(crcp != NULL);
+
+  osalSysLock();
+  osalDbgAssert((crcp->state == CRC_STOP) || (crcp->state == CRC_READY),
+                "invalid state");
+  crcp->config = config;
+  crc_lld_start(crcp);
+  crcp->state = CRC_READY;
+  osalSysUnlock();
+}
+
+/**
+ * @brief   Deactivates the CRC peripheral.
+ *
+ * @param[in] crcp     Pointer to the @p CRCDriver object
+ *
+ * @api
+ */
+void crcStop(CRCDriver *crcp) {
+
+  osalDbgCheck(crcp != NULL);
+
+  osalSysLock();
+  osalDbgAssert((crcp->state == CRC_STOP) || (crcp->state == CRC_READY),
+                "invalid state");
+  crc_lld_stop(crcp);
+  crcp->state = CRC_STOP;
+  osalSysUnlock();
+}
+
+void crcReset(CRCDriver *crcp) {
+  osalDbgCheck(crcp != NULL);
+
+  crc_lld_reset(crcp);
+}
+
+uint32_t crcCalcByte(CRCDriver *crcp, uint8_t data) {
+  osalDbgCheck(crcp != NULL);
+  return crc_lld_calc_byte(crcp, data);
+}
+
+uint32_t crcCalcHalfWord(CRCDriver *crcp, uint16_t data) {
+  osalDbgCheck(crcp != NULL);
+  return crc_lld_calc_halfword(crcp, data);
+}
+
+uint32_t crcCalcWord(CRCDriver *crcp, uint32_t data) {
+  osalDbgCheck(crcp != NULL);
+  return crc_lld_calc_word(crcp, data);
+}
+
+uint32_t crcCalc(CRCDriver *crcp, uint8_t *data, uint32_t size) {
+  osalDbgCheck(crcp != NULL);
+  osalDbgCheck(data != NULL);
+  return crc_lld_calc(crcp, data, size);
+}
+
+#if (CRC_USE_MUTUAL_EXCLUSION == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Gains exclusive access to the CRC unit.
+ * @details This function tries to gain ownership to the CRC, if the CRC is
+ *          already being used then the invoking thread is queued.
+ * @pre     In order to use this function the option @p CRC_USE_MUTUAL_EXCLUSION
+ *          must be enabled.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @api
+ */
+void crcAcquireUnit(CRCDriver *crcp) {
+
+  osalDbgCheck(crcp != NULL);
+
+  osalMutexLock(&crcp->mutex);
+}
+
+/**
+ * @brief   Releases exclusive access to the CRC unit.
+ * @pre     In order to use this function the option @p CRC_USE_MUTUAL_EXCLUSION
+ *          must be enabled.
+ *
+ * @param[in] crcp      pointer to the @p CRCDriver object
+ *
+ * @api
+ */
+void crcReleaseUnit(CRCDriver *crcp) {
+
+  osalDbgCheck(crcp != NULL);
+
+  osalMutexUnlock(&crcp->mutex);
+}
+#endif /* CRC_USE_MUTUAL_EXCLUSION == TRUE */
+
+
+#endif /* HAL_USE_CRC */

--- a/os/hal/src/hal_community.c
+++ b/os/hal/src/hal_community.c
@@ -60,6 +60,10 @@ void halCommunityInit(void) {
 #if HAL_USE_EICU || defined(__DOXYGEN__)
   eicuInit();
 #endif
+
+#if HAL_USE_CRC || defined(__DOXYGEN__)
+  crcInit();
+#endif
 }
 
 #endif /* HAL_USE_COMMUNITY */


### PR DESCRIPTION
Included in this patch is a high level and two low level drivers.

The high level driver is enabled with flag HAL_USE_CRC

The low level drivers include:
    * Hardware CRC for the STM32 cortex processor lines.(when supported)
        * Enabled with flag STM32_CRC_USE_CRC1
    * Software CRC16 and CRC32, done via lookup tables.
        * Enabled with flag CRCSW_USE_CRC1
        * CRC32 and CRC16 can be individually enabled with flags CRCSW_CR32 and CRCSW_CRC16 respectively.