### PR TITLE
Ease dev with flash/debug target helper

### DIFF
--- a/os/hal/boards/NRF51-DK/board.mk
+++ b/os/hal/boards/NRF51-DK/board.mk
@@ -3,3 +3,9 @@ BOARDSRC = ${CHIBIOS_CONTRIB}/os/hal/boards/NRF51-DK/board.c
 
 # Required include directories
 BOARDINC = ${CHIBIOS_CONTRIB}/os/hal/boards/NRF51-DK
+
+# Flash
+JLINK_DEVICE    = nrf51422
+JLINK_PRE_FLASH = w4 4001e504 1
+JLINK_ERASE_ALL = w4 4001e504 2\nw4 4001e50c 1\nsleep 100
+

--- a/os/various/gdb.mk
+++ b/os/various/gdb.mk
@@ -1,0 +1,13 @@
+GDB               ?= arm-none-eabi-gdb
+GDB_PROGRAM       ?= $(BUILDDIR)/$(PROJECT).elf
+GDB_PORT          ?= 2331
+GDB_START_ADDRESS ?= 0
+GDB_BREAK         ?= main
+
+gdb-debug:
+	printf "target remote localhost:$(GDB_PORT)\nmem $(GDB_START_ADDRESS) 0\nbreak $(GDB_BREAK)\nload\nmon reset\ncontinue" > .gdbinit
+	$(GDB) --command=.gdbinit $(GDB_PROGRAM)
+
+
+
+.PHONY: gdb-debug

--- a/os/various/jlink.mk
+++ b/os/various/jlink.mk
@@ -1,0 +1,33 @@
+JLINK               ?= JLinkExe
+JLINK_GDB_SERVER    ?= JLinkGDBServer
+JLINK_GDB_PORT      ?= 2331
+JLINK_IF            ?= swd
+JLINK_SPEED         ?= 2000
+JLINK_START_ADDRESS ?= 0
+JLINK_BURN          ?= $(BUILDDIR)/$(PROJECT).bin
+JLINK_COMMON_OPTS   ?= -device $(JLINK_DEVICE) -if $(JLINK_IF) -speed $(JLINK_SPEED)
+
+jlink-flash:
+	printf "$(JLINK_PRE_FLASH)\nloadbin $(JLINK_BURN) $(JLINK_START_ADDRESS)\nverifybin $(JLINK_BURN) $(JLINK_START_ADDRESS)\nr\ng\nexit\n" > $(BUILDDIR)/flash.jlink
+	$(JLINK) $(JLINK_COMMON_OPTS) $(BUILDDIR)/flash.jlink
+
+ifneq ($(SOFTDEVICE),)
+jlink-flash-softdevice:
+	printf "w4 4001e504 1\nloadbin $(NRF51SDK)/components/softdevice/$(SOFTDEVICE)/hex/$(SOFTDEVICE)_nrf51_$(SOFTDEVICE_RELEASE)_softdevice.hex 0\nr\ng\nexit\n" > $(BUILDDIR)/flash.softdevice.jlink
+	$(JLINK) $(JLINK_COMMON_OPTS) $(BUILDDIR)/flash.softdevice.jlink
+endif
+
+ifneq ($(JLINK_ERASE_ALL),)
+jlink-erase-all: 
+	printf "$(JLINK_ERASE_ALL)\nr\nexit\n" > $(BUILDDIR)/erase-all.jlink
+	$(JLINK) $(JLINK_COMMON_OPTS) $(BUILDDIR)/erase-all.jlink
+endif
+
+jlink-reset: 
+	printf "r\nexit\n" > $(BUILDDIR)/reset.jlink
+	$(JLINK) $(JLINK_COMMON_OPTS) $(BUILDDIR)/reset.jlink
+
+jlink-debug-server:
+	$(JLINK_GDB_SERVER) $(JLINK_COMMON_OPTS) -port $(JLINK_GDB_PORT)
+
+.PHONY: jlink-flash jlink-flash-softdevice jlink-erase-all jlink-reset jlink-debug-server


### PR DESCRIPTION
Adding two make file (jlink.mk and gdb.mk), to simplify development by adding to the Makefile

```
include $(CHIBIOS_CONTRIB)/os/various/jlink.mk
include $(CHIBIOS_CONTRIB)/os/various/gdb.mk

flash: all jlink-flash
debug: gdb-debug
```