### PR TITLE
Add STM32F769 to FSMCv1 sdram driver

### DIFF
--- a/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc.h
+++ b/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc.h
@@ -36,7 +36,7 @@
  */
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
-     defined(STM32F7))
+     defined(STM32F769xx))
   #if !defined(FSMC_Bank1_R_BASE)
   #define FSMC_Bank1_R_BASE               (FMC_R_BASE + 0x0000)
   #endif

--- a/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc_sdram.c
+++ b/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc_sdram.c
@@ -28,7 +28,8 @@
 #include "hal.h"
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
-     defined(STM32F429xx) || defined(STM32F439xx))
+     defined(STM32F429xx) || defined(STM32F439xx) || \
+     defined(STM32F769xx))
 
 #if (STM32_USE_FSMC_SDRAM == TRUE) || defined(__DOXYGEN__)
 

--- a/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc_sdram.h
+++ b/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc_sdram.h
@@ -29,7 +29,8 @@
 #define HAL_FMC_SDRAM_H_
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
-     defined(STM32F429xx) || defined(STM32F439xx))
+     defined(STM32F429xx) || defined(STM32F439xx) || \
+     defined(STM32F769xx))
 
 #include "hal_fsmc.h"
 


### PR DESCRIPTION
Tested on STM32F769I-Discovery DISC1 board.