### PR TITLE
ChibiOS Path rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,35 @@ Code under this directory is not part of the core ChibiOS project
 and the copyright is retained by the original authors. See copyright
 notes in file headers.
 
-Code is maintained via Github https://github.com/ChibiOS/ChibiOS-Contrib
-Feel free to send pull request there.
+Code is maintained via Github: https://github.com/ChibiOS/ChibiOS-Contrib  
+Feel free to open pull request there.
 
 #### Using
 
-```bash
-# git clone git@github.com:Chibios/ChibiOS.git ChibiOS-RT
-# git clone git@github.com:ChibiOS/ChibiOS-Contrib.git ChibiOS-Contrib
+Default makefiles assume this repo will be cloned in the same folder as ChibiOS.  
+If you use another location, you will have to edit the Makefile, or specify an alternate location to make, ie:  
+
 ```
-Note: this repos cloned in the same directory side by side (not inside).
+cd ChibiOS-Contrib/testhal/STM32/STM32F3xx/TIMCAP
+make CHIBIOS=~/src/ChibiOS
+```
+
+A good way to use it is to clone it as a submodule inside your project:  
+
+```
+git submodule add https://github.com/ChibiOS/ChibiOS.git
+git submodule add https://github.com/ChibiOS/ChibiOS-Contrib.git
+```
 
 #### Contributing
 
-When you submit a pull request, make sure all impacted platform tests compile using the tools/build.sh script.  
+When you submit a pull request, make sure all modified platform tests compile using the tools/build.sh script.  
+There is an automated check that will report errors if it doesn't.  
 Feel free to update authors.txt with your name.  
-
 
 #### Useful links
 
 https://help.github.com/  
 http://git-scm.com/  
-http://chibios.org/dokuwiki/doku.php?id=chibios:guides:style_guide
+http://chibios.org/dokuwiki/doku.php?id=chibios:guides:style_guide  
+http://www.chibios.com/forum/  

--- a/demos/KINETIS/RT-FREEDOM-K20D50M-EXT/Makefile
+++ b/demos/KINETIS/RT-FREEDOM-K20D50M-EXT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-FREEDOM-K20D50M/Makefile
+++ b/demos/KINETIS/RT-FREEDOM-K20D50M/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-FREEDOM-KL25Z-EXT/Makefile
+++ b/demos/KINETIS/RT-FREEDOM-KL25Z-EXT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-FREEDOM-KL25Z-SHELL/Makefile
+++ b/demos/KINETIS/RT-FREEDOM-KL25Z-SHELL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-FREEDOM-KL25Z/Makefile
+++ b/demos/KINETIS/RT-FREEDOM-KL25Z/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-MCHCK-K20-GPT/Makefile
+++ b/demos/KINETIS/RT-MCHCK-K20-GPT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-MCHCK-K20-SPI/Makefile
+++ b/demos/KINETIS/RT-MCHCK-K20-SPI/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/KINETIS/RT-TEENSY3/Makefile
+++ b/demos/KINETIS/RT-TEENSY3/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/MSP430X/NIL-EXP430FR5969/Makefile
+++ b/demos/MSP430X/NIL-EXP430FR5969/Makefile
@@ -100,7 +100,7 @@ endif
 PROJECT = nil
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = ../../..
 # Startup files.
 include $(CHIBIOS_CONTRIB)/os/common/startup/MSP430X/compilers/GCC/mk/startup_msp430fr5xxx.mk

--- a/demos/MSP430X/NIL-EXP430FR6989/Makefile
+++ b/demos/MSP430X/NIL-EXP430FR6989/Makefile
@@ -100,7 +100,7 @@ endif
 PROJECT = nil
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = ../../..
 # Startup files.
 include $(CHIBIOS_CONTRIB)/os/common/startup/MSP430X/compilers/GCC/mk/startup_msp430fr5xxx.mk

--- a/demos/NRF51/MICROBIT/Makefile
+++ b/demos/NRF51/MICROBIT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/NRF51/OSHCHIP_V1.0/Makefile
+++ b/demos/NRF51/OSHCHIP_V1.0/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/NRF51/RT-WVSHARE_BLE400/Makefile
+++ b/demos/NRF51/RT-WVSHARE_BLE400/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/NRF52/Classic/Makefile
+++ b/demos/NRF52/Classic/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS         = ../../../../ChibiOS-RT
+CHIBIOS         = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/STM32/RT-STM32F303-DISCOVERY-PID/Makefile
+++ b/demos/STM32/RT-STM32F303-DISCOVERY-PID/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/STM32/RT-STM32F429-DISCOVERY-DMA2D/Makefile
+++ b/demos/STM32/RT-STM32F429-DISCOVERY-DMA2D/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/STM32/RT-STM32F429-DISCOVERY-TRIBUF/Makefile
+++ b/demos/STM32/RT-STM32F429-DISCOVERY-TRIBUF/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/demos/TIVA/RT-TM4C123G-LAUNCHPAD/Makefile
+++ b/demos/TIVA/RT-TM4C123G-LAUNCHPAD/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/demos/TIVA/RT-TM4C1294-LAUNCHPAD-LWIP/Makefile
+++ b/demos/TIVA/RT-TM4C1294-LAUNCHPAD-LWIP/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/demos/TIVA/RT-TM4C1294-LAUNCHPAD/Makefile
+++ b/demos/TIVA/RT-TM4C1294-LAUNCHPAD/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/demos/various/RT-Win32-TriBuf/Makefile
+++ b/demos/various/RT-Win32-TriBuf/Makefile
@@ -56,7 +56,7 @@ UDEFS =
 UADEFS =
 
 # Imported source files
-CHIBIOS = ../../../../ChibiOS-RT
+CHIBIOS = ../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 include $(CHIBIOS)/os/hal/boards/simulator/board.mk
 include $(CHIBIOS)/os/hal/hal.mk

--- a/testhal/KINETIS/FRDM-K20D50M/I2C/Makefile
+++ b/testhal/KINETIS/FRDM-K20D50M/I2C/Makefile
@@ -87,7 +87,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/Makefile
+++ b/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL25Z/ADC/Makefile
+++ b/testhal/KINETIS/FRDM-KL25Z/ADC/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL25Z/GPT/Makefile
+++ b/testhal/KINETIS/FRDM-KL25Z/GPT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL25Z/PWM/Makefile
+++ b/testhal/KINETIS/FRDM-KL25Z/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL25Z/USB_HID/Makefile
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_HID/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/Makefile
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/Makefile
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL26Z/PWM/Makefile
+++ b/testhal/KINETIS/FRDM-KL26Z/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/Makefile
+++ b/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/KL27Z/BLINK/Makefile
+++ b/testhal/KINETIS/KL27Z/BLINK/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/MCHCK/BOOTLOADER/Makefile
+++ b/testhal/KINETIS/MCHCK/BOOTLOADER/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/MCHCK/PWM/Makefile
+++ b/testhal/KINETIS/MCHCK/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/MCHCK/USB_SERIAL/Makefile
+++ b/testhal/KINETIS/MCHCK/USB_SERIAL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/ADC/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/ADC/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/EEPROM_EMU/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/EEPROM_EMU/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/EXT/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/EXT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/GPT/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/GPT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/PWM/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/SERIAL/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/SERIAL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY3_x/USB_SERIAL/Makefile
+++ b/testhal/KINETIS/TEENSY3_x/USB_SERIAL/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY_LC/BOOTLOADER/Makefile
+++ b/testhal/KINETIS/TEENSY_LC/BOOTLOADER/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY_LC/EEPROM_EMU/Makefile
+++ b/testhal/KINETIS/TEENSY_LC/EEPROM_EMU/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/KINETIS/TEENSY_LC/PWM/Makefile
+++ b/testhal/KINETIS/TEENSY_LC/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/MSP430X/EXP430FR5969/ADC/Makefile
+++ b/testhal/MSP430X/EXP430FR5969/ADC/Makefile
@@ -100,7 +100,7 @@ endif
 PROJECT = nil
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = ../../../..
 # Startup files.
 include $(CHIBIOS_CONTRIB)/os/common/startup/MSP430X/compilers/GCC/mk/startup_msp430fr5xxx.mk

--- a/testhal/MSP430X/EXP430FR5969/DMA/Makefile
+++ b/testhal/MSP430X/EXP430FR5969/DMA/Makefile
@@ -100,7 +100,7 @@ endif
 PROJECT = nil
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = ../../../..
 # Startup files.
 include $(CHIBIOS_CONTRIB)/os/common/startup/MSP430X/compilers/GCC/mk/startup_msp430fr5xxx.mk

--- a/testhal/MSP430X/EXP430FR5969/SPI/Makefile
+++ b/testhal/MSP430X/EXP430FR5969/SPI/Makefile
@@ -100,7 +100,7 @@ endif
 PROJECT = nil
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = ../../../..
 # Startup files.
 include $(CHIBIOS_CONTRIB)/os/common/startup/MSP430X/compilers/GCC/mk/startup_msp430fr5xxx.mk

--- a/testhal/MSP430X/EXP430FR6989/ADC/Makefile
+++ b/testhal/MSP430X/EXP430FR6989/ADC/Makefile
@@ -100,7 +100,7 @@ endif
 PROJECT = nil
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = ../../../..
 # Startup files.
 include $(CHIBIOS_CONTRIB)/os/common/startup/MSP430X/compilers/GCC/mk/startup_msp430fr5xxx.mk

--- a/testhal/NRF51/NRF51822/ADC/Makefile
+++ b/testhal/NRF51/NRF51822/ADC/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF51/NRF51822/EXT/Makefile
+++ b/testhal/NRF51/NRF51822/EXT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF51/NRF51822/GPT/Makefile
+++ b/testhal/NRF51/NRF51822/GPT/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF51/NRF51822/I2C/Makefile
+++ b/testhal/NRF51/NRF51822/I2C/Makefile
@@ -80,7 +80,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF51/NRF51822/PWM/Makefile
+++ b/testhal/NRF51/NRF51822/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Startup files.

--- a/testhal/NRF51/NRF51822/RNG/Makefile
+++ b/testhal/NRF51/NRF51822/RNG/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Startup files.

--- a/testhal/NRF51/NRF51822/SPI/Makefile
+++ b/testhal/NRF51/NRF51822/SPI/Makefile
@@ -80,7 +80,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF51/NRF51822/WDG/Makefile
+++ b/testhal/NRF51/NRF51822/WDG/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF52/NRF52832/I2C/Makefile
+++ b/testhal/NRF52/NRF52832/I2C/Makefile
@@ -80,7 +80,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/NRF52/NRF52832/PWM-ICU/Makefile
+++ b/testhal/NRF52/NRF52832/PWM-ICU/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Startup files.

--- a/testhal/NRF52/NRF52832/RADIO-ESB/Makefile
+++ b/testhal/NRF52/NRF52832/RADIO-ESB/Makefile
@@ -80,7 +80,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F0xx/crc/Makefile
+++ b/testhal/STM32/STM32F0xx/crc/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F0xx/onewire/Makefile
+++ b/testhal/STM32/STM32F0xx/onewire/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 TESTHAL = $(CHIBIOS_CONTRIB)/testhal/common/onewire
 # Licensing files.

--- a/testhal/STM32/STM32F0xx/qei/Makefile
+++ b/testhal/STM32/STM32F0xx/qei/Makefile
@@ -81,7 +81,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F1xx/onewire/Makefile
+++ b/testhal/STM32/STM32F1xx/onewire/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 TESTHAL = $(CHIBIOS_CONTRIB)/testhal/common/onewire
 # Licensing files.

--- a/testhal/STM32/STM32F1xx/qei/Makefile
+++ b/testhal/STM32/STM32F1xx/qei/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F3xx/COMP/Makefile
+++ b/testhal/STM32/STM32F3xx/COMP/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F3xx/EEProm/Makefile
+++ b/testhal/STM32/STM32F3xx/EEProm/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F3xx/OPAMP/Makefile
+++ b/testhal/STM32/STM32F3xx/OPAMP/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F3xx/TIMCAP/Makefile
+++ b/testhal/STM32/STM32F3xx/TIMCAP/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F4xx/EICU/Makefile
+++ b/testhal/STM32/STM32F4xx/EICU/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F4xx/FSMC_NAND/Makefile
+++ b/testhal/STM32/STM32F4xx/FSMC_NAND/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F4xx/FSMC_SDRAM/Makefile
+++ b/testhal/STM32/STM32F4xx/FSMC_SDRAM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F4xx/FSMC_SRAM/Makefile
+++ b/testhal/STM32/STM32F4xx/FSMC_SRAM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F4xx/USB_HOST/Makefile
+++ b/testhal/STM32/STM32F4xx/USB_HOST/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/STM32/STM32F4xx/onewire/Makefile
+++ b/testhal/STM32/STM32F4xx/onewire/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 TESTHAL = $(CHIBIOS_CONTRIB)/testhal/common/onewire
 # Licensing files.

--- a/testhal/STM32/STM32F7xx/USB_MSD/Makefile
+++ b/testhal/STM32/STM32F7xx/USB_MSD/Makefile
@@ -91,7 +91,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/testhal/TIVA/TM4C123x/ADC/Makefile
+++ b/testhal/TIVA/TM4C123x/ADC/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/testhal/TIVA/TM4C123x/GPT/Makefile
+++ b/testhal/TIVA/TM4C123x/GPT/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/testhal/TIVA/TM4C123x/I2C/Makefile
+++ b/testhal/TIVA/TM4C123x/I2C/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/testhal/TIVA/TM4C123x/PWM/Makefile
+++ b/testhal/TIVA/TM4C123x/PWM/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/testhal/TIVA/TM4C123x/SPI/Makefile
+++ b/testhal/TIVA/TM4C123x/SPI/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/testhal/TIVA/TM4C123x/UART/Makefile
+++ b/testhal/TIVA/TM4C123x/UART/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.

--- a/testhal/TIVA/TM4C123x/WDG/Makefile
+++ b/testhal/TIVA/TM4C123x/WDG/Makefile
@@ -86,7 +86,7 @@ endif
 PROJECT = ch
 
 # Imported source files and paths
-CHIBIOS = ../../../../../ChibiOS-RT
+CHIBIOS = ../../../../../ChibiOS
 CHIBIOS_CONTRIB = $(CHIBIOS)/../ChibiOS-Contrib
 
 # Licensing files.


### PR DESCRIPTION
The default path now uses the default repo name, making it simpler.