### PR TITLE
Fixed nested osalSysLock() due to osalThreadSleepMilliseconds()

### DIFF
--- a/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc_sdram.c
+++ b/os/hal/ports/STM32/LLD/FSMCv1/hal_fsmc_sdram.c
@@ -106,7 +106,7 @@ static void _sdram_init_sequence(const SDRAMConfig *cfgp) {
   SDRAMD.sdram->SDCMR = FMCCM_CLK_ENABLED | command_target;
 
   /* Step 4: Insert delay (tipically 100uS).*/
-  osalThreadSleepMilliseconds(1);
+  osalSysPolledDelayX(TIME_US2I(100))
 
   /* Step 5: Configure a PALL (precharge all) command.*/
   _sdram_wait_ready();


### PR DESCRIPTION
This previously lead to SV4 panic at runtime. Tested to be working on STM32F746 (@200 MHz).