### PR TITLE
Fix #161: STM32 LLD CRCv1 large data bug in DMA mode

### DIFF
--- a/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.c
+++ b/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.c
@@ -121,9 +121,14 @@ static void crc_lld_serve_interrupt(CRCDriver *crcp, uint32_t flags) {
   /* Stop everything.*/
   dmaStreamDisable(crcp->dma);
 
-  /* Portable CRC ISR code defined in the high level driver, note, it is
-     a macro.*/
-  _crc_isr_code(crcp, crcp->crc->DR ^ crcp->config->final_val);
+  if (crcp->rem_data_size) {
+    /* Start DMA follow up transfer for next data chunk */
+    crc_lld_start_calc(crcp, crcp->rem_data_size,
+      (const void *)crcp->dma->channel->CPAR+0xffff);
+  } else {
+    /* Portable CRC ISR code defined in the high level driver, note, it is a macro.*/
+    _crc_isr_code(crcp, crcp->crc->DR ^ crcp->config->final_val);
+  }
 }
 #endif
 
@@ -308,12 +313,17 @@ uint32_t crc_lld_calc(CRCDriver *crcp, size_t n, const void *buf) {
 
 #if CRC_USE_DMA == TRUE
 void crc_lld_start_calc(CRCDriver *crcp, size_t n, const void *buf) {
+  /* The STM32 DMA can only handle max 65535 bytes per transfer
+   * because it's data count register has only 16 bit. */
+  size_t sz = (n > 0xffff) ? 0xffff : n;
+  crcp->rem_data_size = n-sz;
+
   dmaStreamSetPeripheral(crcp->dma, buf);
   dmaStreamSetMemory0(crcp->dma, &crcp->crc->DR);
 #if STM32_CRC_PROGRAMMABLE == TRUE
-  dmaStreamSetTransactionSize(crcp->dma, n);
+  dmaStreamSetTransactionSize(crcp->dma, sz);
 #else
-  dmaStreamSetTransactionSize(crcp->dma, (n / 4));
+  dmaStreamSetTransactionSize(crcp->dma, (sz / 4));
 #endif
   dmaStreamSetMode(crcp->dma, crcp->dmamode);
 

--- a/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.h
+++ b/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.h
@@ -203,6 +203,12 @@ struct CRCDriver {
    */
   thread_reference_t        thread;
   /**
+   * @brief   Remaining data size.
+   * @note    The DMA can handle only 65535 bytes per transfer because
+   *            it's data count register is only 16 bits wide.
+   */
+  size_t rem_data_size;
+  /**
    * @brief CRC DMA stream
    */
   const stm32_dma_stream_t  *dma;


### PR DESCRIPTION
Hi guys,

sorry for my issue duplicate.

As you already mentions correctly in #161 we have to split up the DMA transfer because the STM32 DMA can only handle 65535 bytes per transfer.
This is my current fix and the results are very promising.

What do you think about my solution?