### PR TITLE
NRF51/NRF52: Added support for internal I2C pull-ups

### DIFF
--- a/os/hal/ports/NRF5/LLD/TWIMv1/hal_i2c_lld.c
+++ b/os/hal/ports/NRF5/LLD/TWIMv1/hal_i2c_lld.c
@@ -38,17 +38,17 @@
 #define I2C_INPUT(p)  do { IOPORT1->DIRCLR = (1UL << (p)); } while(0)   /*!< Configures I2C pin as input  */
 #define I2C_OUTPUT(p) do { IOPORT1->DIRSET = (1UL << (p)); } while(0)   /*!< Configures I2C pin as output */
 
-#define I2C_PIN_CNF \
+#define I2C_PIN_CNF(internal_pullup) \
       ((GPIO_PIN_CNF_SENSE_Disabled  << GPIO_PIN_CNF_SENSE_Pos) \
       | (GPIO_PIN_CNF_DRIVE_S0D1     << GPIO_PIN_CNF_DRIVE_Pos) \
-      | (GPIO_PIN_CNF_PULL_Disabled  << GPIO_PIN_CNF_PULL_Pos)  \
+      | (((internal_pullup) ? GPIO_PIN_CNF_PULL_Pullup : GPIO_PIN_CNF_PULL_Disabled)  << GPIO_PIN_CNF_PULL_Pos)  \
       | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) \
       | (GPIO_PIN_CNF_DIR_Input      << GPIO_PIN_CNF_DIR_Pos))
 
-#define I2C_PIN_CNF_CLR \
+#define I2C_PIN_CNF_CLR(internal_pullup) \
       ((GPIO_PIN_CNF_SENSE_Disabled  << GPIO_PIN_CNF_SENSE_Pos) \
       | (GPIO_PIN_CNF_DRIVE_S0D1     << GPIO_PIN_CNF_DRIVE_Pos) \
-      | (GPIO_PIN_CNF_PULL_Disabled  << GPIO_PIN_CNF_PULL_Pos)  \
+      | (((internal_pullup) ? GPIO_PIN_CNF_PULL_Pullup : GPIO_PIN_CNF_PULL_Disabled)  << GPIO_PIN_CNF_PULL_Pos)  \
       | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) \
       | (GPIO_PIN_CNF_DIR_Output     << GPIO_PIN_CNF_DIR_Pos))
 
@@ -97,14 +97,14 @@ static void i2c_clear_bus(I2CDriver *i2cp) {
   const I2CConfig *cfg = i2cp->config;
   uint8_t i;
 
-  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF;
-  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF;
+  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF(cfg->scl_pullup);
+  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF(cfg->sda_pullup);
 
   I2C_HIGH(cfg->sda_pad);
   I2C_HIGH(cfg->scl_pad);
 
-  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR;
-  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR;
+  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR(cfg->scl_pullup);
+  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR(cfg->sda_pullup);
 
   nrf_delay_us(4);
 
@@ -233,8 +233,8 @@ void i2c_lld_start(I2CDriver *i2cp) {
 
   i2c_clear_bus(i2cp);
 
-  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF;
-  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF;
+  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF(cfg->scl_pullup);
+  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF(cfg->sda_pullup);
 
   i2c->SHORTS = 0;
 
@@ -300,8 +300,8 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 
     i2c->ENABLE = TWIM_ENABLE_ENABLE_Disabled << TWIM_ENABLE_ENABLE_Pos;
 
-    IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR;
-    IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR;
+    IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR(cfg->scl_pullup);
+    IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR(cfg->sda_pullup);
   }
 }
 

--- a/os/hal/ports/NRF5/LLD/TWIMv1/hal_i2c_lld.h
+++ b/os/hal/ports/NRF5/LLD/TWIMv1/hal_i2c_lld.h
@@ -113,6 +113,10 @@ typedef struct {
   uint8_t              scl_pad;
   /* @brief Pad number for SDA */
   uint8_t              sda_pad;
+  /* @brief Whether to use the internal pull-up for SCL */
+  bool                 scl_pullup;
+  /* @brief Whether to use the internal pull-up for SDA */
+  bool                 sda_pullup;
 
 } I2CConfig;
 

