### PR TITLE
NUC123 change USBEndpointConfig

### DIFF
--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
@@ -100,6 +100,11 @@ static union {
 } ep0_state;
 
 /**
+* @brief   Buffer for the EP0 setup packets.
+*/
+static uint8_t ep0setup_buffer[8];
+
+/**
  * @brief   EP0 initialization structure.
  */
 static const USBEndpointConfig ep0config = {USB_EP_MODE_TYPE_CTRL,
@@ -109,7 +114,9 @@ static const USBEndpointConfig ep0config = {USB_EP_MODE_TYPE_CTRL,
                                             0x40,
                                             0x40,
                                             &ep0_state.in,
-                                            &ep0_state.out};
+                                            &ep0_state.out,
+                                            1,
+                                            ep0setup_buffer};
 
 /**
  * @brief   Tracks the first unallocated word in the SRAM buffer

--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.h
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.h
@@ -211,6 +211,17 @@ typedef struct {
   USBOutEndpointState *out_state;
   /* End of the mandatory fields.*/
 
+  /**
+   * @brief   Reserved field, not currently used.
+   * @note    Initialize this field to 1 in order to be forward compatible.
+   */
+  uint16_t                      ep_buffers;
+  /**
+   * @brief   Pointer to a buffer for setup packets, not currently used.
+   * @details Setup packets require a dedicated 8-bytes buffer, set this
+   *          field to @p NULL for non-control endpoints.
+   */
+  uint8_t                       *setup_buf;
 } USBEndpointConfig;
 
 /**

--- a/testhal/NUMICRO/NUC123/NUTINY-SDK-NUC123-V2.0/USB_HID/Makefile
+++ b/testhal/NUMICRO/NUC123/NUTINY-SDK-NUC123-V2.0/USB_HID/Makefile
@@ -88,7 +88,7 @@ PROJECT = ch
 MCU  = cortex-m0
 
 # Imported source files and paths.
-BASE_PATH       := /Users/lewontin/Documents/development/Projects
+BASE_PATH       := ../../../../../../..
 CHIBIOS         := $(BASE_PATH)/ChibiOS/ChibiOS
 CHIBIOS_CONTRIB := $(BASE_PATH)/ChibiOS/ChibiOS-Contrib
 CONFDIR         := ./cfg

--- a/testhal/NUMICRO/NUC123/NUTINY-SDK-NUC123-V2.0/USB_HID/usbcfg.c
+++ b/testhal/NUMICRO/NUC123/NUTINY-SDK-NUC123-V2.0/USB_HID/usbcfg.c
@@ -276,7 +276,9 @@ static const USBEndpointConfig ep1config = {
   0x0040,
   0x0040,
   &ep1instate,
-  &ep1outstate
+  &ep1outstate,
+  0,
+  NULL
 };
 
 /*


### PR DESCRIPTION
USBEndpointConfig should have the same list of arguments as every other USB driver to allow downstream apps to use the same initializer