### PR TITLE
SCSI: Respond to unit serial number inquiry

### DIFF
--- a/os/hal/include/hal_usb_msd.h
+++ b/os/hal/include/hal_usb_msd.h
@@ -172,7 +172,8 @@ extern "C" {
   void msdObjectInit(USBMassStorageDriver *msdp);
   void msdStart(USBMassStorageDriver *msdp, USBDriver *usbp,
                 BaseBlockDevice *blkdev, uint8_t *blkbuf,
-                const scsi_inquiry_response_t *scsi_inquiry_response);
+                const scsi_inquiry_response_t *scsi_inquiry_response,
+                const scsi_unit_serial_number_inquiry_response_t *serialInquiry);
   void msdStop(USBMassStorageDriver *msdp);
   bool msd_request_hook(USBDriver *usbp);
 #ifdef __cplusplus

--- a/os/hal/src/hal_usb_msd.c
+++ b/os/hal/src/hal_usb_msd.c
@@ -84,6 +84,19 @@ static const scsi_inquiry_response_t default_scsi_inquiry_response = {
     {'v',CH_KERNEL_MAJOR+'0','.',CH_KERNEL_MINOR+'0'}
 };
 
+/**
+ * @brief   Hardcoded default SCSI unit serial number inquiry response structure.
+ */
+static const scsi_unit_serial_number_inquiry_response_t default_scsi_unit_serial_number_inquiry_response =
+{
+    0x00,
+    0x80,
+    0x00,
+    0x08,
+    "00000000"
+};
+
+
 /*===========================================================================*/
 /* Driver local functions.                                                   */
 /*===========================================================================*/
@@ -373,7 +386,8 @@ void msdStop(USBMassStorageDriver *msdp) {
  */
 void msdStart(USBMassStorageDriver *msdp, USBDriver *usbp,
               BaseBlockDevice *blkdev, uint8_t *blkbuf,
-              const scsi_inquiry_response_t *inquiry) {
+              const scsi_inquiry_response_t *inquiry,
+              const scsi_unit_serial_number_inquiry_response_t *serialInquiry) {
 
   osalDbgCheck((msdp != NULL) && (usbp != NULL)
               && (blkdev != NULL) && (blkbuf != NULL));
@@ -392,6 +406,12 @@ void msdStart(USBMassStorageDriver *msdp, USBDriver *usbp,
   }
   else {
     msdp->scsi_config.inquiry_response = inquiry;
+  }
+  if (NULL == serialInquiry) {
+    msdp->scsi_config.unit_serial_number_inquiry_response = &default_scsi_unit_serial_number_inquiry_response;
+  }
+  else {
+    msdp->scsi_config.unit_serial_number_inquiry_response = serialInquiry;
   }
   msdp->scsi_config.blkbuf = blkbuf;
   msdp->scsi_config.blkdev = blkdev;

--- a/os/various/lib_scsi.c
+++ b/os/various/lib_scsi.c
@@ -175,7 +175,12 @@ static bool cmd_ignored(SCSITarget *scsip, const uint8_t *cmd) {
  */
 static bool inquiry(SCSITarget *scsip, const uint8_t *cmd) {
 
-  if ((cmd[1] & 0b11) || cmd[2] != 0) {
+  if ((cmd[1] & 0b1) && cmd[2] == 0x80) {
+    /* Unit serial number page */
+    return transmit_data(scsip, (const uint8_t *)scsip->config->unit_serial_number_inquiry_response,
+                                sizeof(scsi_unit_serial_number_inquiry_response_t));
+  }
+  else if ((cmd[1] & 0b11) || cmd[2] != 0) {
     set_sense(scsip, SCSI_SENSE_KEY_ILLEGAL_REQUEST,
                      SCSI_ASENSE_INVALID_FIELD_IN_CDB,
                      SCSI_ASENSEQ_NO_QUALIFIER);

--- a/os/various/lib_scsi.h
+++ b/os/various/lib_scsi.h
@@ -133,6 +133,17 @@ typedef struct PACKED_VAR {
 } scsi_inquiry_response_t;
 
 /**
+ * @brief   Represents SCSI unit serial number inquiry response structure.
+ * @details See SCSI specification.
+ */
+typedef struct PACKED_VAR {
+  uint8_t peripheral;
+  uint8_t page_code;
+  uint8_t reserved;
+  uint8_t page_length;
+  uint8_t serianNumber[8];
+} scsi_unit_serial_number_inquiry_response_t;
+/**
  * @brief   Represents SCSI mode sense (6) request structure.
  * @details See SCSI specification.
  */
@@ -225,6 +236,10 @@ typedef struct {
    * @brief   Pointer to SCSI inquiry response object.
    */
   const scsi_inquiry_response_t *inquiry_response;
+  /**
+   * @brief   Pointer to SCSI unit serial number inquiry response object.
+   */
+  const scsi_unit_serial_number_inquiry_response_t *unit_serial_number_inquiry_response;
 } SCSITargetConfig;
 
 /**


### PR DESCRIPTION
The SCSI library does not reply to certain inquiries made by a Windows host.
At least the Vital Product Data Page 80h, Unit Serial Number is required. If this is not handled correctly, the inquiry fails, and causes 3 retries with each having 20 second timeout/delay on mounting the drive.

This change will add this response. It also adds possibility to use your own response for it, but unfortunately it adds a argument to msdStart() function, which might not be ok. Therefore i pushed this here to rise conversation how this could be done more efficiently.
Maybe just always use a hardcoded default? This would not change msd api.

Sample capture of inquiry:
```
Inquiry
Requests the device server to return information regarding the logical unit and SCSI target device.
CBW
Offset Field Size Value Description 
0 dCBWSignature 4 43425355h "USBC" 
4 dCBWTag 4 1BF92B10h  
8 dCBWDataTransferLength 4 000000FFh 255 bytes of data are expected to be transferred 
12 bmCBWFlags 1 80h  
 5..0: Reserved  ..000000   
 6: Obsolete  .0......   
 7: Direction  1.......  Data-In from device to host 
13 bCBWLUN 1 00h LUN 0 
14 bCBWCBLength 1 06h SCSI command descriptor block size (valid bytes) 
15 CBWCB 16 12 01 80 00 FF 00 00 00 
00 00 00 00 00 00 00 00  SCSI command descriptor block 

CDB - Inquiry
Field Value Description 
Operation Code 12h Inquiry 
Enable Vital Product Data (EVPD) 1b Vital Product Data 
Page Code 80h Unit Serial Number 
Allocation Length 00FFh 255 bytes 
Control 00h  
````
Fail response:
````
Offset | Field | Size | Value | Description
-- | -- | -- | -- | --
0 | dCSWSignature | 4 | 53425355h | "USBS"
4 | dCSWTag | 4 | 1D4C2BD0h |  
8 | dCSWDataResidue | 4 | 00000000h | 0 bytes
12 | bCSWStatus | 1 | 01h | Failed
````

After fix:
````
Field | Value | Description
-- | -- | --
Peripheral Qualifier | 000b | Currently connected
Peripheral Device Type | 00h | Direct access block device
Page Code | 80h | Unit Serial Number
Page Length | 08h |  
Product Serial Number | "00000000" |  

Offset | Field | Size | Value | Description
-- | -- | -- | -- | --
0 | dCSWSignature | 4 | 53425355h | "USBS"
4 | dCSWTag | 4 | 12BE3010h |  
8 | dCSWDataResidue | 4 | 00000000h | 0 bytes
12 | bCSWStatus | 1 | 00h | Passed
````

