### PR TITLE
Added setting qei to value for stm32

### DIFF
--- a/os/hal/include/hal_qei.h
+++ b/os/hal/include/hal_qei.h
@@ -145,6 +145,7 @@ extern "C" {
   void qeiEnable(QEIDriver *qeip);
   void qeiDisable(QEIDriver *qeip);
   qeicnt_t qeiGetCount(QEIDriver *qeip);
+  void qeiSetCount(QEIDriver *qeip, qeicnt_t value);
   qeidelta_t qeiUpdate(QEIDriver *qeip);
   qeidelta_t qeiUpdateI(QEIDriver *qeip);
   qeidelta_t qeiAdjustI(QEIDriver *qeip, qeidelta_t delta);

--- a/os/hal/ports/STM32/LLD/TIMv1/hal_qei_lld.h
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_qei_lld.h
@@ -415,7 +415,7 @@ struct QEIDriver {
  *
  * @notapi
  */
-#define qei_lld_set_count(qeip, value)
+#define qei_lld_set_count(qeip, value) ((qeip)->tim->CNT = (value))
 
 /*===========================================================================*/
 /* External declarations.                                                    */


### PR DESCRIPTION
The qeiSetCount prototype was not in header file (causing -Wimplicit-function-declaration warning in gcc) plus the stm32 port had empty body of qei_lld_set_count.