### PR TITLE
SCSI: Respond to TEST UNIT READY command, Fix REQUEST SENSE replying

### DIFF
--- a/os/various/lib_scsi.c
+++ b/os/various/lib_scsi.c
@@ -159,7 +159,6 @@ static bool cmd_ignored(SCSITarget *scsip, const uint8_t *cmd) {
   (void)scsip;
   (void)cmd;
 
-  set_sense_ok(scsip);
   return SCSI_SUCCESS;
 }
 
@@ -204,10 +203,7 @@ static bool inquiry(SCSITarget *scsip, const uint8_t *cmd) {
  */
 static bool request_sense(SCSITarget *scsip, const uint8_t *cmd) {
 
-  uint32_t tmp;
-  memcpy(&tmp, &cmd[1], 3);
-
-  if ((tmp != 0) || (cmd[4] != sizeof(scsi_sense_response_t))) {
+  if (((cmd[1] & 0x01) != 0) || (cmd[4] != sizeof(scsi_sense_response_t))) {
     set_sense(scsip, SCSI_SENSE_KEY_ILLEGAL_REQUEST,
                      SCSI_ASENSE_INVALID_FIELD_IN_CDB,
                      SCSI_ASENSEQ_NO_QUALIFIER);
@@ -383,6 +379,30 @@ static bool data_read_write10(SCSITarget *scsip, const uint8_t *cmd) {
   }
   return SCSI_SUCCESS;
 }
+
+/**
+ * @brief   SCSI test unit ready command handler
+ * @details If block device is inserted, sets sense data in 'all OK' condition
+ *          and returns success status.
+ *          If block device is not inserted, sets sense data to 'Medium not present' considion,
+ *          and returns check condition status.
+ */
+static bool test_unit_ready(SCSITarget *scsip, const uint8_t *cmd) {
+  (void)cmd;
+
+  if (blkIsInserted(scsip->config->blkdev)) {
+    return SCSI_SUCCESS;
+  }
+  else {
+    warnprintf("SCSI Medium is not inserted.\r\n");
+    set_sense(scsip, SCSI_SENSE_KEY_NOT_READY,
+                     SCSI_ASENSE_MEDIUM_NOT_PRESENT,
+                     SCSI_ASENSEQ_NO_QUALIFIER);
+    return SCSI_FAILED;
+  }
+
+}
+
 /*===========================================================================*/
 /* Driver interrupt handlers.                                                */
 /*===========================================================================*/
@@ -403,54 +423,69 @@ static bool data_read_write10(SCSITarget *scsip, const uint8_t *cmd) {
  */
 bool scsiExecCmd(SCSITarget *scsip, const uint8_t *cmd) {
 
-  /* status will be overwritten later in case of error */
-  set_sense_ok(scsip);
+  bool ret = SCSI_SUCCESS;
 
   switch (cmd[0]) {
   case SCSI_CMD_INQUIRY:
     dbgprintf("SCSI_CMD_INQUIRY\r\n");
-    return inquiry(scsip, cmd);
+    ret = inquiry(scsip, cmd);
+    break;
 
   case SCSI_CMD_REQUEST_SENSE:
     dbgprintf("SCSI_CMD_REQUEST_SENSE\r\n");
-    return request_sense(scsip, cmd);
+    ret = request_sense(scsip, cmd);
+    break;
 
   case SCSI_CMD_READ_CAPACITY_10:
     dbgprintf("SCSI_CMD_READ_CAPACITY_10\r\n");
-    return read_capacity10(scsip, cmd);
+    ret = read_capacity10(scsip, cmd);
+    break;
 
   case SCSI_CMD_READ_10:
     dbgprintf("SCSI_CMD_READ_10\r\n");
-    return data_read_write10(scsip, cmd);
+    ret = data_read_write10(scsip, cmd);
+    break;
 
   case SCSI_CMD_WRITE_10:
     dbgprintf("SCSI_CMD_WRITE_10\r\n");
-    return data_read_write10(scsip, cmd);
+    ret = data_read_write10(scsip, cmd);
+    break;
 
   case SCSI_CMD_TEST_UNIT_READY:
     dbgprintf("SCSI_CMD_TEST_UNIT_READY\r\n");
-    return cmd_ignored(scsip, cmd);
+    ret = test_unit_ready(scsip, cmd);
+    break;
 
   case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
     dbgprintf("SCSI_CMD_ALLOW_MEDIUM_REMOVAL\r\n");
-    return cmd_ignored(scsip, cmd);
+    ret = cmd_ignored(scsip, cmd);
+    break;
 
   case SCSI_CMD_MODE_SENSE_6:
     dbgprintf("SCSI_CMD_MODE_SENSE_6\r\n");
-    return mode_sense6(scsip, cmd);
+    ret = mode_sense6(scsip, cmd);
+    break;
 
   case SCSI_CMD_READ_FORMAT_CAPACITIES:
     dbgprintf("SCSI_CMD_READ_FORMAT_CAPACITIES\r\n");
-    return read_format_capacities(scsip, cmd);
+    ret = read_format_capacities(scsip, cmd);
+    break;
 
   case SCSI_CMD_VERIFY_10:
     dbgprintf("SCSI_CMD_VERIFY_10\r\n");
-    return cmd_ignored(scsip, cmd);
+    ret = cmd_ignored(scsip, cmd);
+    break;
 
   default:
     warnprintf("SCSI unhandled command: %X\r\n", cmd[0]);
-    return cmd_unhandled(scsip, cmd);
+    ret = cmd_unhandled(scsip, cmd);
+    break;
   }
+
+  if (ret == SCSI_SUCCESS)
+    set_sense_ok(scsip);
+
+  return ret;
 }
 
 /**


### PR DESCRIPTION
When host sends TEST UNIT READY command, set sense 'all ok' if block device reports
that medium is inserted, or set sense 'medium not present' if medium is not inserted.

Do not override sense by default with 'all ok', allow REQUEST SENSE command
to be responded with correct sense data which was set on last failure.

Check just DESC bit when responding to REQUEST SENSE command.

----

Example use cases:
* Allow host to know the external media inserted state on your device
* Forcibly remount mass media by setting is_inserted virtual method return value to false for one round

Windows (at least) tells to "Insert disk in drive" when 

Analyzer capture (of latter use case)
```
Type	Seq	Time	Elapsed	Duration	Request	Request Details	I/O	C:I:E	Device Object	Device Name	Driver Name	IRP	IRP Status (URB Status)	URB Transfer Buffer Raw Data Dump
URB	0005-0002	13:21:05.156	790.619 ms	254 us	Bulk or Interrupt Transfer	Test Unit Ready - CBW	out	01:00:01	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)
URB	0009-0006	13:21:05.156	790.854 ms	230 us	Bulk or Interrupt Transfer	Test Unit Ready - CSW (Passed)	in	01:00:81	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)	55 53 42 53 F0 F4 54 15 00 00 00 00 00
URB	0013-0010	13:21:06.155	1.789572 s	192 us	Bulk or Interrupt Transfer	Test Unit Ready - CBW	out	01:00:01	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)
URB	0017-0014	13:21:06.155	1.789822 s	244 us	Bulk or Interrupt Transfer	Test Unit Ready - CSW (Failed)	in	01:00:81	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)	55 53 42 53 F0 F4 54 15 00 00 00 00 01
URB	0021-0018	13:21:06.155	1.790047 s	221 us	Bulk or Interrupt Transfer	Request Sense - CBW	out	01:00:01	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)
URB	0025-0022	13:21:06.156	1.790318 s	265 us	Bulk or Interrupt Transfer	Request Sense (Not Ready, Medium not Present) - Data-In	in	01:00:81	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)	70 00 02 00 00 00 00 08 00 00 00 00 3A 00 00 00 00 00
URB	0029-0026	13:21:06.156	1.790560 s	237 us	Bulk or Interrupt Transfer	Request Sense - CSW (Passed)	in	01:00:81	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA801554F4F0h	Success (Success)	55 53 42 53 F0 F4 54 15 00 00 00 00 00
URB	0035-0032	13:21:06.168	1.802284 s	263 us	Bulk or Interrupt Transfer	Test Unit Ready - CBW	out	01:00:01	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA8011A1FA20h	Success (Success)
URB	0039-0036	13:21:06.168	1.802521 s	230 us	Bulk or Interrupt Transfer	Test Unit Ready - CSW (Passed)	in	01:00:81	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA8011A1FA20h	Success (Success)	55 53 42 53 20 FA A1 11 00 00 00 00 00
URB	0045-0042	13:21:06.188	1.823054 s	218 us	Bulk or Interrupt Transfer	Test Unit Ready - CBW	out	01:00:01	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA80199AB3B0h	Success (Success)
URB	0049-0046	13:21:06.189	1.823309 s	248 us	Bulk or Interrupt Transfer	Test Unit Ready - CSW (Passed)	in	01:00:81	FFFFFA801995D730h	0000056a	usbccgp	FFFFFA80199AB3B0h	Success (Success)	55 53 42 53 B0 B3 9A 19 00 00 00 00 00
```

Datails of Request Sense reponse data:

```
Sense Data
Field Value Description 
Response Code 70h Current Information (Fixed) 
 
File Mark 0b  
End of Medium (EOM) 0b  
Incorrect Length Indicator (ILI) 0b  
Sense Key 2h Not Ready 
 
Information Field Valid (Valid) 0b  
Information 00000000h  
 
Additional Sense Length 08h  
Command-Specific Information 00000000h  
 
ASC and ASCQ 3Ah 00h Medium not Present 
 
Field Replaceable Unit Code 00h  
 
Sense-Key Specific Valid (SKSV) 0b  
Sense-Key Specific Information 000000h  
```