### PR TITLE
Fix KINETIS USB_SERIAL testhal compilation.

### DIFF
--- a/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/usbcfg.c
@@ -284,7 +284,7 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysLockFromISR();
 
     /* Disconnection event on suspend.*/
-    sduDisconnectI(&SDU1);
+    sduSuspendHookI(&SDU1);
 
     chSysUnlockFromISR();
     return;

--- a/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/usbcfg.c
@@ -284,7 +284,7 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysLockFromISR();
 
     /* Disconnection event on suspend.*/
-    sduDisconnectI(&SDU1);
+    sduSuspendHookI(&SDU1);
 
     chSysUnlockFromISR();
     return;

--- a/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/usbcfg.c
@@ -284,7 +284,7 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysLockFromISR();
 
     /* Disconnection event on suspend.*/
-    sduDisconnectI(&SDU1);
+    sduSuspendHookI(&SDU1);
 
     chSysUnlockFromISR();
     return;

--- a/testhal/KINETIS/MCHCK/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/MCHCK/USB_SERIAL/usbcfg.c
@@ -284,7 +284,7 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysLockFromISR();
 
     /* Disconnection event on suspend.*/
-    sduDisconnectI(&SDU1);
+    sduSuspendHookI(&SDU1);
 
     chSysUnlockFromISR();
     return;

--- a/testhal/KINETIS/TEENSY3_x/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/TEENSY3_x/USB_SERIAL/usbcfg.c
@@ -284,7 +284,7 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysLockFromISR();
 
     /* Disconnection event on suspend.*/
-    sduDisconnectI(&SDU1);
+    sduSuspendHookI(&SDU1);
 
     chSysUnlockFromISR();
     return;


### PR DESCRIPTION
Fix KINETIS USB_SERIAL testhal compilation by renaming the function
sduDisconnectI() to sduSuspendHookI().