### PR TITLE
PAL Line

### DIFF
--- a/os/hal/boards/NRF51-DK/board.h
+++ b/os/hal/boards/NRF51-DK/board.h
@@ -66,6 +66,12 @@
 #define IOPORT1_SPI_SS         24U
 #define IOPORT1_I2C_SCL         7U
 #define IOPORT1_I2C_SDA        30U
+#define IOPORT1_A0              1U
+#define IOPORT1_A1              2U
+#define IOPORT1_A2              3U
+#define IOPORT1_A3              4U
+#define IOPORT1_A4              5U
+#define IOPORT1_A5              6U
 
 /*
  * IO lines assignments.
@@ -88,6 +94,13 @@
 #define LINE_SPI_SS    PAL_LINE(IOPORT1, IOPORT1_SPI_SS)
 #define LINE_I2C_SCL   PAL_LINE(IOPORT1, IOPORT1_I2C_SCL)
 #define LINE_I2C_SDA   PAL_LINE(IOPORT1, IOPORT1_I2C_SDA)
+#define LINE_A0        PAL_LINE(IOPORT1, IOPORT1_A0)
+#define LINE_A1        PAL_LINE(IOPORT1, IOPORT1_A1)
+#define LINE_A2        PAL_LINE(IOPORT1, IOPORT1_A2)
+#define LINE_A3        PAL_LINE(IOPORT1, IOPORT1_A3)
+#define LINE_A4        PAL_LINE(IOPORT1, IOPORT1_A4)
+#define LINE_A5        PAL_LINE(IOPORT1, IOPORT1_A5)
+
 
 #if !defined(_FROM_ASM_)
 #ifdef __cplusplus

--- a/os/hal/boards/NRF51-DK/board.h
+++ b/os/hal/boards/NRF51-DK/board.h
@@ -45,6 +45,50 @@
 #define I2C_SCL         7
 #define I2C_SDA        30
 
+/*
+ * IO pins assignments.
+ */
+#define IOPORT1_BTN1           17U
+#define IOPORT1_BTN2           18U
+#define IOPORT1_BTN3           19U
+#define IOPORT1_BTN4           20U
+#define IOPORT1_LED1           21U
+#define IOPORT1_LED2           22U
+#define IOPORT1_LED3           23U
+#define IOPORT1_LED4           24U
+#define IOPORT1_UART_RTS        8U
+#define IOPORT1_UART_TX         9U
+#define IOPORT1_UART_CTS       10U
+#define IOPORT1_UART_RX        11U
+#define IOPORT1_SPI_SCK        29U
+#define IOPORT1_SPI_MOSI       25U
+#define IOPORT1_SPI_MISO       28U
+#define IOPORT1_SPI_SS         24U
+#define IOPORT1_I2C_SCL         7U
+#define IOPORT1_I2C_SDA        30U
+
+/*
+ * IO lines assignments.
+ */
+#define LINE_BTN1      PAL_LINE(IOPORT1, IOPORT1_BTN1)
+#define LINE_BTN2      PAL_LINE(IOPORT1, IOPORT1_BTN2)
+#define LINE_BTN3      PAL_LINE(IOPORT1, IOPORT1_BTN3)
+#define LINE_BTN4      PAL_LINE(IOPORT1, IOPORT1_BTN4)
+#define LINE_LED1      PAL_LINE(IOPORT1, IOPORT1_LED1)
+#define LINE_LED2      PAL_LINE(IOPORT1, IOPORT1_LED2)
+#define LINE_LED3      PAL_LINE(IOPORT1, IOPORT1_LED3)
+#define LINE_LED4      PAL_LINE(IOPORT1, IOPORT1_LED4)
+#define LINE_UART_RTS  PAL_LINE(IOPORT1, IOPORT1_UART_RTS)
+#define LINE_UART_TX   PAL_LINE(IOPORT1, IOPORT1_UART_TX)
+#define LINE_UART_CTS  PAL_LINE(IOPORT1, IOPORT1_UART_CTS)
+#define LINE_UART_RX   PAL_LINE(IOPORT1, IOPORT1_UART_RX)
+#define LINE_SPI_SCK   PAL_LINE(IOPORT1, IOPORT1_SPI_SCK)
+#define LINE_SPI_MOSI  PAL_LINE(IOPORT1, IOPORT1_SPI_MOSI)
+#define LINE_SPI_MISO  PAL_LINE(IOPORT1, IOPORT1_SPI_MISO)
+#define LINE_SPI_SS    PAL_LINE(IOPORT1, IOPORT1_SPI_SS)
+#define LINE_I2C_SCL   PAL_LINE(IOPORT1, IOPORT1_I2C_SCL)
+#define LINE_I2C_SDA   PAL_LINE(IOPORT1, IOPORT1_I2C_SDA)
+
 #if !defined(_FROM_ASM_)
 #ifdef __cplusplus
 extern "C" {

--- a/os/hal/boards/WVSHARE_BLE400/board.h
+++ b/os/hal/boards/WVSHARE_BLE400/board.h
@@ -43,6 +43,48 @@
 #define I2C_SCL        1
 #define I2C_SDA        0
 
+/*
+ * IO pins assignments.
+ */
+#define IOPORT1_KEY1           16U
+#define IOPORT1_KEY2           17U
+#define IOPORT1_LED0           18U
+#define IOPORT1_LED1           19U
+#define IOPORT1_LED2           20U
+#define IOPORT1_LED3           21U
+#define IOPORT1_LED4           22U
+#define IOPORT1_UART_TX         9U
+#define IOPORT1_UART_RX        11U
+#define IOPORT1_UART_RTS        8U
+#define IOPORT1_UART_CTS       10U
+#define IOPORT1_SPI_SCK        25U
+#define IOPORT1_SPI_MOSI       24U
+#define IOPORT1_SPI_MISO       23U
+#define IOPORT1_SPI_SS         30U
+#define IOPORT1_I2C_SCL         1U
+#define IOPORT1_I2C_SDA         0U
+
+/*
+ * IO lines assignments.
+ */
+#define LINE_KEY1       PAL_LINE(IOPORT1, IOPORT1_KEY1)
+#define LINE_KEY2       PAL_LINE(IOPORT1, IOPORT1_KEY2)
+#define LINE_LED0       PAL_LINE(IOPORT1, IOPORT1_LED0)
+#define LINE_LED1       PAL_LINE(IOPORT1, IOPORT1_LED1)
+#define LINE_LED2       PAL_LINE(IOPORT1, IOPORT1_LED2)
+#define LINE_LED3       PAL_LINE(IOPORT1, IOPORT1_LED3)
+#define LINE_LED4       PAL_LINE(IOPORT1, IOPORT1_LED4)
+#define LINE_UART_TX    PAL_LINE(IOPORT1, IOPORT1_UART_TX)
+#define LINE_UART_RX    PAL_LINE(IOPORT1, IOPORT1_UART_RX)
+#define LINE_UART_RTS   PAL_LINE(IOPORT1, IOPORT1_UART_RTS)
+#define LINE_UART_CTS   PAL_LINE(IOPORT1, IOPORT1_UART_CTS)
+#define LINE_SPI_SCK    PAL_LINE(IOPORT1, IOPORT1_SPI_SCK)
+#define LINE_SPI_MOSI   PAL_LINE(IOPORT1, IOPORT1_SPI_MOSI)
+#define LINE_SPI_MISO   PAL_LINE(IOPORT1, IOPORT1_SPI_MISO)
+#define LINE_SPI_SS     PAL_LINE(IOPORT1, IOPORT1_SPI_SS)
+#define LINE_I2C_SCL    PAL_LINE(IOPORT1, IOPORT1_I2C_SCL)
+#define LINE_I2C_SDA    PAL_LINE(IOPORT1, IOPORT1_I2C_SDA)
+
 #if !defined(_FROM_ASM_)
 #ifdef __cplusplus
 extern "C" {

--- a/os/hal/ports/NRF51/NRF51822/hal_pal_lld.h
+++ b/os/hal/ports/NRF51/NRF51822/hal_pal_lld.h
@@ -38,6 +38,52 @@
 #define TOTAL_GPIO_PADS 32
 
 /**
+ * @name    Port related definitions
+ * @{
+ */
+/**
+ * @brief   Width, in bits, of an I/O port.
+ */
+#define PAL_IOPORTS_WIDTH 32U
+
+/**
+ * @brief   Whole port mask.
+ * @brief   This macro specifies all the valid bits into a port.
+ */
+#define PAL_WHOLE_PORT ((ioportmask_t)0xFFFFFFFFU)
+/** @} */
+
+/**
+ * @name    Line handling macros
+ * @{
+ */
+/**
+ * @brief   Forms a line identifier.
+ * @details A port/pad pair are encoded into an @p ioline_t type. The encoding
+ *          of this type is platform-dependent.
+ */
+#define PAL_LINE(port, pad)                                                 \
+  ((ioline_t)((uint32_t)(pad)))
+
+/**
+ * @brief   Decodes a port identifier from a line identifier.
+ */
+#define PAL_PORT(line)                                                      \
+  ((ioportid_t)(IOPORT1))
+
+/**
+ * @brief   Decodes a pad identifier from a line identifier.
+ */
+#define PAL_PAD(line)                                                       \
+  ((uint32_t)(line))
+
+/**
+ * @brief   Value identifying an invalid line.
+ */
+#define PAL_NOLINE                      FFU
+/** @} */
+
+/**
  * @brief   Generic I/O ports static initializer.
  * @details An instance of this structure must be passed to @p palInit() at
  *          system startup time in order to initialized the digital I/O
@@ -51,17 +97,6 @@ typedef struct {
 } PALConfig;
 
 /**
- * @brief   Width, in bits, of an I/O port.
- */
-#define PAL_IOPORTS_WIDTH 32U
-
-/**
- * @brief   Whole port mask.
- * @brief   This macro specifies all the valid bits into a port.
- */
-#define PAL_WHOLE_PORT ((ioportmask_t)0xFFFFFFFFU)
-
-/**
  * @brief   Digital I/O port sized unsigned type.
  */
 typedef uint32_t ioportmask_t;
@@ -70,6 +105,11 @@ typedef uint32_t ioportmask_t;
  * @brief   Digital I/O modes.
  */
 typedef uint8_t iomode_t;
+
+/**
+ * @brief   Type of an I/O line.
+ */
+typedef uint32_t ioline_t;
 
 /**
  * @brief   Port Identifier.
@@ -265,7 +305,6 @@ typedef NRF_GPIO_Type *ioportid_t;
     else                                                                    \
       NRF_GPIO->OUTSET = 1 << (pad);                                        \
   } while (0)
-
 
 /**
  * @brief   Pad mode setup.


### PR DESCRIPTION
Added PAL_LINE macro (assuming only one port: IOPORT1)
Following STM32 naming for IO pins/lines