### PR TITLE
Fix Kinetis usb databank synchronization problems

### DIFF
--- a/os/common/ext/CMSIS/KINETIS/k20xx.h
+++ b/os/common/ext/CMSIS/KINETIS/k20xx.h
@@ -2242,7 +2242,7 @@ typedef struct
 /******** Bits definition for USBx_CTL register *****************/
 #define USBx_CTL_JSTATE              ((uint8_t)0x80) /*!< Live USB differential receiver JSTATE signal */
 #define USBx_CTL_SE0                 ((uint8_t)0x40) /*!< Live USB single ended zero signal */
-#define USBx_CTL_TXSUSPENDTOKENBUS   ((uint8_t)0x20) /*!<  */
+#define USBx_CTL_TXSUSPENDTOKENBUSY  ((uint8_t)0x20) /*!<  */
 #define USBx_CTL_RESET               ((uint8_t)0x10) /*!< Generates an USB reset signal (host mode) */
 #define USBx_CTL_HOSTMODEEN          ((uint8_t)0x08) /*!< Operate in Host mode */
 #define USBx_CTL_RESUME              ((uint8_t)0x04) /*!< Executes resume signaling */

--- a/os/hal/ports/KINETIS/LLD/hal_usb_lld.c
+++ b/os/hal/ports/KINETIS/LLD/hal_usb_lld.c
@@ -158,7 +158,7 @@ void usb_packet_transmit(USBDriver *usbp, usbep_t ep, size_t n)
   USBInEndpointState *isp = epc->in_state;
 
   bd_t *bd = (bd_t *)&_bdt[BDT_INDEX(ep, TX, isp->odd_even)];
-  
+
   if (n > (size_t)epc->in_maxsize)
     n = (size_t)epc->in_maxsize;
 
