### PR TITLE
Added spi and fixed FSMC alternate setup

### DIFF
--- a/tools/mx2board.py
+++ b/tools/mx2board.py
@@ -240,6 +240,11 @@ def read_project(gpio, filename):
                 elif 'GPIO_Input' == prop_value:
                     pads[pad_port][pad_num]["MODER"] = PIN_MODE_INPUT
                 else:
+                    # workaround for different names in project and gpio defs
+                    if "FSMC" in prop_value:
+                        prop_value = re.sub(r"FSMC_D([0-9]+)_DA[0-9]+",
+                                r"FSMC_D\1", prop_value)
+
                     pads[pad_port][pad_num]["SIGNAL"] = prop_value
                     pads[pad_port][pad_num]["MODER"] = PIN_MODE_ALTERNATE
                     pads[pad_port][pad_num]["OSPEEDR"] = PIN_OSPEED_MEDIUM
@@ -314,6 +319,11 @@ def gen_defines(project):
             match = re.search(r"I2C(\d)_S(CL|DA)", signal)
             if match:
                 defines['I2C_' + label] = match.group(1)
+                continue
+
+            match = re.search(r"SPI(\d)_(MOSI|MISO|SCK|NSS)", signal)
+            if match:
+                defines['SPI_' + label] = match.group(1)
                 continue
 
             match = re.search(r"CAN(\d*)_[RT]X", signal)


### PR DESCRIPTION
Hi,
I've added generator of SPI device in addition to others like I2C, etc.

Also I've noticed that the script fails to generate FSMC AF registers correctly as the name of the signal is FSMC_D12_DA12, but there are two different signals in the gpios - FSMC_D12 and FSMC_DA12, at least for the STM32F412. I'm not really familiar with the different types, but I guess that's because these signals share the AFRx register values.