### PR TITLE
[KINETIS] I2C update (timeouts, KL27Z)

### DIFF
--- a/os/common/ext/CMSIS/KINETIS/kl25z.h
+++ b/os/common/ext/CMSIS/KINETIS/kl25z.h
@@ -777,57 +777,9 @@ typedef struct
 
 /****************************************************************/
 /*                                                              */
-/*             Inter-Integrated Circuit (I2C)                   */
+/*   Inter-Integrated Circuit (I2C): Device dependent part      */
 /*                                                              */
 /****************************************************************/
-/***********  Bits definition for I2Cx_A1 register  *************/
-#define I2Cx_A1_AD_MASK              ((uint8_t)0xFE)    /*!< Address [7:1] */
-#define I2Cx_A1_AD_SHIFT             1
-#define I2Cx_A1_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_A1_AD_SHIFT) & I2Cx_A1_AD_MASK)
-
-/***********  Bits definition for I2Cx_F register  **************/
-#define I2Cx_F_MULT_MASK             ((uint8_t)0xC0)    /*!< Multiplier factor */
-#define I2Cx_F_MULT_SHIFT            6
-#define I2Cx_F_MULT(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_F_MULT_SHIFT) & I2Cx_F_MULT_MASK)
-#define I2Cx_F_ICR_MASK              ((uint8_t)0x3F)    /*!< Clock rate */
-#define I2Cx_F_ICR_SHIFT             0
-#define I2Cx_F_ICR(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_F_ICR_SHIFT) & I2Cx_F_ICR_MASK)
-
-/***********  Bits definition for I2Cx_C1 register  *************/
-#define I2Cx_C1_IICEN                ((uint8_t)0x80)    /*!< I2C Enable */
-#define I2Cx_C1_IICIE                ((uint8_t)0x40)    /*!< I2C Interrupt Enable */
-#define I2Cx_C1_MST                  ((uint8_t)0x20)    /*!< Master Mode Select */
-#define I2Cx_C1_TX                   ((uint8_t)0x10)    /*!< Transmit Mode Select */
-#define I2Cx_C1_TXAK                 ((uint8_t)0x08)    /*!< Transmit Acknowledge Enable */
-#define I2Cx_C1_RSTA                 ((uint8_t)0x04)    /*!< Repeat START */
-#define I2Cx_C1_WUEN                 ((uint8_t)0x02)    /*!< Wakeup Enable */
-#define I2Cx_C1_DMAEN                ((uint8_t)0x01)    /*!< DMA Enable */
-
-/***********  Bits definition for I2Cx_S register  **************/
-#define I2Cx_S_TCF                   ((uint8_t)0x80)    /*!< Transfer Complete Flag */
-#define I2Cx_S_IAAS                  ((uint8_t)0x40)    /*!< Addressed As A Slave */
-#define I2Cx_S_BUSY                  ((uint8_t)0x20)    /*!< Bus Busy */
-#define I2Cx_S_ARBL                  ((uint8_t)0x10)    /*!< Arbitration Lost */
-#define I2Cx_S_RAM                   ((uint8_t)0x08)    /*!< Range Address Match */
-#define I2Cx_S_SRW                   ((uint8_t)0x04)    /*!< Slave Read/Write */
-#define I2Cx_S_IICIF                 ((uint8_t)0x02)    /*!< Interrupt Flag */
-#define I2Cx_S_RXAK                  ((uint8_t)0x01)    /*!< Receive Acknowledge */
-
-/***********  Bits definition for I2Cx_D register  **************/
-#define I2Cx_D_DATA_SHIFT            0                  /*!< Data */
-#define I2Cx_D_DATA_MASK             ((uint8_t)((uint8_t)0xFF << I2Cx_D_DATA_SHIFT))
-#define I2Cx_D_DATA(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_D_DATA_SHIFT) & I2Cx_D_DATA_MASK))
-
-/***********  Bits definition for I2Cx_C2 register  *************/
-#define I2Cx_C2_GCAEN                ((uint8_t)0x80)    /*!< General Call Address Enable */
-#define I2Cx_C2_ADEXT                ((uint8_t)0x40)    /*!< Address Extension */
-#define I2Cx_C2_HDRS                 ((uint8_t)0x20)    /*!< High Drive Select */
-#define I2Cx_C2_SBRC                 ((uint8_t)0x10)    /*!< Slave Baud Rate Control */
-#define I2Cx_C2_RMEN                 ((uint8_t)0x08)    /*!< Range Address Matching Enable */
-#define I2Cx_C2_AD_SHIFT             0                  /*!< Slave Address [10:8] */
-#define I2Cx_C2_AD_MASK              ((uint8_t)((uint8_t)0x7 << I2Cx_C2_AD_SHIFT))
-#define I2Cx_C2_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_C2_AD_SHIFT) & I2Cx_C2_AD_MASK))
-
 /***********  Bits definition for I2Cx_FLT register  ************/
 #define I2Cx_FLT_SHEN                ((uint8_t)0x80)    /*!< Stop Hold Enable */
 #define I2Cx_FLT_STOPF               ((uint8_t)0x40)    /*!< I2C Bus Stop Detect Flag */
@@ -835,36 +787,6 @@ typedef struct
 #define I2Cx_FLT_FLT_SHIFT           0                  /*!< I2C Programmable Filter Factor */
 #define I2Cx_FLT_FLT_MASK            ((uint8_t)((uint8_t)0x1F << I2Cx_FLT_FLT_SHIFT))
 #define I2Cx_FLT_FLT(x)              ((uint8_t)(((uint8_t)(x) << I2Cx_FLT_FLT_SHIFT) & I2Cx_FLT_FLT_MASK))
-
-/***********  Bits definition for I2Cx_RA register  *************/
-#define I2Cx_RA_RAD_SHIFT            1                  /*!< Range Slave Address */
-#define I2Cx_RA_RAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_RA_RAD_SHIFT))
-#define I2Cx_RA_RAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_RA_RAD_SHIFT) & I2Cx_RA_RAD_MASK))
-
-/***********  Bits definition for I2Cx_SMB register  ************/
-#define I2Cx_SMB_FACK                ((uint8_t)0x80)    /*!< Fast NACK/ACK Enable */
-#define I2Cx_SMB_ALERTEN             ((uint8_t)0x40)    /*!< SMBus Alert Response Address Enable */
-#define I2Cx_SMB_SIICAEN             ((uint8_t)0x20)    /*!< Second I2C Address Enable */
-#define I2Cx_SMB_TCKSEL              ((uint8_t)0x10)    /*!< Timeout Counter Clock Select */
-#define I2Cx_SMB_SLTF                ((uint8_t)0x08)    /*!< SCL Low Timeout Flag */
-#define I2Cx_SMB_SHTF1               ((uint8_t)0x04)    /*!< SCL High Timeout Flag 1 */
-#define I2Cx_SMB_SHTF2               ((uint8_t)0x02)    /*!< SCL High Timeout Flag 2 */
-#define I2Cx_SMB_SHTF2IE             ((uint8_t)0x01)    /*!< SHTF2 Interrupt Enable */
-
-/***********  Bits definition for I2Cx_A2 register  *************/
-#define I2Cx_A2_SAD_SHIFT            1                  /*!< SMBus Address */
-#define I2Cx_A2_SAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_A2_SAD_SHIFT))
-#define I2Cx_A2_SAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_A2_SAD_SHIFT) & I2Cx_A2_SAD_MASK))
-
-/***********  Bits definition for I2Cx_SLTH register  ***********/
-#define I2Cx_SLTH_SSLT_SHIFT         0                  /*!< MSB of SCL low timeout value */
-#define I2Cx_SLTH_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTH_SSLT_SHIFT))
-#define I2Cx_SLTH_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTH_SSLT_SHIFT) & I2Cx_SLTH_SSLT_MASK))
-
-/***********  Bits definition for I2Cx_SLTL register  ***********/
-#define I2Cx_SLTL_SSLT_SHIFT         0                  /*!< LSB of SCL low timeout value */
-#define I2Cx_SLTL_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTL_SSLT_SHIFT))
-#define I2Cx_SLTL_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTL_SSLT_SHIFT) & I2Cx_SLTL_SSLT_MASK))
 
 /****************************************************************/
 /*                                                              */