@@ -244,19 +244,16 @@ OSAL_IRQ_HANDLER(KINETIS_USB_IRQ_VECTOR) {
     {
       case BDT_PID_SETUP:                                              // SETUP
       {
-        /* Clear any pending IN stuff */
-        _bdt[BDT_INDEX(ep, TX, EVEN)].desc = 0;
-        _bdt[BDT_INDEX(ep, TX,  ODD)].desc = 0;
-        /* Also in the chibios state machine */
+        /* Clear receiving in the chibios state machine */
         (usbp)->receiving &= ~1;
-        /* After a SETUP, IN is always DATA1 */
-        usbp->epc[ep]->in_state->data_bank = DATA1;
-
-        /* Call SETUP function (ChibiOS core), which sends back stuff */
+        /* Call SETUP function (ChibiOS core), which prepares
+         * for send or receive and releases the buffer
+         */
         _usb_isr_invoke_setup_cb(usbp, ep);
-        /* Buffer is released by the above callback. */
-        /* from Paul: "unfreeze the USB, now that we're ready" */
-        USB0->CTL = USBx_CTL_USBENSOFEN;
+        /* When a setup packet is received, tx is suspended,
+         * so it needs to be resumed here.
+         */
+        USB0->CTL &= ~USBx_CTL_TXSUSPENDTOKENBUSY;
       } break;
       case BDT_PID_IN:                                                 // IN
       {
@@ -728,9 +725,23 @@ void usb_lld_read_setup(USBDriver *usbp, usbep_t ep, uint8_t *buf) {
   }
   /* Release the buffer
    * Setup packet is always DATA0
-   * Initialize buffers so current expects DATA0 & opposite DATA1 */
+   * Release the current DATA0 buffer
+   */
   bd->desc = BDT_DESC(usbp->epc[ep]->out_maxsize,DATA0);
-  _bdt[BDT_INDEX(ep, RX, os->odd_even^ODD)].desc = BDT_DESC(usbp->epc[ep]->out_maxsize,DATA1);
+  /* If DATA1 was expected, then the states are out of sync.
+   * So reset the other buffer too, and set it as DATA1.
+   * This should not happen in normal cases, but is possible in
+   * error situations. NOTE: it's possible that this is too late
+   * and the next packet has already been received and dropped, but
+   * there's nothing that we can do about that anymore at this point.
+   */
+  if (os->data_bank == DATA1)
+  {
+    bd_t *bd_next = (bd_t*)&_bdt[BDT_INDEX(ep, RX, os->odd_even^ODD)];
+    bd_next->desc = BDT_DESC(usbp->epc[ep]->out_maxsize,DATA1);
+  }
+  /* After a SETUP, both in and out are always DATA1 */
+  usbp->epc[ep]->in_state->data_bank = DATA1;
   os->data_bank = DATA1;
 }
 
@@ -762,8 +773,22 @@ void usb_lld_start_out(USBDriver *usbp, usbep_t ep) {
  * @notapi
  */
 void usb_lld_start_in(USBDriver *usbp, usbep_t ep) {
-  (void)usbp;
-  (void)ep;
+  if (ep == 0 && usbp->ep0state == USB_EP0_IN_SENDING_STS) {
+    /* When a status packet is about to be sent on endpoint 0 the
+     * next packet will be a setup packet, which means that the
+     * buffer we expect after this should be DATA0, and the following
+     * DATA1. Since no out packets should be in flight at this time
+     * it's safe to initialize the buffers according to the expectations
+     * here.
+     */
+    const USBEndpointConfig* epc = usbp->epc[ep];
+    bd_t * bd = (bd_t*)&_bdt[BDT_INDEX(ep, RX, epc->out_state->odd_even)];
+    bd_t *bd_next = (bd_t*)&_bdt[BDT_INDEX(ep, RX, epc->out_state->odd_even^ODD)];
+
+    bd->desc = BDT_DESC(usbp->epc[ep]->out_maxsize,DATA1);
+    bd_next->desc = BDT_DESC(usbp->epc[ep]->out_maxsize,DATA0);
+    epc->out_state->data_bank = DATA0;
+  }
   usb_packet_transmit(usbp,ep,usbp->epc[ep]->in_state->txsize);
 }
 


### PR DESCRIPTION
This is another fix for the problem described in this thread http://www.chibios.com/forum/viewtopic.php?f=26&t=2401&sid=4e6ff9b730db4a2a8fe9254f9bc72680&start=40, the last post on the linked page. For me it was stil occuring with the exact symptoms when I tried to use the Virtual Serial port support. At least on Windows 10, it failed maybe once every 5 tries.

From the commit message 
> USB control transfers are structured as the following.
For incoming transfers
Setup (Data0 out)
Data (Data1/Data0 in) - starting with data 1
Status (Data1 out)

>For outgoing transfers
Setup (Data0 out)
Data (Data1/Data0 out) - starting with data 1
Status (Data1 in)

>The in buffers (device to host) are always correctly synchronized, since
they can always be reset to Data1 each setup packet without any
synchronization problems.

>The problem occured for outgoing transfers (host to device). For
incoming transfers the data banks always alternates, and will
automatically stay in sync. Outgoing transfers also stays in sync when
there's an odd number of data packets. However when the number is even,
including zero, then the last packet received by the device will be
data0 and the next setup packet also has to be data0, so there's a
synchronization problem.

>This itself is not a problem since data toggle synchronization(DTS) is
ignored for setup packets, however if the follwoing packet after that
is also an out packet, then the data bank will be wrong and the packet
dropped. In this case the USB spec don't allow sending a nack, so it
will only recover after a timeout, when the host tries to send a new
setup packet.

>The old code tried to take care of this situation by reinitializing
both data banks when a setup packet is received. The problem is that the
next packet might already have been received or is in progress of being
received at this point, so the fixup comes to late. The new code does
the fixup when a status packet is about to be sent from the device to
avoid this problem.

@flabbergast and @jstruebel are probably interested in seeing this.