### PR TITLE
Fixed Timer number generation

### DIFF
--- a/tools/mx2board.py
+++ b/tools/mx2board.py
@@ -275,7 +275,7 @@ def gen_defines(project):
             defines['LINE_'+label] += ', ' + str(pad_key) + 'U)'
 
             if re.search(r"TIM\d+_CH\d$", signal, re.M):
-                timer = signal.replace('S_TIM', '').replace('_CH', '')[:-1]
+                timer = signal.replace('TIM', '').replace('_CH', '')[:-1]
                 ch_num = int(signal[-1:])
 
                 defines['TIM_' + label] = timer


### PR DESCRIPTION
S_TIM will never appear in the signal list as the S_ is removed in read_project(), I guess the required output is the timer number instead of text TIMx where x is the timer number. It won't fail during the compilation as TIMx is usually defined in CMSIS headers, but...