### PR TITLE
FIX PID demo after ChibiOS ADC callback rework

### DIFF
--- a/demos/STM32/RT-STM32F303-DISCOVERY-PID/main.c
+++ b/demos/STM32/RT-STM32F303-DISCOVERY-PID/main.c
@@ -30,17 +30,16 @@ static adcsample_t samples[ADC_GRP1_NUM_CHANNELS * ADC_GRP1_BUF_DEPTH];
 /*
  * ADC streaming callback.
  */
-static void adccallback(ADCDriver *adcp, adcsample_t *buffer, size_t n) {
+static void adccallback(ADCDriver *adcp) {
 
   (void)adcp;
-  (void)n;
   uint32_t i, tmp = 0;
-  if (samples == buffer) {
+  if (adcIsBufferComplete(adcp)) {
 
-    for (i = 0; i < n; i++) {
-        tmp += buffer[i];
+    for (i = 0; i < (adcp)->depth; i++) {
+        tmp += (adcp)->samples[i];
     }
-    input = tmp / n;
+    input = tmp / (adcp)->depth;
     
     if (input <= target) {
         palClearLine(LINE_LED7_GREEN);


### PR DESCRIPTION
https://github.com/ChibiOS/ChibiOS/commit/f20ecc78178fc8cdfa682e100398c240224dbb4a#diff-e42edbbb9a343d9d1b70e68f524cbc22

I see that there is a Jenkinsfile that should catch this kind of API breakage but here it was only a warning:

> Compiling main.c                                                                                                                                                                   
main.c:64:3: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   adccallback,
   ^~~~~~~~~~~
main.c:64:3: note: (near initialization for 'adcgrpcfg1.end_cb')

Is the Jenkins running those tests publicly available?