### PR TITLE
[KINETIS] Add saved_state to USB driver.

### DIFF
--- a/os/hal/ports/KINETIS/LLD/hal_usb_lld.h
+++ b/os/hal/ports/KINETIS/LLD/hal_usb_lld.h
@@ -326,6 +326,10 @@ struct USBDriver {
    * @brief   Current USB device configuration.
    */
   uint8_t                       configuration;
+  /**
+   * @brief   State of the driver when a suspend happened.
+   */
+  usbstate_t                    saved_state;
 #if defined(USB_DRIVER_EXT_FIELDS)
   USB_DRIVER_EXT_FIELDS
 #endif


### PR DESCRIPTION
The upstream USB driver adds and uses 'saved_state' member of USBDriver struct. Done for kinetis.