### PR TITLE
Fix for rccEnableCRC macro parameter.

### DIFF
--- a/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.c
+++ b/os/hal/ports/STM32/LLD/CRCv1/hal_crc_lld.c
@@ -160,7 +160,7 @@ void crc_lld_start(CRCDriver *crcp) {
   if (crcp->config == NULL)
     crcp->config = &default_config;
 
-  rccEnableCRC();
+  rccEnableCRC( FALSE );
 
 #if STM32_CRC_PROGRAMMABLE == TRUE
   crcp->crc->INIT = crcp->config->initial_val;


### PR DESCRIPTION
This was removed in commit
ae7a4d40b84d8afc999691577210696f16e682f6#diff-7ddaa5ecc31109f41b7801dea2660b47

But I think is still necessary as the underlying rccEnableAHB macros
take parameter 'lp'.  It seems to work for the F0xx series, because its
rccEnableAHB ignores the 'lp'.  It is required when I tried to use the
CRC driver on a family that does require the 'lp' parameter in the lower
level macros.