### PR TITLE
Kinetis fixes

### DIFF
--- a/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/usbcfg.c
@@ -289,6 +289,12 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysUnlockFromISR();
     return;
   case USB_EVENT_WAKEUP:
+    chSysLockFromISR();
+
+    /* Disconnection event on suspend */
+    sduWakeupHookI(&SDU1);
+
+    chSysUnlockFromISR();
     return;
   case USB_EVENT_STALLED:
     return;

--- a/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/usbcfg.c
@@ -262,8 +262,6 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
   extern SerialUSBDriver SDU1;
 
   switch (event) {
-  case USB_EVENT_RESET:
-    return;
   case USB_EVENT_ADDRESS:
     return;
   case USB_EVENT_CONFIGURED:
@@ -280,6 +278,10 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 
     chSysUnlockFromISR();
     return;
+  case USB_EVENT_RESET:
+    /* Falls into. */
+  case USB_EVENT_UNCONFIGURED:
+    /* Falls into. */
   case USB_EVENT_SUSPEND:
     chSysLockFromISR();
 

--- a/testhal/KINETIS/FRDM-KL25Z/USB_HID/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_HID/usbcfg.c
@@ -315,6 +315,8 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 
     osalSysUnlockFromISR();
     return;
+  case USB_EVENT_UNCONFIGURED:
+    return;
   case USB_EVENT_SUSPEND:
     return;
   case USB_EVENT_WAKEUP:

--- a/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/usbcfg.c
@@ -289,6 +289,12 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysUnlockFromISR();
     return;
   case USB_EVENT_WAKEUP:
+    chSysLockFromISR();
+
+    /* Disconnection event on suspend */
+    sduWakeupHookI(&SDU1);
+
+    chSysUnlockFromISR();
     return;
   case USB_EVENT_STALLED:
     return;

--- a/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/usbcfg.c
@@ -262,8 +262,6 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
   extern SerialUSBDriver SDU1;
 
   switch (event) {
-  case USB_EVENT_RESET:
-    return;
   case USB_EVENT_ADDRESS:
     return;
   case USB_EVENT_CONFIGURED:
@@ -280,6 +278,10 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 
     chSysUnlockFromISR();
     return;
+  case USB_EVENT_RESET:
+    /* Falls into. */
+  case USB_EVENT_UNCONFIGURED:
+    /* Falls into. */
   case USB_EVENT_SUSPEND:
     chSysLockFromISR();
 

--- a/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/usbcfg.c
@@ -289,6 +289,12 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysUnlockFromISR();
     return;
   case USB_EVENT_WAKEUP:
+    chSysLockFromISR();
+
+    /* Disconnection event on suspend */
+    sduWakeupHookI(&SDU1);
+
+    chSysUnlockFromISR();
     return;
   case USB_EVENT_STALLED:
     return;

--- a/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/usbcfg.c
@@ -262,8 +262,6 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
   extern SerialUSBDriver SDU1;
 
   switch (event) {
-  case USB_EVENT_RESET:
-    return;
   case USB_EVENT_ADDRESS:
     return;
   case USB_EVENT_CONFIGURED:
@@ -280,6 +278,10 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 
     chSysUnlockFromISR();
     return;
+  case USB_EVENT_RESET:
+    /* Falls into. */
+  case USB_EVENT_UNCONFIGURED:
+    /* Falls into. */
   case USB_EVENT_SUSPEND:
     chSysLockFromISR();
 

--- a/testhal/KINETIS/MCHCK/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/MCHCK/USB_SERIAL/usbcfg.c
@@ -289,6 +289,12 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysUnlockFromISR();
     return;
   case USB_EVENT_WAKEUP:
+    chSysLockFromISR();
+
+    /* Disconnection event on suspend */
+    sduWakeupHookI(&SDU1);
+
+    chSysUnlockFromISR();
     return;
   case USB_EVENT_STALLED:
     return;

--- a/testhal/KINETIS/MCHCK/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/MCHCK/USB_SERIAL/usbcfg.c
@@ -262,8 +262,6 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
   extern SerialUSBDriver SDU1;
 
   switch (event) {
-  case USB_EVENT_RESET:
-    return;
   case USB_EVENT_ADDRESS:
     return;
   case USB_EVENT_CONFIGURED:
@@ -280,6 +278,10 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 
     chSysUnlockFromISR();
     return;
+  case USB_EVENT_RESET:
+    /* Falls into. */
+  case USB_EVENT_UNCONFIGURED:
+    /* Falls into. */
   case USB_EVENT_SUSPEND:
     chSysLockFromISR();
 

--- a/testhal/KINETIS/TEENSY3_x/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/TEENSY3_x/USB_SERIAL/usbcfg.c
@@ -289,6 +289,12 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
     chSysUnlockFromISR();
     return;
   case USB_EVENT_WAKEUP:
+    chSysLockFromISR();
+
+    /* Disconnection event on suspend */
+    sduWakeupHookI(&SDU1);
+
+    chSysUnlockFromISR();
     return;
   case USB_EVENT_STALLED:
     return;

--- a/testhal/KINETIS/TEENSY3_x/USB_SERIAL/usbcfg.c
+++ b/testhal/KINETIS/TEENSY3_x/USB_SERIAL/usbcfg.c
@@ -262,8 +262,6 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
   extern SerialUSBDriver SDU1;
 
   switch (event) {
-  case USB_EVENT_RESET:
-    return;
   case USB_EVENT_ADDRESS:
     return;
   case USB_EVENT_CONFIGURED:
@@ -280,6 +278,10 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 
     chSysUnlockFromISR();
     return;
+  case USB_EVENT_RESET:
+    /* Falls into. */
+  case USB_EVENT_UNCONFIGURED:
+    /* Falls into. */
   case USB_EVENT_SUSPEND:
     chSysLockFromISR();
 


### PR DESCRIPTION
Additional fixes for the testhal demos of the KINETIS boards:

 * call sduWakeupHookI() when the device gets the USB_EVENT_WAKEUP event.
 * handle USB_EVENT_RESET and USB_EVENT_UNCONFIGURED like it was USB_EVENT_SUSPEND.

The first patch was lightly tested on a teensy3.2 in linux by simulating a suspend event (echo auto > control in sysfs) and it worked as expected.
