### PR TITLE
Added missing HEAP_RAM definition

### DIFF
--- a/os/common/ports/ARMCMx/compilers/GCC/ld/NRF51822.ld
+++ b/os/common/ports/ARMCMx/compilers/GCC/ld/NRF51822.ld
@@ -44,5 +44,7 @@ REGION_ALIAS("DATA_RAM", ram0);
 /* RAM region to be used for BSS segment.*/
 REGION_ALIAS("BSS_RAM", ram0);
 
+/* RAM region to be used for HEAP segment.*/
+REGION_ALIAS("HEAP_RAM", ram0);
 
 INCLUDE rules.ld


### PR DESCRIPTION
linker was generating a warning, and tests were failing on "Heap, allocation and fragmentation test"