--- a/os/common/ext/CMSIS/KINETIS/kl26z.h
+++ b/os/common/ext/CMSIS/KINETIS/kl26z.h
@@ -152,7 +152,7 @@ typedef struct
   __IO uint8_t  A1;
   __IO uint8_t  F;
   __IO uint8_t  C1;
-  __IO uint8_t  S1;
+  __IO uint8_t  S; /* Denoted 'S1' in datasheet. */
   __IO uint8_t  D;
   __IO uint8_t  C2;
   __IO uint8_t  FLT;
@@ -876,14 +876,14 @@ typedef struct {
 #define I2Cx_C1_DMAEN                ((uint8_t)0x01)    /*!< DMA Enable */
 
 /***********  Bits definition for I2Cx_S1 register  *************/
-#define I2Cx_S1_TCF                  ((uint8_t)0x80)    /*!< Transfer Complete Flag */
-#define I2Cx_S1_IAAS                 ((uint8_t)0x40)    /*!< Addressed As A Slave */
-#define I2Cx_S1_BUSY                 ((uint8_t)0x20)    /*!< Bus Busy */
-#define I2Cx_S1_ARBL                 ((uint8_t)0x10)    /*!< Arbitration Lost */
-#define I2Cx_S1_RAM                  ((uint8_t)0x08)    /*!< Range Address Match */
-#define I2Cx_S1_SRW                  ((uint8_t)0x04)    /*!< Slave Read/Write */
-#define I2Cx_S1_IICIF                ((uint8_t)0x02)    /*!< Interrupt Flag */
-#define I2Cx_S1_RXAK                 ((uint8_t)0x01)    /*!< Receive Acknowledge */
+#define I2Cx_S_TCF                   ((uint8_t)0x80)    /*!< Transfer Complete Flag */
+#define I2Cx_S_IAAS                  ((uint8_t)0x40)    /*!< Addressed As A Slave */
+#define I2Cx_S_BUSY                  ((uint8_t)0x20)    /*!< Bus Busy */
+#define I2Cx_S_ARBL                  ((uint8_t)0x10)    /*!< Arbitration Lost */
+#define I2Cx_S_RAM                   ((uint8_t)0x08)    /*!< Range Address Match */
+#define I2Cx_S_SRW                   ((uint8_t)0x04)    /*!< Slave Read/Write */
+#define I2Cx_S_IICIF                 ((uint8_t)0x02)    /*!< Interrupt Flag */
+#define I2Cx_S_RXAK                  ((uint8_t)0x01)    /*!< Receive Acknowledge */
 
 /***********  Bits definition for I2Cx_D register  **************/
 #define I2Cx_D_DATA_SHIFT            0                  /*!< Data */

--- a/os/common/ext/CMSIS/KINETIS/kl26z.h
+++ b/os/common/ext/CMSIS/KINETIS/kl26z.h
@@ -849,57 +849,9 @@ typedef struct {
 
 /****************************************************************/
 /*                                                              */
-/*             Inter-Integrated Circuit (I2C)                   */
+/*   Inter-Integrated Circuit (I2C): Device dependent part      */
 /*                                                              */
 /****************************************************************/
-/***********  Bits definition for I2Cx_A1 register  *************/
-#define I2Cx_A1_AD_MASK              ((uint8_t)0xFE)    /*!< Address [7:1] */
-#define I2Cx_A1_AD_SHIFT             1
-#define I2Cx_A1_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_A1_AD_SHIFT) & I2Cx_A1_AD_MASK)
-
-/***********  Bits definition for I2Cx_F register  **************/
-#define I2Cx_F_MULT_MASK             ((uint8_t)0xC0)    /*!< Multiplier factor */
-#define I2Cx_F_MULT_SHIFT            6
-#define I2Cx_F_MULT(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_F_MULT_SHIFT) & I2Cx_F_MULT_MASK)
-#define I2Cx_F_ICR_MASK              ((uint8_t)0x3F)    /*!< Clock rate */
-#define I2Cx_F_ICR_SHIFT             0
-#define I2Cx_F_ICR(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_F_ICR_SHIFT) & I2Cx_F_ICR_MASK)
-
-/***********  Bits definition for I2Cx_C1 register  *************/
-#define I2Cx_C1_IICEN                ((uint8_t)0x80)    /*!< I2C Enable */
-#define I2Cx_C1_IICIE                ((uint8_t)0x40)    /*!< I2C Interrupt Enable */
-#define I2Cx_C1_MST                  ((uint8_t)0x20)    /*!< Master Mode Select */
-#define I2Cx_C1_TX                   ((uint8_t)0x10)    /*!< Transmit Mode Select */
-#define I2Cx_C1_TXAK                 ((uint8_t)0x08)    /*!< Transmit Acknowledge Enable */
-#define I2Cx_C1_RSTA                 ((uint8_t)0x04)    /*!< Repeat START */
-#define I2Cx_C1_WUEN                 ((uint8_t)0x02)    /*!< Wakeup Enable */
-#define I2Cx_C1_DMAEN                ((uint8_t)0x01)    /*!< DMA Enable */
-
-/***********  Bits definition for I2Cx_S1 register  *************/
-#define I2Cx_S_TCF                   ((uint8_t)0x80)    /*!< Transfer Complete Flag */
-#define I2Cx_S_IAAS                  ((uint8_t)0x40)    /*!< Addressed As A Slave */
-#define I2Cx_S_BUSY                  ((uint8_t)0x20)    /*!< Bus Busy */
-#define I2Cx_S_ARBL                  ((uint8_t)0x10)    /*!< Arbitration Lost */
-#define I2Cx_S_RAM                   ((uint8_t)0x08)    /*!< Range Address Match */
-#define I2Cx_S_SRW                   ((uint8_t)0x04)    /*!< Slave Read/Write */
-#define I2Cx_S_IICIF                 ((uint8_t)0x02)    /*!< Interrupt Flag */
-#define I2Cx_S_RXAK                  ((uint8_t)0x01)    /*!< Receive Acknowledge */
-
-/***********  Bits definition for I2Cx_D register  **************/
-#define I2Cx_D_DATA_SHIFT            0                  /*!< Data */
-#define I2Cx_D_DATA_MASK             ((uint8_t)((uint8_t)0xFF << I2Cx_D_DATA_SHIFT))
-#define I2Cx_D_DATA(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_D_DATA_SHIFT) & I2Cx_D_DATA_MASK))
-
-/***********  Bits definition for I2Cx_C2 register  *************/
-#define I2Cx_C2_GCAEN                ((uint8_t)0x80)    /*!< General Call Address Enable */
-#define I2Cx_C2_ADEXT                ((uint8_t)0x40)    /*!< Address Extension */
-#define I2Cx_C2_HDRS                 ((uint8_t)0x20)    /*!< High Drive Select */
-#define I2Cx_C2_SBRC                 ((uint8_t)0x10)    /*!< Slave Baud Rate Control */
-#define I2Cx_C2_RMEN                 ((uint8_t)0x08)    /*!< Range Address Matching Enable */
-#define I2Cx_C2_AD_SHIFT             0                  /*!< Slave Address [10:8] */
-#define I2Cx_C2_AD_MASK              ((uint8_t)((uint8_t)0x7 << I2Cx_C2_AD_SHIFT))
-#define I2Cx_C2_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_C2_AD_SHIFT) & I2Cx_C2_AD_MASK))
-
 /***********  Bits definition for I2Cx_FLT register  ************/
 #define I2Cx_FLT_SHEN                ((uint8_t)0x80)    /*!< Stop Hold Enable */
 #define I2Cx_FLT_STOPF               ((uint8_t)0x40)    /*!< I2C Bus Stop Detect Flag */
@@ -907,36 +859,6 @@ typedef struct {
 #define I2Cx_FLT_FLT_SHIFT           0                  /*!< I2C Programmable Filter Factor */
 #define I2Cx_FLT_FLT_MASK            ((uint8_t)((uint8_t)0x1F << I2Cx_FLT_FLT_SHIFT))
 #define I2Cx_FLT_FLT(x)              ((uint8_t)(((uint8_t)(x) << I2Cx_FLT_FLT_SHIFT) & I2Cx_FLT_FLT_MASK))
-
-/***********  Bits definition for I2Cx_RA register  *************/
-#define I2Cx_RA_RAD_SHIFT            1                  /*!< Range Slave Address */
-#define I2Cx_RA_RAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_RA_RAD_SHIFT))
-#define I2Cx_RA_RAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_RA_RAD_SHIFT) & I2Cx_RA_RAD_MASK))
-
-/***********  Bits definition for I2Cx_SMB register  ************/
-#define I2Cx_SMB_FACK                ((uint8_t)0x80)    /*!< Fast NACK/ACK Enable */
-#define I2Cx_SMB_ALERTEN             ((uint8_t)0x40)    /*!< SMBus Alert Response Address Enable */
-#define I2Cx_SMB_SIICAEN             ((uint8_t)0x20)    /*!< Second I2C Address Enable */
-#define I2Cx_SMB_TCKSEL              ((uint8_t)0x10)    /*!< Timeout Counter Clock Select */
-#define I2Cx_SMB_SLTF                ((uint8_t)0x08)    /*!< SCL Low Timeout Flag */
-#define I2Cx_SMB_SHTF1               ((uint8_t)0x04)    /*!< SCL High Timeout Flag 1 */
-#define I2Cx_SMB_SHTF2               ((uint8_t)0x02)    /*!< SCL High Timeout Flag 2 */
-#define I2Cx_SMB_SHTF2IE             ((uint8_t)0x01)    /*!< SHTF2 Interrupt Enable */
-
-/***********  Bits definition for I2Cx_A2 register  *************/
-#define I2Cx_A2_SAD_SHIFT            1                  /*!< SMBus Address */
-#define I2Cx_A2_SAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_A2_SAD_SHIFT))
-#define I2Cx_A2_SAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_A2_SAD_SHIFT) & I2Cx_A2_SAD_MASK))
-
-/***********  Bits definition for I2Cx_SLTH register  ***********/
-#define I2Cx_SLTH_SSLT_SHIFT         0                  /*!< MSB of SCL low timeout value */
-#define I2Cx_SLTH_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTH_SSLT_SHIFT))
-#define I2Cx_SLTH_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTH_SSLT_SHIFT) & I2Cx_SLTH_SSLT_MASK))
-
-/***********  Bits definition for I2Cx_SLTL register  ***********/
-#define I2Cx_SLTL_SSLT_SHIFT         0                  /*!< LSB of SCL low timeout value */
-#define I2Cx_SLTL_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTL_SSLT_SHIFT))
-#define I2Cx_SLTL_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTL_SSLT_SHIFT) & I2Cx_SLTL_SSLT_MASK))
 
 /****************************************************************/
 /*                                                              */

--- a/os/common/ext/CMSIS/KINETIS/kl27zxx.h
+++ b/os/common/ext/CMSIS/KINETIS/kl27zxx.h
@@ -757,57 +757,9 @@ typedef struct
 
 /****************************************************************/
 /*                                                              */
-/*             Inter-Integrated Circuit (I2C)                   */
+/*   Inter-Integrated Circuit (I2C): Device dependent part      */
 /*                                                              */
 /****************************************************************/
-/***********  Bits definition for I2Cx_A1 register  *************/
-#define I2Cx_A1_AD_MASK              ((uint8_t)0xFE)    /*!< Address [7:1] */
-#define I2Cx_A1_AD_SHIFT             1
-#define I2Cx_A1_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_A1_AD_SHIFT) & I2Cx_A1_AD_MASK)
-
-/***********  Bits definition for I2Cx_F register  **************/
-#define I2Cx_F_MULT_MASK             ((uint8_t)0xC0)    /*!< Multiplier factor */
-#define I2Cx_F_MULT_SHIFT            6
-#define I2Cx_F_MULT(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_F_MULT_SHIFT) & I2Cx_F_MULT_MASK)
-#define I2Cx_F_ICR_MASK              ((uint8_t)0x3F)    /*!< Clock rate */
-#define I2Cx_F_ICR_SHIFT             0
-#define I2Cx_F_ICR(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_F_ICR_SHIFT) & I2Cx_F_ICR_MASK)
-
-/***********  Bits definition for I2Cx_C1 register  *************/
-#define I2Cx_C1_IICEN                ((uint8_t)0x80)    /*!< I2C Enable */
-#define I2Cx_C1_IICIE                ((uint8_t)0x40)    /*!< I2C Interrupt Enable */
-#define I2Cx_C1_MST                  ((uint8_t)0x20)    /*!< Master Mode Select */
-#define I2Cx_C1_TX                   ((uint8_t)0x10)    /*!< Transmit Mode Select */
-#define I2Cx_C1_TXAK                 ((uint8_t)0x08)    /*!< Transmit Acknowledge Enable */
-#define I2Cx_C1_RSTA                 ((uint8_t)0x04)    /*!< Repeat START */
-#define I2Cx_C1_WUEN                 ((uint8_t)0x02)    /*!< Wakeup Enable */
-#define I2Cx_C1_DMAEN                ((uint8_t)0x01)    /*!< DMA Enable */
-
-/***********  Bits definition for I2Cx_S register  **************/
-#define I2Cx_S_TCF                   ((uint8_t)0x80)    /*!< Transfer Complete Flag */
-#define I2Cx_S_IAAS                  ((uint8_t)0x40)    /*!< Addressed As A Slave */
-#define I2Cx_S_BUSY                  ((uint8_t)0x20)    /*!< Bus Busy */
-#define I2Cx_S_ARBL                  ((uint8_t)0x10)    /*!< Arbitration Lost */
-#define I2Cx_S_RAM                   ((uint8_t)0x08)    /*!< Range Address Match */
-#define I2Cx_S_SRW                   ((uint8_t)0x04)    /*!< Slave Read/Write */
-#define I2Cx_S_IICIF                 ((uint8_t)0x02)    /*!< Interrupt Flag */
-#define I2Cx_S_RXAK                  ((uint8_t)0x01)    /*!< Receive Acknowledge */
-
-/***********  Bits definition for I2Cx_D register  **************/
-#define I2Cx_D_DATA_SHIFT            0                  /*!< Data */
-#define I2Cx_D_DATA_MASK             ((uint8_t)((uint8_t)0xFF << I2Cx_D_DATA_SHIFT))
-#define I2Cx_D_DATA(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_D_DATA_SHIFT) & I2Cx_D_DATA_MASK))
-
-/***********  Bits definition for I2Cx_C2 register  *************/
-#define I2Cx_C2_GCAEN                ((uint8_t)0x80)    /*!< General Call Address Enable */
-#define I2Cx_C2_ADEXT                ((uint8_t)0x40)    /*!< Address Extension */
-#define I2Cx_C2_HDRS                 ((uint8_t)0x20)    /*!< High Drive Select */
-#define I2Cx_C2_SBRC                 ((uint8_t)0x10)    /*!< Slave Baud Rate Control */
-#define I2Cx_C2_RMEN                 ((uint8_t)0x08)    /*!< Range Address Matching Enable */
-#define I2Cx_C2_AD_SHIFT             0                  /*!< Slave Address [10:8] */
-#define I2Cx_C2_AD_MASK              ((uint8_t)((uint8_t)0x7 << I2Cx_C2_AD_SHIFT))
-#define I2Cx_C2_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_C2_AD_SHIFT) & I2Cx_C2_AD_MASK))
-
 /***********  Bits definition for I2Cx_FLT register  ************/
 #define I2Cx_FLT_SHEN                ((uint8_t)0x80)    /*!< Stop Hold Enable */
 #define I2Cx_FLT_STOPF               ((uint8_t)0x40)    /*!< I2C Bus Stop Detect Flag */
@@ -816,36 +768,6 @@ typedef struct
 #define I2Cx_FLT_FLT_SHIFT           0                  /*!< I2C Programmable Filter Factor */
 #define I2Cx_FLT_FLT_MASK            ((uint8_t)((uint8_t)0x0F << I2Cx_FLT_FLT_SHIFT))
 #define I2Cx_FLT_FLT(x)              ((uint8_t)(((uint8_t)(x) << I2Cx_FLT_FLT_SHIFT) & I2Cx_FLT_FLT_MASK))
-
-/***********  Bits definition for I2Cx_RA register  *************/
-#define I2Cx_RA_RAD_SHIFT            1                  /*!< Range Slave Address */
-#define I2Cx_RA_RAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_RA_RAD_SHIFT))
-#define I2Cx_RA_RAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_RA_RAD_SHIFT) & I2Cx_RA_RAD_MASK))
-
-/***********  Bits definition for I2Cx_SMB register  ************/
-#define I2Cx_SMB_FACK                ((uint8_t)0x80)    /*!< Fast NACK/ACK Enable */
-#define I2Cx_SMB_ALERTEN             ((uint8_t)0x40)    /*!< SMBus Alert Response Address Enable */
-#define I2Cx_SMB_SIICAEN             ((uint8_t)0x20)    /*!< Second I2C Address Enable */
-#define I2Cx_SMB_TCKSEL              ((uint8_t)0x10)    /*!< Timeout Counter Clock Select */
-#define I2Cx_SMB_SLTF                ((uint8_t)0x08)    /*!< SCL Low Timeout Flag */
-#define I2Cx_SMB_SHTF1               ((uint8_t)0x04)    /*!< SCL High Timeout Flag 1 */
-#define I2Cx_SMB_SHTF2               ((uint8_t)0x02)    /*!< SCL High Timeout Flag 2 */
-#define I2Cx_SMB_SHTF2IE             ((uint8_t)0x01)    /*!< SHTF2 Interrupt Enable */
-
-/***********  Bits definition for I2Cx_A2 register  *************/
-#define I2Cx_A2_SAD_SHIFT            1                  /*!< SMBus Address */
-#define I2Cx_A2_SAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_A2_SAD_SHIFT))
-#define I2Cx_A2_SAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_A2_SAD_SHIFT) & I2Cx_A2_SAD_MASK))
-
-/***********  Bits definition for I2Cx_SLTH register  ***********/
-#define I2Cx_SLTH_SSLT_SHIFT         0                  /*!< MSB of SCL low timeout value */
-#define I2Cx_SLTH_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTH_SSLT_SHIFT))
-#define I2Cx_SLTH_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTH_SSLT_SHIFT) & I2Cx_SLTH_SSLT_MASK))
-
-/***********  Bits definition for I2Cx_SLTL register  ***********/
-#define I2Cx_SLTL_SSLT_SHIFT         0                  /*!< LSB of SCL low timeout value */
-#define I2Cx_SLTL_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTL_SSLT_SHIFT))
-#define I2Cx_SLTL_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTL_SSLT_SHIFT) & I2Cx_SLTL_SSLT_MASK))
 
 /***********  Bits definition for I2Cx_S2 register  *************/
 #define I2Cx_S2_ERROR                ((uint8_t)0x02)    /*!< Error flag */

--- a/os/common/ext/CMSIS/KINETIS/kl27zxxx.h
+++ b/os/common/ext/CMSIS/KINETIS/kl27zxxx.h
@@ -783,57 +783,9 @@ typedef struct {
 
 /****************************************************************/
 /*                                                              */
-/*             Inter-Integrated Circuit (I2C)                   */
+/*   Inter-Integrated Circuit (I2C): Device dependent part      */
 /*                                                              */
 /****************************************************************/
-/***********  Bits definition for I2Cx_A1 register  *************/
-#define I2Cx_A1_AD_MASK              ((uint8_t)0xFE)    /*!< Address [7:1] */
-#define I2Cx_A1_AD_SHIFT             1
-#define I2Cx_A1_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_A1_AD_SHIFT) & I2Cx_A1_AD_MASK)
-
-/***********  Bits definition for I2Cx_F register  **************/
-#define I2Cx_F_MULT_MASK             ((uint8_t)0xC0)    /*!< Multiplier factor */
-#define I2Cx_F_MULT_SHIFT            6
-#define I2Cx_F_MULT(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_F_MULT_SHIFT) & I2Cx_F_MULT_MASK)
-#define I2Cx_F_ICR_MASK              ((uint8_t)0x3F)    /*!< Clock rate */
-#define I2Cx_F_ICR_SHIFT             0
-#define I2Cx_F_ICR(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_F_ICR_SHIFT) & I2Cx_F_ICR_MASK)
-
-/***********  Bits definition for I2Cx_C1 register  *************/
-#define I2Cx_C1_IICEN                ((uint8_t)0x80)    /*!< I2C Enable */
-#define I2Cx_C1_IICIE                ((uint8_t)0x40)    /*!< I2C Interrupt Enable */
-#define I2Cx_C1_MST                  ((uint8_t)0x20)    /*!< Master Mode Select */
-#define I2Cx_C1_TX                   ((uint8_t)0x10)    /*!< Transmit Mode Select */
-#define I2Cx_C1_TXAK                 ((uint8_t)0x08)    /*!< Transmit Acknowledge Enable */
-#define I2Cx_C1_RSTA                 ((uint8_t)0x04)    /*!< Repeat START */
-#define I2Cx_C1_WUEN                 ((uint8_t)0x02)    /*!< Wakeup Enable */
-#define I2Cx_C1_DMAEN                ((uint8_t)0x01)    /*!< DMA Enable */
-
-/***********  Bits definition for I2Cx_S register  **************/
-#define I2Cx_S_TCF                   ((uint8_t)0x80)    /*!< Transfer Complete Flag */
-#define I2Cx_S_IAAS                  ((uint8_t)0x40)    /*!< Addressed As A Slave */
-#define I2Cx_S_BUSY                  ((uint8_t)0x20)    /*!< Bus Busy */
-#define I2Cx_S_ARBL                  ((uint8_t)0x10)    /*!< Arbitration Lost */
-#define I2Cx_S_RAM                   ((uint8_t)0x08)    /*!< Range Address Match */
-#define I2Cx_S_SRW                   ((uint8_t)0x04)    /*!< Slave Read/Write */
-#define I2Cx_S_IICIF                 ((uint8_t)0x02)    /*!< Interrupt Flag */
-#define I2Cx_S_RXAK                  ((uint8_t)0x01)    /*!< Receive Acknowledge */
-
-/***********  Bits definition for I2Cx_D register  **************/
-#define I2Cx_D_DATA_SHIFT            0                  /*!< Data */
-#define I2Cx_D_DATA_MASK             ((uint8_t)((uint8_t)0xFF << I2Cx_D_DATA_SHIFT))
-#define I2Cx_D_DATA(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_D_DATA_SHIFT) & I2Cx_D_DATA_MASK))
-
-/***********  Bits definition for I2Cx_C2 register  *************/
-#define I2Cx_C2_GCAEN                ((uint8_t)0x80)    /*!< General Call Address Enable */
-#define I2Cx_C2_ADEXT                ((uint8_t)0x40)    /*!< Address Extension */
-#define I2Cx_C2_HDRS                 ((uint8_t)0x20)    /*!< High Drive Select */
-#define I2Cx_C2_SBRC                 ((uint8_t)0x10)    /*!< Slave Baud Rate Control */
-#define I2Cx_C2_RMEN                 ((uint8_t)0x08)    /*!< Range Address Matching Enable */
-#define I2Cx_C2_AD_SHIFT             0                  /*!< Slave Address [10:8] */
-#define I2Cx_C2_AD_MASK              ((uint8_t)((uint8_t)0x7 << I2Cx_C2_AD_SHIFT))
-#define I2Cx_C2_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_C2_AD_SHIFT) & I2Cx_C2_AD_MASK))
-
 /***********  Bits definition for I2Cx_FLT register  ************/
 #define I2Cx_FLT_SHEN                ((uint8_t)0x80)    /*!< Stop Hold Enable */
 #define I2Cx_FLT_STOPF               ((uint8_t)0x40)    /*!< I2C Bus Stop Detect Flag */
@@ -842,36 +794,6 @@ typedef struct {
 #define I2Cx_FLT_FLT_SHIFT           0                  /*!< I2C Programmable Filter Factor */
 #define I2Cx_FLT_FLT_MASK            ((uint8_t)((uint8_t)0x0F << I2Cx_FLT_FLT_SHIFT))
 #define I2Cx_FLT_FLT(x)              ((uint8_t)(((uint8_t)(x) << I2Cx_FLT_FLT_SHIFT) & I2Cx_FLT_FLT_MASK))
-
-/***********  Bits definition for I2Cx_RA register  *************/
-#define I2Cx_RA_RAD_SHIFT            1                  /*!< Range Slave Address */
-#define I2Cx_RA_RAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_RA_RAD_SHIFT))
-#define I2Cx_RA_RAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_RA_RAD_SHIFT) & I2Cx_RA_RAD_MASK))
-
-/***********  Bits definition for I2Cx_SMB register  ************/
-#define I2Cx_SMB_FACK                ((uint8_t)0x80)    /*!< Fast NACK/ACK Enable */
-#define I2Cx_SMB_ALERTEN             ((uint8_t)0x40)    /*!< SMBus Alert Response Address Enable */
-#define I2Cx_SMB_SIICAEN             ((uint8_t)0x20)    /*!< Second I2C Address Enable */
-#define I2Cx_SMB_TCKSEL              ((uint8_t)0x10)    /*!< Timeout Counter Clock Select */
-#define I2Cx_SMB_SLTF                ((uint8_t)0x08)    /*!< SCL Low Timeout Flag */
-#define I2Cx_SMB_SHTF1               ((uint8_t)0x04)    /*!< SCL High Timeout Flag 1 */
-#define I2Cx_SMB_SHTF2               ((uint8_t)0x02)    /*!< SCL High Timeout Flag 2 */
-#define I2Cx_SMB_SHTF2IE             ((uint8_t)0x01)    /*!< SHTF2 Interrupt Enable */
-
-/***********  Bits definition for I2Cx_A2 register  *************/
-#define I2Cx_A2_SAD_SHIFT            1                  /*!< SMBus Address */
-#define I2Cx_A2_SAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_A2_SAD_SHIFT))
-#define I2Cx_A2_SAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_A2_SAD_SHIFT) & I2Cx_A2_SAD_MASK))
-
-/***********  Bits definition for I2Cx_SLTH register  ***********/
-#define I2Cx_SLTH_SSLT_SHIFT         0                  /*!< MSB of SCL low timeout value */
-#define I2Cx_SLTH_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTH_SSLT_SHIFT))
-#define I2Cx_SLTH_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTH_SSLT_SHIFT) & I2Cx_SLTH_SSLT_MASK))
-
-/***********  Bits definition for I2Cx_SLTL register  ***********/
-#define I2Cx_SLTL_SSLT_SHIFT         0                  /*!< LSB of SCL low timeout value */
-#define I2Cx_SLTL_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTL_SSLT_SHIFT))
-#define I2Cx_SLTL_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTL_SSLT_SHIFT) & I2Cx_SLTL_SSLT_MASK))
 
 /***********  Bits definition for I2Cx_S2 register  *************/
 #define I2Cx_S2_ERROR                ((uint8_t)0x02)    /*!< Error flag */

--- a/os/common/ext/CMSIS/KINETIS/kl2xz.h
+++ b/os/common/ext/CMSIS/KINETIS/kl2xz.h
@@ -693,11 +693,87 @@ typedef struct
 
 /****************************************************************/
 /*                                                              */
-/*             Inter-Integrated Circuit (I2C)                   */
+/*   Inter-Integrated Circuit (I2C): Device independent part    */
 /*                                                              */
 /****************************************************************/
+/***********  Bits definition for I2Cx_A1 register  *************/
+#define I2Cx_A1_AD_MASK              ((uint8_t)0xFE)    /*!< Address [7:1] */
+#define I2Cx_A1_AD_SHIFT             1
+#define I2Cx_A1_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_A1_AD_SHIFT) & I2Cx_A1_AD_MASK)
 
-/* Device dependent */
+/***********  Bits definition for I2Cx_F register  **************/
+#define I2Cx_F_MULT_MASK             ((uint8_t)0xC0)    /*!< Multiplier factor */
+#define I2Cx_F_MULT_SHIFT            6
+#define I2Cx_F_MULT(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_F_MULT_SHIFT) & I2Cx_F_MULT_MASK)
+#define I2Cx_F_ICR_MASK              ((uint8_t)0x3F)    /*!< Clock rate */
+#define I2Cx_F_ICR_SHIFT             0
+#define I2Cx_F_ICR(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_F_ICR_SHIFT) & I2Cx_F_ICR_MASK)
+
+/***********  Bits definition for I2Cx_C1 register  *************/
+#define I2Cx_C1_IICEN                ((uint8_t)0x80)    /*!< I2C Enable */
+#define I2Cx_C1_IICIE                ((uint8_t)0x40)    /*!< I2C Interrupt Enable */
+#define I2Cx_C1_MST                  ((uint8_t)0x20)    /*!< Master Mode Select */
+#define I2Cx_C1_TX                   ((uint8_t)0x10)    /*!< Transmit Mode Select */
+#define I2Cx_C1_TXAK                 ((uint8_t)0x08)    /*!< Transmit Acknowledge Enable */
+#define I2Cx_C1_RSTA                 ((uint8_t)0x04)    /*!< Repeat START */
+#define I2Cx_C1_WUEN                 ((uint8_t)0x02)    /*!< Wakeup Enable */
+#define I2Cx_C1_DMAEN                ((uint8_t)0x01)    /*!< DMA Enable */
+
+/***********  Bits definition for I2Cx_S register  **************/
+/*** This register is referred to as 'S1' in KL26Z manual *******/
+#define I2Cx_S_TCF                   ((uint8_t)0x80)    /*!< Transfer Complete Flag */
+#define I2Cx_S_IAAS                  ((uint8_t)0x40)    /*!< Addressed As A Slave */
+#define I2Cx_S_BUSY                  ((uint8_t)0x20)    /*!< Bus Busy */
+#define I2Cx_S_ARBL                  ((uint8_t)0x10)    /*!< Arbitration Lost */
+#define I2Cx_S_RAM                   ((uint8_t)0x08)    /*!< Range Address Match */
+#define I2Cx_S_SRW                   ((uint8_t)0x04)    /*!< Slave Read/Write */
+#define I2Cx_S_IICIF                 ((uint8_t)0x02)    /*!< Interrupt Flag */
+#define I2Cx_S_RXAK                  ((uint8_t)0x01)    /*!< Receive Acknowledge */
+
+/***********  Bits definition for I2Cx_D register  **************/
+#define I2Cx_D_DATA_SHIFT            0                  /*!< Data */
+#define I2Cx_D_DATA_MASK             ((uint8_t)((uint8_t)0xFF << I2Cx_D_DATA_SHIFT))
+#define I2Cx_D_DATA(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_D_DATA_SHIFT) & I2Cx_D_DATA_MASK))
+
+/***********  Bits definition for I2Cx_C2 register  *************/
+#define I2Cx_C2_GCAEN                ((uint8_t)0x80)    /*!< General Call Address Enable */
+#define I2Cx_C2_ADEXT                ((uint8_t)0x40)    /*!< Address Extension */
+#define I2Cx_C2_HDRS                 ((uint8_t)0x20)    /*!< High Drive Select */
+#define I2Cx_C2_SBRC                 ((uint8_t)0x10)    /*!< Slave Baud Rate Control */
+#define I2Cx_C2_RMEN                 ((uint8_t)0x08)    /*!< Range Address Matching Enable */
+#define I2Cx_C2_AD_SHIFT             0                  /*!< Slave Address [10:8] */
+#define I2Cx_C2_AD_MASK              ((uint8_t)((uint8_t)0x7 << I2Cx_C2_AD_SHIFT))
+#define I2Cx_C2_AD(x)                ((uint8_t)(((uint8_t)(x) << I2Cx_C2_AD_SHIFT) & I2Cx_C2_AD_MASK))
+
+/***********  Bits definition for I2Cx_RA register  *************/
+#define I2Cx_RA_RAD_SHIFT            1                  /*!< Range Slave Address */
+#define I2Cx_RA_RAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_RA_RAD_SHIFT))
+#define I2Cx_RA_RAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_RA_RAD_SHIFT) & I2Cx_RA_RAD_MASK))
+
+/***********  Bits definition for I2Cx_SMB register  ************/
+#define I2Cx_SMB_FACK                ((uint8_t)0x80)    /*!< Fast NACK/ACK Enable */
+#define I2Cx_SMB_ALERTEN             ((uint8_t)0x40)    /*!< SMBus Alert Response Address Enable */
+#define I2Cx_SMB_SIICAEN             ((uint8_t)0x20)    /*!< Second I2C Address Enable */
+#define I2Cx_SMB_TCKSEL              ((uint8_t)0x10)    /*!< Timeout Counter Clock Select */
+#define I2Cx_SMB_SLTF                ((uint8_t)0x08)    /*!< SCL Low Timeout Flag */
+#define I2Cx_SMB_SHTF1               ((uint8_t)0x04)    /*!< SCL High Timeout Flag 1 */
+#define I2Cx_SMB_SHTF2               ((uint8_t)0x02)    /*!< SCL High Timeout Flag 2 */
+#define I2Cx_SMB_SHTF2IE             ((uint8_t)0x01)    /*!< SHTF2 Interrupt Enable */
+
+/***********  Bits definition for I2Cx_A2 register  *************/
+#define I2Cx_A2_SAD_SHIFT            1                  /*!< SMBus Address */
+#define I2Cx_A2_SAD_MASK             ((uint8_t)((uint8_t)0x7F << I2Cx_A2_SAD_SHIFT))
+#define I2Cx_A2_SAD(x)               ((uint8_t)(((uint8_t)(x) << I2Cx_A2_SAD_SHIFT) & I2Cx_A2_SAD_MASK))
+
+/***********  Bits definition for I2Cx_SLTH register  ***********/
+#define I2Cx_SLTH_SSLT_SHIFT         0                  /*!< MSB of SCL low timeout value */
+#define I2Cx_SLTH_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTH_SSLT_SHIFT))
+#define I2Cx_SLTH_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTH_SSLT_SHIFT) & I2Cx_SLTH_SSLT_MASK))
+
+/***********  Bits definition for I2Cx_SLTL register  ***********/
+#define I2Cx_SLTL_SSLT_SHIFT         0                  /*!< LSB of SCL low timeout value */
+#define I2Cx_SLTL_SSLT_MASK          ((uint8_t)((uint8_t)0xFF << I2Cx_SLTL_SSLT_SHIFT))
+#define I2Cx_SLTL_SSLT(x)            ((uint8_t)(((uint8_t)(x) << I2Cx_SLTL_SSLT_SHIFT) & I2Cx_SLTL_SSLT_MASK))
 
 /****************************************************************/
 /*                                                              */

--- a/os/hal/boards/FREESCALE_FREEDOM_KL26Z/board.h
+++ b/os/hal/boards/FREESCALE_FREEDOM_KL26Z/board.h
@@ -49,11 +49,13 @@
 #define GPIO_LIGHTSNS   IOPORT5
 #define PIN_LIGHTSNS    22
 
-#define I2C_INERIAL_SENSOR I2C0
-
 /*
  * Not configured:
  *  - TSI Slider on PTB16/TSI0_CH9 and PTB17/TSI_CH10
+ *  - I2C inertial sensor on I2C0, routed to PTE25 and PTE25
+ *    Note: these pins are assigned to I2C0 by default;
+ *          if I2C0 is wanted on other pins, these need to be
+ *          assigned another function explicitly!
  */
 
 #if !defined(_FROM_ASM_)

--- a/os/hal/ports/KINETIS/LLD/hal_i2c_lld.c
+++ b/os/hal/ports/KINETIS/LLD/hal_i2c_lld.c
@@ -80,9 +80,9 @@ void config_frequency(I2CDriver *i2cp) {
   uint16_t best, diff;
 
   if (i2cp->config != NULL)
-    divisor = KINETIS_SYSCLK_FREQUENCY / i2cp->config->clock;
+    divisor = KINETIS_BUSCLK_FREQUENCY / i2cp->config->clock;
   else
-    divisor = KINETIS_SYSCLK_FREQUENCY / 100000;
+    divisor = KINETIS_BUSCLK_FREQUENCY / 100000;
 
   best = ~0;
   index = 0;

--- a/os/hal/ports/KINETIS/LLD/hal_i2c_lld.h
+++ b/os/hal/ports/KINETIS/LLD/hal_i2c_lld.h
@@ -77,6 +77,13 @@
 #define KINETIS_I2C_I2C1_PRIORITY        12
 #endif
 
+/**
+ * @brief   Timeout for external clearing BUSY bus (in ms).
+ */
+#if !defined(KINETIS_I2C_BUSY_TIMEOUT) || defined(__DOXYGEN__)
+#define KINETIS_I2C_BUSY_TIMEOUT 50
+#endif
+
 /*===========================================================================*/
 /* Derived constants and error checks.                                       */
 /*===========================================================================*/

--- a/os/hal/ports/KINETIS/LLD/hal_i2c_lld.h
+++ b/os/hal/ports/KINETIS/LLD/hal_i2c_lld.h
@@ -34,7 +34,11 @@
 #define STATE_STOP    0x00
 #define STATE_SEND    0x01
 #define STATE_RECV    0x02
-#define STATE_DUMMY   0x03
+
+#if defined(KL27Zxxx) || defined(KL27Zxx) /* KL27Z RST workaround */
+#define RSTA_WORKAROUND_OFF    0x00
+#define RSTA_WORKAROUND_ON     0x01
+#endif /* KL27Z RST workaround */
 
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
@@ -188,6 +192,10 @@ struct I2CDriver {
   intstate_t                intstate;
   /* @brief Low-level register access. */
   I2C_TypeDef               *i2c;
+#if defined(KL27Zxxx) || defined(KL27Zxx) /* KL27Z RST workaround */
+  /* @brief Auxiliary variable for KL27Z repeated start workaround. */
+  intstate_t                rsta_workaround;
+#endif /* KL27Z RST workaround */
 };
 
 /*===========================================================================*/

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/Makefile
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/Makefile
@@ -1,0 +1,210 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 -DCRT0_INIT_STACKS=0
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO)
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+# If enabled, this option allows to compile the application in THUMB mode.
+ifeq ($(USE_THUMB),)
+  USE_THUMB = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x200
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x400
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Imported source files and paths
+CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
+# Startup files.
+include $(CHIBIOS_CONTRIB)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_kl2x.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS_CONTRIB)/os/hal/ports/KINETIS/KL2x/platform.mk
+include $(CHIBIOS_CONTRIB)/os/hal/boards/FREESCALE_FREEDOM_KL26Z/board.mk
+include $(CHIBIOS)/os/hal/osal/rt/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC/mk/port_v6m.mk
+# Other files (optional).
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/MKL2xZ128.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(STARTUPSRC) \
+       $(KERNSRC) \
+       $(PORTSRC) \
+       $(OSALSRC) \
+       $(HALSRC) \
+       $(PLATFORMSRC) \
+       $(BOARDSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC =
+
+# C sources to be compiled in ARM mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+ACSRC =
+
+# C++ sources to be compiled in ARM mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+ACPPSRC =
+
+# C sources to be compiled in THUMB mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+TCSRC =
+
+# C sources to be compiled in THUMB mode regardless of the global setting.
+# NOTE: Mixing ARM and THUMB mode enables the -mthumb-interwork compiler
+#       option that results in lower performance and larger code size.
+TCPPSRC =
+
+# List ASM source files here
+ASMSRC = $(STARTUPASM) $(PORTASM) $(OSALASM)
+
+INCDIR = $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
+         $(HALINC) $(PLATFORMINC) $(BOARDINC)
+
+#
+# Project, sources and paths
+##############################################################################
+
+##############################################################################
+# Compiler settings
+#
+
+MCU  = cortex-m0plus
+
+#TRGT = arm-elf-
+TRGT = arm-none-eabi-
+CC   = $(TRGT)gcc
+CPPC = $(TRGT)g++
+# Enable loading with g++ only if you need C++ runtime support.
+# NOTE: You can use C++ even without C++ support if you are careful. C++
+#       runtime support makes code size explode.
+LD   = $(TRGT)gcc
+#LD   = $(TRGT)g++
+CP   = $(TRGT)objcopy
+AS   = $(TRGT)gcc -x assembler-with-cpp
+AR   = $(TRGT)ar
+OD   = $(TRGT)objdump
+SZ   = $(TRGT)size
+HEX  = $(CP) -O ihex
+BIN  = $(CP) -O binary
+SREC = $(CP) -O srec
+
+# ARM-specific options here
+AOPT =
+
+# THUMB-specific options here
+TOPT = -mthumb -DTHUMB
+
+# Define C warning options here
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Compiler settings
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS =
+
+# Define ASM defines here
+UADEFS =
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user defines
+##############################################################################
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC
+include $(RULESPATH)/rules.mk

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/chconf.h
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/chconf.h
@@ -1,0 +1,516 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel related settings and hooks.
+ * @{
+ */
+
+#ifndef _CHCONF_H_
+#define _CHCONF_H_
+
+#define _CHIBIOS_RT_CONF_
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#define CH_CFG_ST_RESOLUTION                32
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ */
+#define CH_CFG_ST_FREQUENCY                 1000
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#define CH_CFG_ST_TIMEDELTA                 0
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#define CH_CFG_TIME_QUANTUM                 20
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#define CH_CFG_MEMCORE_SIZE                 0
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_TM                       FALSE
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_REGISTRY                 TRUE
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_WAITEXIT                 TRUE
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_SEMAPHORES               TRUE
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MUTEXES                  TRUE
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#define CH_CFG_USE_CONDVARS                 TRUE
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_EVENTS                   TRUE
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MESSAGES                 TRUE
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_CFG_USE_MAILBOXES                TRUE
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MEMCORE                  TRUE
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#define CH_CFG_USE_HEAP                     TRUE
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#define CH_CFG_USE_DYNAMIC                  TRUE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_STATISTICS                   FALSE
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_ENABLE_CHECKS                FALSE
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the context switch circular trace buffer is
+ *          activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_ENABLE_TRACE                 FALSE
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_FILL_THREADS                 FALSE
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#define CH_DBG_THREADS_PROFILING            FALSE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p chThdInit() API.
+ *
+ * @note    It is invoked from within @p chThdInit() and implicitly from all
+ *          the threads creation APIs.
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) {                                       \
+  /* Add threads initialization code here.*/                                \
+}
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @note    It is inserted into lock zone.
+ * @note    It is also invoked when the threads simply return in order to
+ *          terminate.
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) {                                       \
+  /* Add threads finalization code here.*/                                  \
+}
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) {                              \
+  /* Context switch code here.*/                                            \
+}
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() {                                        \
+  /* IRQ prologue code here.*/                                              \
+}
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() {                                        \
+  /* IRQ epilogue code here.*/                                              \
+}
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() {                                          \
+}
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() {                                          \
+}
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() {                                           \
+  /* Idle loop code here.*/                                                 \
+}
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() {                                         \
+  /* System tick event code here.*/                                         \
+}
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) {                                   \
+  /* System halt code here.*/                                               \
+}
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) {                                            \
+  /* Trace code here.*/                                                     \
+}
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* _CHCONF_H_ */
+
+/** @} */

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/halconf.h
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/halconf.h
@@ -1,0 +1,381 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef _HALCONF_H_
+#define _HALCONF_H_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                 TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                 FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the EXT subsystem.
+ */
+#if !defined(HAL_USE_EXT) || defined(__DOXYGEN__)
+#define HAL_USE_EXT                 FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                 FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                 TRUE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                 FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                 FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI             FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                 FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL              FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB          FALSE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                 FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                 FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                 FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE          TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY           FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS              TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ *          This option is recommended also if the SPI driver does not
+ *          use a DMA channel and heavily loads the CPU.
+ */
+#if !defined(MMC_NICE_WAITING) || defined(__DOXYGEN__)
+#define MMC_NICE_WAITING            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY              100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT             FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING            TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE      38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE         16
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE     256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER   2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT               FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION   FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                FALSE
+#endif
+
+#endif /* _HALCONF_H_ */
+
+/** @} */

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/main.c
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/main.c
@@ -1,0 +1,89 @@
+/*
+    (c) 2015-2016 flabbergast <s3+flabbergast@sdfeu.org>
+    Based on K20 I2C demo (c) 2015 Fabio Utzig, http://fabioutzig.com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#define FXOS8700CQ_ADDR 0x1D
+
+// FXOS8700CQ internal register addresses
+#define FXOS8700CQ_STATUS 0x00
+#define FXOS8700CQ_WHOAMI 0x0D
+#define FXOS8700CQ_XYZ_DATA_CFG 0x0E
+#define FXOS8700CQ_CTRL_REG1 0x2A
+#define FXOS8700CQ_M_CTRL_REG1 0x5B
+#define FXOS8700CQ_M_CTRL_REG2 0x5C
+#define FXOS8700CQ_WHOAMI_VAL 0xC7
+
+static bool i2cOk = false;
+
+static const I2CConfig i2ccfg = {
+  400000 // clock
+};
+
+static THD_WORKING_AREA(waThread1, 64);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("Blinker");
+  while(true) {
+    if(i2cOk) {
+      palSetPad(GPIO_LED_RED, PIN_LED_RED); /* Off red */
+      palTogglePad(GPIO_LED_GREEN, PIN_LED_GREEN); /* Blink green */
+    } else {
+      palSetPad(GPIO_LED_GREEN, PIN_LED_GREEN); /* Off green */
+      palTogglePad(GPIO_LED_RED, PIN_LED_RED); /* Blink red */
+    }
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*
+ * Application entry point.
+ */
+int main(void) {
+
+  uint8_t tx[1], rx[1];
+
+  /*
+   * System initializations.
+   * - HAL initialization, this also initializes the configured device drivers
+   *   and performs the board-specific initializations.
+   * - Kernel initialization, the main() function becomes a thread and the
+   *   RTOS is active.
+   */
+  halInit();
+  chSysInit();
+
+  /*
+   * Turn off the RGB LED.
+   */
+  palSetPad(GPIO_LED_RED, PIN_LED_RED); /* red */
+  palSetPad(GPIO_LED_GREEN, PIN_LED_GREEN); /* green */
+  palSetPad(GPIO_LED_BLUE, PIN_LED_BLUE); /* blue */
+
+  i2cStart(&I2CD1, &i2ccfg);
+
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  while (1) {
+    tx[0] = FXOS8700CQ_WHOAMI;
+    i2cMasterTransmitTimeout(&I2CD1, FXOS8700CQ_ADDR, tx, 1, rx, 1, TIME_INFINITE);
+    i2cOk = (rx[0] == FXOS8700CQ_WHOAMI_VAL) ? true : false;
+    chThdSleepMilliseconds(2000);
+  }
+}

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/mcuconf.h
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/mcuconf.h
@@ -1,0 +1,54 @@
+/*
+    ChibiOS - (C) 2015-2016 flabbergast <s3+flabbergast@sdfeu.org>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef _MCUCONF_H_
+#define _MCUCONF_H_
+
+#define KL2x_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#if 1
+/* PEE mode - 48MHz system clock driven by (8 MHz) external crystal. */
+#define KINETIS_MCG_MODE            KINETIS_MCG_MODE_PEE
+#define KINETIS_PLLCLK_FREQUENCY    96000000UL
+#define KINETIS_SYSCLK_FREQUENCY    48000000UL
+#endif
+
+#if 0
+/* crystal-less FEI mode - 48 MHz with internal 32.768 kHz crystal */
+#define KINETIS_MCG_MODE            KINETIS_MCG_MODE_FEI
+#define KINETIS_MCG_FLL_DMX32       1           /* Fine-tune for 32.768 kHz */
+#define KINETIS_MCG_FLL_DRS         1           /* 1464x FLL factor */
+#define KINETIS_SYSCLK_FREQUENCY    47972352UL  /* 32.768 kHz * 1464 (~48 MHz) */
+#define KINETIS_CLKDIV1_OUTDIV1     1           /* do not divide system clock */
+#endif
+
+/*
+ * SERIAL driver system settings.
+ */
+#define KINETIS_SERIAL_USE_UART0              TRUE
+
+/*
+ * I2C driver settings.
+ */
+#define KINETIS_I2C_USE_I2C0                  TRUE
+#define KINETIS_I2C_USE_I2C1                  FALSE
+/* need to redefine this, since the default is for K20x */
+#define KINETIS_I2C_I2C0_PRIORITY             2
+
+#endif /* _MCUCONF_H_ */

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/readme.txt
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/readme.txt
@@ -1,0 +1,20 @@
+*********************************************************************
+** ChibiOS/RT I2C test demo for Freedom Board KL26Z.               **
+*********************************************************************
+
+** TARGET **
+
+The test runs on an Freescale Freedom KL26Z board.
+
+** The Demo **
+
+This test tries to access the onboard FXOS8700CQ chip using the I2C bus.
+It sends the command WHO_AM_I which has a standard answer that can be
+verified. If the correct answer is received the GREEN led will blink.
+If no answer or invalid answer is received the RED led will blink.
+
+** Build Procedure **
+
+This test was built using the ARM GCC toolchain available at:
+
+https://launchpad.net/gcc-arm-embedded


### PR DESCRIPTION
Slight rewrite of the I2C driver.
 - shuffled the if branches in ISR around a bit, added some checks (e.g. master/slave), and comments
 - removed S&S_BUSY waits (I haven't seen them in other kinetis I2C drivers and the datasheet also doesn't mention that it's needed - but I may be wrong about this)
 - implemented timeouts
 - fixed the base frequency for clock speed (SYS->BUS) as reported by Fred on the forums
 - added a workaround for repeated start for KL27Z MCUs (as reported [here](https://community.freescale.com/thread/377611), my own tests confirm this)