### PR TITLE
[KINETIS] Fix KL26Z/I2C/Makefile.

### DIFF
--- a/testhal/KINETIS/FRDM-KL26Z/I2C/Makefile
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/Makefile
@@ -134,10 +134,12 @@ TCSRC =
 TCPPSRC =
 
 # List ASM source files here
-ASMSRC = $(STARTUPASM) $(PORTASM) $(OSALASM)
+ASMSRC =
+ASMXSRC = $(STARTUPASM) $(PORTASM) $(OSALASM)
 
-INCDIR = $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
-         $(HALINC) $(PLATFORMINC) $(BOARDINC)
+INCDIR = $(CHIBIOS)/os/license \
+         $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
+         $(HALINC) $(PLATFORMINC) $(BOARDINC) $(TESTINC)
 
 #
 # Project, sources and paths


### PR DESCRIPTION
Out-of-sync bug; just the same update as all the other Makefiles (ASMXSRC and license).