### PR TITLE
Fixed board generation for pins with note in name

### DIFF
--- a/tools/mx2board.py
+++ b/tools/mx2board.py
@@ -171,7 +171,11 @@ def read_gpio(filename):
     for pin in root.findall('GPIO_Pin'):
         try:
             port = pin.attrib['Name'][1]
-            num = int(pin.attrib['Name'][2:])
+            num = pin.attrib['Name'][2:]
+            # remove notes from pin name (e.g. PH0 - OSC_IN)
+            num = num.split('-')[0].strip()
+            num = int(num)
+
             if port not in gpio['ports']:
                 gpio['ports'][port] = {}
             if num not in gpio['ports'][port]:


### PR DESCRIPTION
Some pins are ignored when the pin name in stm32cubemx xml is in format like:
PC14-OSC32_IN
PH0 - OSC_IN

This can cause build errors (e.g. for stm32f412 the VAL_GPIO_X are not defined in generated output and the build fails when the board.c tries to use these defines).

This patch fixes the port name generation.