### PR TITLE
allow use of GPIOTE/PPI in PWM to drive gpio pin

### DIFF
--- a/os/hal/ports/NRF51/NRF51822/hal_pal_lld.h
+++ b/os/hal/ports/NRF51/NRF51822/hal_pal_lld.h
@@ -80,7 +80,7 @@
 /**
  * @brief   Value identifying an invalid line.
  */
-#define PAL_NOLINE                      FFU
+#define PAL_NOLINE              ((ioline_t)-1)
 /** @} */
 
 /**

--- a/os/hal/ports/NRF51/NRF51822/hal_pwm_lld.h
+++ b/os/hal/ports/NRF51/NRF51822/hal_pwm_lld.h
@@ -52,14 +52,28 @@
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
 
+/**
+ * @name    Configuration options
+ * @{
+ */
+
+/**
+ * @brief   TIMER0 as driver implementation
+ */
 #if !defined(NRF51_PWM_USE_TIMER0)
 #define NRF51_PWM_USE_TIMER0 FALSE
 #endif
 
+/**
+ * @brief   TIMER1 as driver implementation
+ */
 #if !defined(NRF51_PWM_USE_TIMER1)
 #define NRF51_PWM_USE_TIMER1 FALSE
 #endif
 
+/**
+ * @brief   TIMER2 as driver implementation
+ */
 #if !defined(NRF51_PWM_USE_TIMER2)
 #define NRF51_PWM_USE_TIMER2 FALSE
 #endif
@@ -85,12 +99,13 @@
 #define NRF51_PWM_TIMER2_PRIORITY        12
 #endif
 
-/** @} */
-
 /**
- * @name    Configuration options
- * @{
+ * @brief   Allow driver to use GPIOTE/PPI to control PAL line
  */
+#if !defined(NRF51_PWM_USE_GPIOTE_PPI)
+#define NRF51_PWM_USE_GPIOTE_PPI FALSE
+#endif
+
 /** @} */
 
 /*===========================================================================*/
@@ -145,6 +160,32 @@ typedef struct {
    */
   pwmcallback_t             callback;
   /* End of the mandatory fields.*/
+
+  /**
+   * @brief PAL line to toggle.
+   * @note  Only used if mode is PWM_OUTPUT_HIGH or PWM_OUTPUT_LOW.
+   * @note  When NRF51_PWM_USE_GPIOTE_PPI is used and channel enabled,
+   *        it wont be possible to access this PAL line using the PAL
+   *        driver.
+   */
+  ioline_t ioline;
+
+#if NRF51_PWM_USE_GPIOTE_PPI || defined(__DOXYGEN__)
+  /**
+   * @brief Unique GPIOTE channel to use. (1 channel)
+   * @note  Only used if mode is PWM_OUTPUT_HIGH or PWM_OUTPUT_LOW.
+   * @note  Only 4 GPIOTE channels are available on nRF51.
+   */
+  uint8_t gpiote_channel;
+
+  /**
+   * @brief Unique PPI channels to use. (2 channels)
+   * @note  Only used if mode is PWM_OUTPUT_HIGH or PWM_OUTPUT_LOW.
+   * @note  Only 16 PPI channels are available on nRF51
+   *        (When Softdevice is enabled, only channels 0-7 are available)
+   */
+  uint8_t ppi_channel[2];
+#endif
 } PWMChannelConfig;
 
 /**

--- a/testhal/NRF51/NRF51822/PWM/main.c
+++ b/testhal/NRF51/NRF51822/PWM/main.c
@@ -39,9 +39,15 @@ int main(void) {
     .frequency = PWM_FREQUENCY_31250HZ, 
     .period = 31250,                 
     .callback = pwm_cb_period,
-    { {PWM_OUTPUT_ACTIVE_HIGH, pwm_cb_channel0},
-      {PWM_OUTPUT_DISABLED, NULL},
-      {PWM_OUTPUT_DISABLED, NULL}
+    { { .mode           = PWM_OUTPUT_DISABLED,
+	.callback       = pwm_cb_channel0, },
+      { .mode           = PWM_OUTPUT_ACTIVE_HIGH,
+	.callback       = NULL,
+	.ioline         = LINE_LED2,
+	.gpiote_channel = 0,
+	.ppi_channel    = { 0, 1 } },
+      { .mode           = PWM_OUTPUT_DISABLED,
+	.callback       = NULL, },
     },
   };
 
@@ -62,6 +68,7 @@ int main(void) {
   pwmEnablePeriodicNotification(&PWMD1);
   pwmEnableChannel(&PWMD1, 0, PWM_FRACTION_TO_WIDTH(&PWMD1, 2, 1));
   pwmEnableChannelNotification(&PWMD1, 0);
+  pwmEnableChannel(&PWMD1, 1, PWM_FRACTION_TO_WIDTH(&PWMD1, 4, 3));
 
   while (1) {
     chThdSleepMilliseconds(500);

--- a/testhal/NRF51/NRF51822/PWM/mcuconf.h
+++ b/testhal/NRF51/NRF51822/PWM/mcuconf.h
@@ -25,5 +25,6 @@
 #define NRF51_ST_USE_RTC1                  FALSE
 #define NRF51_ST_USE_TIMER0                FALSE
 #define NRF51_PWM_USE_TIMER0               TRUE
+#define NRF51_PWM_USE_GPIOTE_PPI           TRUE
 
 #endif /* _MCUCONF_H_ */


### PR DESCRIPTION
allow use of GPIOTE/PPI to drive gpio pin (without callback)
changed value of PAL_NOLINE to ((ioline_t)-1)