### PR TITLE
hal: fix the compilation of hal_usb_hid.c

### DIFF
--- a/os/hal/src/hal_usb_hid.c
+++ b/os/hal/src/hal_usb_hid.c
@@ -221,10 +221,10 @@ void hidObjectInit(USBHIDDriver *uhdp) {
   uhdp->vmt = &vmt;
   osalEventObjectInit(&uhdp->event);
   uhdp->state = HID_STOP;
-  ibqObjectInit(&uhdp->ibqueue, uhdp->ib,
+  ibqObjectInit(&uhdp->ibqueue, true, uhdp->ib,
                 USB_HID_BUFFERS_SIZE, USB_HID_BUFFERS_NUMBER,
                 ibnotify, uhdp);
-  obqObjectInit(&uhdp->obqueue, uhdp->ob,
+  obqObjectInit(&uhdp->obqueue, true, uhdp->ob,
                 USB_HID_BUFFERS_SIZE, USB_HID_BUFFERS_NUMBER,
                 obnotify, uhdp);
 }


### PR DESCRIPTION
Fix the compilation of hal_usb_hid.c that broke because of the changes
in ibqObjectInit() and obqObjectInit() prototypes.

In hidObjectInit() call these functions with the additional suspend
parameter set to true as done in ChibiOS-RT.