### PR TITLE
Adding missing interrupt vector for SDHC on MK66F18 MCU

### DIFF
--- a/os/hal/ports/KINETIS/MK66F18/kinetis_registry.h
+++ b/os/hal/ports/KINETIS/MK66F18/kinetis_registry.h
@@ -161,6 +161,10 @@
 /* LPTMR attributes.*/
 #define KINETIS_LPTMR0_IRQ_VECTOR   Vector128
 
+/* SDHC (SDC, MMC, SDIO) attributes */
+#define KINETIS_HAS_SDHC            TRUE
+#define KINETIS_SDHC_IRQ_VECTOR     Vector184
+
 /** @} */
 
 #endif /* KINETIS_REGISTRY_H_ */


### PR DESCRIPTION
This fixes a minor error causing SDHC not to work on the MK66F18 MCU.  After this fix, the SDHC driver wiml contributed is working on this MCU.  Tested using fatfs library.