### PR TITLE
Cleanup nRF51 serial driver

### DIFF
--- a/demos/NRF51/RT-WVSHARE_BLE400/main.c
+++ b/demos/NRF51/RT-WVSHARE_BLE400/main.c
@@ -39,8 +39,8 @@ int main(void) {
 
   SerialConfig serial_config = {
     .speed = 38400,
-    .tx_pin = UART_TX,
-    .rx_pin = UART_RX,
+    .tx_pad = UART_TX,
+    .rx_pad = UART_RX,
   };
 
   /*

--- a/os/hal/ports/NRF51/NRF51822/serial_lld.h
+++ b/os/hal/ports/NRF51/NRF51822/serial_lld.h
@@ -40,13 +40,25 @@
  * @{
  */
 /**
- * @brief   USART1 driver enable switch.
- * @details If set to @p TRUE the support for USART1 is included.
+ * @brief   SD1 driver enable switch.
+ * @details If set to @p TRUE the support for SD1 is included.
  * @note    The default is @p FALSE.
  */
 #if !defined(NRF51_SERIAL_USE_UART0) || defined(__DOXYGEN__)
 #define NRF51_SERIAL_USE_UART0             FALSE
 #endif
+
+/**
+ * @brief   UART0 interrupt priority level setting.
+ */
+#if !defined(NRF51_SERIAL_UART0_PRIORITY) || defined(__DOXYGEN__)
+#define NRF51_SERIAL_UART0_PRIORITY        12
+#endif
+
+/* Value indicating that no pad is connected to this UART register. */
+#define  NRF51_SERIAL_PAD_DISCONNECTED 0xFFFFFFFFU
+#define  NRF51_SERIAL_INVALID_BAUDRATE 0xFFFFFFFFU
+
 /** @} */
 
 /*===========================================================================*/
@@ -71,8 +83,8 @@ typedef struct {
    */
   uint32_t                  speed;
   /* End of the mandatory fields.*/
-  uint8_t                   tx_pin;
-  uint8_t                   rx_pin;
+  uint32_t                  tx_pad;
+  uint32_t                  rx_pad;
 } SerialConfig;
 
 /**
@@ -90,6 +102,8 @@ typedef struct {
   uint8_t                   ib[SERIAL_BUFFERS_SIZE];                        \
   /* Output circular buffer.*/                                              \
   uint8_t                   ob[SERIAL_BUFFERS_SIZE];                        \
+  /* 1 if port is busy transmitting, 0 otherwise. */                        \
+  uint8_t                   tx_busy;                                        \
   /* End of the mandatory fields.*/                                         \
   thread_t                  *thread;
 


### PR DESCRIPTION
Use values from bitfields header. Also convert notify1 function to be
non-blocking, which seems to be how most of the other serial drivers are
implemented.