--- a/os/hal/ports/NRF5/LLD/TWIv1/hal_i2c_lld.c
+++ b/os/hal/ports/NRF5/LLD/TWIv1/hal_i2c_lld.c
@@ -38,17 +38,17 @@
 #define I2C_INPUT(p)  do { IOPORT1->DIRCLR = (1UL << (p)); } while(0)   /*!< Configures I2C pin as input  */
 #define I2C_OUTPUT(p) do { IOPORT1->DIRSET = (1UL << (p)); } while(0)   /*!< Configures I2C pin as output */
 
-#define I2C_PIN_CNF \
+#define I2C_PIN_CNF(internal_pullup) \
       ((GPIO_PIN_CNF_SENSE_Disabled  << GPIO_PIN_CNF_SENSE_Pos) \
       | (GPIO_PIN_CNF_DRIVE_S0D1     << GPIO_PIN_CNF_DRIVE_Pos) \
-      | (GPIO_PIN_CNF_PULL_Disabled  << GPIO_PIN_CNF_PULL_Pos)  \
+      | (((internal_pullup) ? GPIO_PIN_CNF_PULL_Pullup : GPIO_PIN_CNF_PULL_Disabled)  << GPIO_PIN_CNF_PULL_Pos)  \
       | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) \
       | (GPIO_PIN_CNF_DIR_Input      << GPIO_PIN_CNF_DIR_Pos))
 
-#define I2C_PIN_CNF_CLR \
+#define I2C_PIN_CNF_CLR(internal_pullup) \
       ((GPIO_PIN_CNF_SENSE_Disabled  << GPIO_PIN_CNF_SENSE_Pos) \
       | (GPIO_PIN_CNF_DRIVE_S0D1     << GPIO_PIN_CNF_DRIVE_Pos) \
-      | (GPIO_PIN_CNF_PULL_Disabled  << GPIO_PIN_CNF_PULL_Pos)  \
+      | (((internal_pullup) ? GPIO_PIN_CNF_PULL_Pullup : GPIO_PIN_CNF_PULL_Disabled)  << GPIO_PIN_CNF_PULL_Pos)  \
       | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) \
       | (GPIO_PIN_CNF_DIR_Output     << GPIO_PIN_CNF_DIR_Pos))
 
@@ -102,14 +102,14 @@ static void i2c_clear_bus(I2CDriver *i2cp)
   const I2CConfig *cfg = i2cp->config;
   int i;
 
-  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF;
-  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF;
+  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF(cfg->scl_pullup);
+  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF(cfg->sda_pullup);
 
   I2C_HIGH(cfg->sda_pad);
   I2C_HIGH(cfg->scl_pad);
 
-  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR;
-  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR;
+  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR(cfg->scl_pullup);
+  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR(cfg->sda_pullup);
 
   nrf_delay_us(4);
 
@@ -290,8 +290,8 @@ void i2c_lld_start(I2CDriver *i2cp) {
 
   i2c_clear_bus(i2cp);
 
-  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF;
-  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF;
+  IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF(cfg->scl_pullup);
+  IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF(cfg->sda_pullup);
 
   i2c->EVENTS_RXDREADY = 0;
   i2c->EVENTS_TXDSENT = 0;
@@ -351,8 +351,8 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 
     nvicDisableVector(I2C_IRQ_NUM);
 
-    IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR;
-    IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR;
+    IOPORT1->PIN_CNF[cfg->scl_pad] = I2C_PIN_CNF_CLR(cfg->scl_pullup);
+    IOPORT1->PIN_CNF[cfg->sda_pad] = I2C_PIN_CNF_CLR(cfg->sda_pullup);
   }
 }
 

--- a/os/hal/ports/NRF5/LLD/TWIv1/hal_i2c_lld.h
+++ b/os/hal/ports/NRF5/LLD/TWIv1/hal_i2c_lld.h
@@ -121,6 +121,10 @@ typedef struct {
   uint8_t              scl_pad;
   /* @brief Pad number for SDA */
   uint8_t              sda_pad;
+  /* @brief Whether to use the internal pull-up for SCL */
+  bool                 scl_pullup;
+  /* @brief Whether to use the internal pull-up for SDA */
+  bool                 sda_pullup;
 
 } I2CConfig;
 


### PR DESCRIPTION
Hello, I'm developing on a NRF52832-based board (DecaWave DWM1001) that has no external pull-up resistors on the I2C lines.

This patch adds two boolean I2C configuration options to optionally enable the MCU's internal pull-ups.

I've tested the patch on NRF52 only (TWIMv1) and it works for me. The NRF51 driver (TWIv1) looked very similar and I mirrored the changes there too, but I don't have a board to test it.
