### PR TITLE
NRF: Make the SPI driver compile on NRF52 too

### DIFF
--- a/os/hal/ports/NRF5/LLD/SPIv1/hal_spi_lld.c
+++ b/os/hal/ports/NRF5/LLD/SPIv1/hal_spi_lld.c
@@ -26,6 +26,11 @@
 
 #if HAL_USE_SPI || defined(__DOXYGEN__)
 
+#if NRF_SERIES == 52
+#define SPI0_TWI0_IRQn SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn
+#define SPI1_TWI1_IRQn SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn
+#endif
+
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/


### PR DESCRIPTION
Hello, the attached patch makes it possible to actually compile the SPI driver for NRF52832.

The driver was probably only developed for NRF51, where the IRQ is simply called `SPI0_TWI0_IRQn`. On NRF52, the same IRQ is called `SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn`, therefore the current code doesn't compile, complaining that `SPI0_TWI0_IRQn` is not defined.

The attached patch defines `SPI0_TWI0_IRQn` as an alias for `SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn` if we are compiling for NRF52. This is the same approach already adopted for the UART driver.

I have tested the resulting driver on a real board, and it works flawlessly.