### PR TITLE
NUC123 USB driver: bug fix

### DIFF
--- a/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
@@ -148,9 +148,9 @@ unaligned:
   str     r5, [r4, #16]
 
 unaligned_loop_top:
+  subs    r2, r2, #1
   ldrb    r5, [r1, r2]
   strb    r5, [r0, r2]
-  subs    r2, r2, #1
 unaligned_loop_check:
   bne.n   unaligned_loop_top
 


### PR DESCRIPTION
This PR addresses a problem @fishman reported in the updated USB driver: in situations where memory was being copied between the USB SRAM buffer and general memory, and one block was word aligned, and one block is not, there was an off-by-one error in the index used for copying.