### PR TITLE
Added comment that might help others to prevent cache coherence issues.

### DIFF
--- a/os/hal/include/hal_ee24xx.h
+++ b/os/hal/include/hal_ee24xx.h
@@ -28,6 +28,8 @@ typedef struct {
   i2caddr_t     addr;
   /**
    * Pointer to write buffer. The safest size is (pagesize + 2)
+   * Declare with CC_SECTION(".nocache") ... if using I2C with DMA to avoid
+   * cache coherence issues.
    */
   uint8_t       *write_buf;
 } I2CEepromFileConfig;


### PR DESCRIPTION
Knowing this may save time on debugging.

However, as the (default) .nocache section is rather small, a better solution would be to include cache flushing / invalidation into the read and write functions.

See: http://www.chibios.org/dokuwiki/doku.php?id=chibios:articles:cache_coherence