### PR TITLE
STM32 CRC : Fix asserts

### DIFF
--- a/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.c
+++ b/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.c
@@ -185,15 +185,15 @@ void crc_lld_start(CRCDriver *crcp) {
     crcp->crc->CR |= CRC_CR_REV_OUT;
   }
 #else
-  osalDbgAssert(crcp->config->initial_val != default_config.initial_val,
+  osalDbgAssert(crcp->config->initial_val == default_config.initial_val,
       "hardware doesn't support programmable initial value");
-  osalDbgAssert(crcp->config->poly_size != default_config.poly_size,
+  osalDbgAssert(crcp->config->poly_size == default_config.poly_size,
       "hardware doesn't support programmable polynomial size");
-  osalDbgAssert(crcp->config->poly != default_config.poly,
+  osalDbgAssert(crcp->config->poly == default_config.poly,
       "hardware doesn't support programmable polynomial");
-  osalDbgAssert(crcp->config->reflect_data != default_config.reflect_data,
+  osalDbgAssert(crcp->config->reflect_data == default_config.reflect_data,
       "hardware doesn't support reflect of input data");
-  osalDbgAssert(crcp->config->reflect_remainder != default_config.reflect_remainder,
+  osalDbgAssert(crcp->config->reflect_remainder == default_config.reflect_remainder,
       "hardware doesn't support reflect of output remainder");
 #endif
 
@@ -299,7 +299,7 @@ uint32_t crc_lld_calc(CRCDriver *crcp, size_t n, const void *buf) {
     n--;
   }
 #else
-  osalDbgAssert(n != 0, "STM32 CRC Unit only supports WORD accesses");
+  osalDbgAssert(n == 0, "STM32 CRC Unit only supports WORD accesses");
 #endif
 
 #endif


### PR DESCRIPTION
These asserts will trigger when !(config != default_config), and IMHO just reverse is expeceted when CRC is not programmable.