### PR TITLE
Fixes for USB MSD

### DIFF
--- a/os/hal/ports/STM32/LLD/USBHv1/hal_usbh_lld.c
+++ b/os/hal/ports/STM32/LLD/USBHv1/hal_usbh_lld.c
@@ -1505,8 +1505,8 @@ static void _usbh_start(USBHDriver *usbh) {
 #endif
 	{
 		/* OTG HS clock enable and reset.*/
-		rccEnableOTG_HS(TRUE); // Enable HS clock when cpu is in sleep mode
-		rccDisableOTG_HSULPI(TRUE); // Disable HS ULPI clock when cpu is in sleep mode
+		rccEnableOTG_HS(FALSE); // Disable HS clock when cpu is in sleep mode
+		rccDisableOTG_HSULPI();
 		rccResetOTG_HS();
 
 		otgp->GINTMSK = 0;

--- a/os/hal/src/usbh/hal_usbh_msd.c
+++ b/os/hal/src/usbh/hal_usbh_msd.c
@@ -516,6 +516,8 @@ static msd_result_t _scsi_perform_transaction(USBHMassStorageLUNDriver *lunp,
 			if (scsi_requestsense(lunp, &sense) == MSD_RESULT_OK) {
 				uwarnf("\tMSD: REQUEST SENSE: Sense key=%x, ASC=%02x, ASCQ=%02x",
 						sense.byte[2] & 0xf, sense.byte[12], sense.byte[13]);
+
+				return MSD_RESULT_OK;
 			}
 		}
 		return MSD_RESULT_FAILED;


### PR DESCRIPTION
- Fix return value on succesfull scsi_requestsense.
- Fix calls to LL SMT32 API for OTG2.
- Port changes from ChibiOS fatfs_diskio.
- Rework checks to allow simultaneous use of SD Card and USB MSD.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>