### PR TITLE
Keep track of STM32 RCC API

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/hal_eicu_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_eicu_lld.c
@@ -1057,75 +1057,75 @@ void eicu_lld_stop(EICUDriver *eicup) {
     if (&EICUD1 == eicup) {
       nvicDisableVector(STM32_TIM1_UP_NUMBER);
       nvicDisableVector(STM32_TIM1_CC_NUMBER);
-      rccDisableTIM1(FALSE);
+      rccDisableTIM1();
     }
 #endif
 #if STM32_EICU_USE_TIM2
     if (&EICUD2 == eicup) {
       nvicDisableVector(STM32_TIM2_NUMBER);
-      rccDisableTIM2(FALSE);
+      rccDisableTIM2();
     }
 #endif
 #if STM32_EICU_USE_TIM3
     if (&EICUD3 == eicup) {
       nvicDisableVector(STM32_TIM3_NUMBER);
-      rccDisableTIM3(FALSE);
+      rccDisableTIM3();
     }
 #endif
 #if STM32_EICU_USE_TIM4
     if (&EICUD4 == eicup) {
       nvicDisableVector(STM32_TIM4_NUMBER);
-      rccDisableTIM4(FALSE);
+      rccDisableTIM4();
     }
 #endif
 #if STM32_EICU_USE_TIM5
     if (&EICUD5 == eicup) {
       nvicDisableVector(STM32_TIM5_NUMBER);
-      rccDisableTIM5(FALSE);
+      rccDisableTIM5();
     }
 #endif
 #if STM32_EICU_USE_TIM8
     if (&EICUD8 == eicup) {
       nvicDisableVector(STM32_TIM8_UP_NUMBER);
       nvicDisableVector(STM32_TIM8_CC_NUMBER);
-      rccDisableTIM8(FALSE);
+      rccDisableTIM8();
     }
 #endif
 #if STM32_EICU_USE_TIM9
     if (&EICUD9 == eicup) {
       nvicDisableVector(STM32_TIM9_NUMBER);
-      rccDisableTIM9(FALSE);
+      rccDisableTIM9();
     }
 #endif
 #if STM32_EICU_USE_TIM12
     if (&EICUD12 == eicup) {
       nvicDisableVector(STM32_TIM12_NUMBER);
-      rccDisableTIM12(FALSE);
+      rccDisableTIM12();
     }
 #endif
   }
 #if STM32_EICU_USE_TIM10
     if (&EICUD10 == eicup) {
       nvicDisableVector(STM32_TIM10_NUMBER);
-      rccDisableTIM10(FALSE);
+      rccDisableTIM10();
     }
 #endif
 #if STM32_EICU_USE_TIM11
     if (&EICUD11 == eicup) {
       nvicDisableVector(STM32_TIM11_NUMBER);
-      rccDisableTIM11(FALSE);
+      rccDisableTIM11();
     }
 #endif
 #if STM32_EICU_USE_TIM13
     if (&EICUD13 == eicup) {
       nvicDisableVector(STM32_TIM13_NUMBER);
-      rccDisableTIM13(FALSE);
+      rccDisableTIM13();
     }
 #endif
 #if STM32_EICU_USE_TIM14
     if (&EICUD14 == eicup) {
       nvicDisableVector(STM32_TIM14_NUMBER);
-      rccDisableTIM14(FALSE);
+      rccDisableTIM14();
     }
 #endif
 }

--- a/os/hal/ports/STM32/LLD/TIMv1/hal_qei_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_qei_lld.c
@@ -157,38 +157,38 @@ void qei_lld_start(QEIDriver *qeip) {
     /* Clock activation and timer reset.*/
 #if STM32_QEI_USE_TIM1
     if (&QEID1 == qeip) {
-      rccEnableTIM1();
+      rccEnableTIM1(FALSE);
       rccResetTIM1();
     }
 #endif
 #if STM32_QEI_USE_TIM2
     if (&QEID2 == qeip) {
-      rccEnableTIM2();
+      rccEnableTIM2(FALSE);
       rccResetTIM2();
     }
 #endif
 #if STM32_QEI_USE_TIM3
     if (&QEID3 == qeip) {
-      rccEnableTIM3();
+      rccEnableTIM3(FALSE);
       rccResetTIM3();
     }
 #endif
 #if STM32_QEI_USE_TIM4
     if (&QEID4 == qeip) {
-      rccEnableTIM4();
+      rccEnableTIM4(FALSE);
       rccResetTIM4();
     }
 #endif
 
 #if STM32_QEI_USE_TIM5
     if (&QEID5 == qeip) {
-      rccEnableTIM5();
+      rccEnableTIM5(FALSE);
       rccResetTIM5();
     }
 #endif
 #if STM32_QEI_USE_TIM8
     if (&QEID8 == qeip) {
-      rccEnableTIM8();
+      rccEnableTIM8(FALSE);
       rccResetTIM8();
     }
 #endif

--- a/os/hal/ports/STM32/LLD/TIMv1/hal_timcap_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_timcap_lld.c
@@ -713,44 +713,44 @@ void timcap_lld_stop(TIMCAPDriver *timcapp) {
     if (&TIMCAPD1 == timcapp) {
       nvicDisableVector(STM32_TIM1_UP_NUMBER);
       nvicDisableVector(STM32_TIM1_CC_NUMBER);
-      rccDisableTIM1(FALSE);
+      rccDisableTIM1();
     }
 #endif
 #if STM32_TIMCAP_USE_TIM2
     if (&TIMCAPD2 == timcapp) {
       nvicDisableVector(STM32_TIM2_NUMBER);
-      rccDisableTIM2(FALSE);
+      rccDisableTIM2();
     }
 #endif
 #if STM32_TIMCAP_USE_TIM3
     if (&TIMCAPD3 == timcapp) {
       nvicDisableVector(STM32_TIM3_NUMBER);
-      rccDisableTIM3(FALSE);
+      rccDisableTIM3();
     }
 #endif
 #if STM32_TIMCAP_USE_TIM4
     if (&TIMCAPD4 == timcapp) {
       nvicDisableVector(STM32_TIM4_NUMBER);
-      rccDisableTIM4(FALSE);
+      rccDisableTIM4();
     }
 #endif
 #if STM32_TIMCAP_USE_TIM5
     if (&TIMCAPD5 == timcapp) {
       nvicDisableVector(STM32_TIM5_NUMBER);
-      rccDisableTIM5(FALSE);
+      rccDisableTIM5();
     }
 #endif
 #if STM32_TIMCAP_USE_TIM8
     if (&TIMCAPD8 == timcapp) {
       nvicDisableVector(STM32_TIM8_UP_NUMBER);
       nvicDisableVector(STM32_TIM8_CC_NUMBER);
-      rccDisableTIM8(FALSE);
+      rccDisableTIM8();
     }
 #endif
 #if STM32_TIMCAP_USE_TIM9
     if (&TIMCAPD9 == timcapp) {
       nvicDisableVector(STM32_TIM9_NUMBER);
-      rccDisableTIM9(FALSE);
+      rccDisableTIM9();
     }
 #endif
   }


### PR DESCRIPTION
RCC API changed in 01/2018 so apply the changes.

Note that ae7a4d40b84d8afc999691577210696f16e682f6 partially fixed the changes in QEI module but some were missing.
So update the other modules too.