### PR TITLE
[NUC123] USB driver bug fixes

### DIFF
--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
@@ -54,7 +54,7 @@
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
 
-#define NUC123_USB_HW_ENDPOINTS 8
+#define NUC123_USB_HW_ENDPOINTS 6
 
 #define NUC123_USBD_CFG_OUT (1UL << USBD_CFG_STATE_Pos)
 #define NUC123_USBD_CFG_IN  (2UL << USBD_CFG_STATE_Pos)
@@ -352,10 +352,12 @@ static void usb_lld_serve_interrupt(USBDriver* usbp)
 
     if (intsts & USBD_INTSTS_EPEVT5_Msk) {
       /* Clear event flag */
-      USBD->INTSTS = (USBD_INTSTS_EPEVT5_Msk);
+      /* TODO: when the EP5/6 confusion bug is resolved, remove the EP6 mask here */
+      USBD->INTSTS = (USBD_INTSTS_EPEVT5_Msk | USBD_INTSTS_EPEVT6_Msk);
       usb_serve_in_endpoint(2);
     }
 
+#if 0
     if (intsts & USBD_INTSTS_EPEVT6_Msk) {
       /* Clear event flag */
       USBD->INTSTS = (USBD_INTSTS_EPEVT6_Msk);
@@ -367,6 +369,7 @@ static void usb_lld_serve_interrupt(USBDriver* usbp)
       USBD->INTSTS = (USBD_INTSTS_EPEVT7_Msk);
       usb_serve_in_endpoint(3);
     }
+#endif
   }
 }
 

--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
@@ -423,6 +423,7 @@ void usb_lld_init(void)
  */
 void usb_lld_start(USBDriver* usbp)
 {
+  uint32_t delay;
 
   if (usbp->state == USB_STOP) {
     /* Enables the peripheral.*/
@@ -437,6 +438,8 @@ void usb_lld_start(USBDriver* usbp)
   /* Reset procedure enforced on driver start.*/
 
   SYS->IPRSTC2 |= SYS_IPRSTC2_USBD_RST_Msk;
+  for (delay = 0; delay < 0x800; ++delay)
+    ;
   SYS->IPRSTC2 &= ~(SYS_IPRSTC2_USBD_RST_Msk);
 
   /* Post reset initialization.*/
@@ -455,6 +458,8 @@ void usb_lld_start(USBDriver* usbp)
 
   nvicEnableVector(USBD_IRQn, NUC123_USB_IRQ_PRIORITY);
 
+  for (delay = 0; delay < 0x800; ++delay)
+    ;
   usb_lld_reset(usbp);
 }
 

--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
@@ -313,8 +313,8 @@ static void usb_lld_serve_interrupt(USBDriver* usbp)
       HW_IN_EP(0)->CFGP |= USBD_CFGP_CLRRDY_Msk;
       HW_OUT_EP(0)->CFGP |= USBD_CFGP_CLRRDY_Msk;
 
-      _usb_isr_invoke_setup_cb(&USBD1, 0);
       HW_IN_EP(0)->CFG |= USBD_CFG_DSQ_SYNC_Msk;
+      _usb_isr_invoke_setup_cb(&USBD1, 0);
     }
 
     /* EP events */

--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
@@ -300,7 +300,7 @@ static void usb_lld_serve_interrupt(USBDriver* usbp)
     if (bussts & USBD_ATTR_RESUME_Msk) {
       /* Enable USB and enable PHY */
       USBD->ATTR |= (USBD_ATTR_PHY_EN_Msk | USBD_ATTR_USB_EN_Msk);
-
+      _usb_wakeup(usbp);
     }
   }
 

--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.h
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.h
@@ -35,7 +35,7 @@
  * @brief   Maximum endpoint address.
  * @details This value does not include the endpoint 0 which is always present.
 */
-#define USB_MAX_ENDPOINTS 3
+#define USB_MAX_ENDPOINTS 2
 
 /**
  * @brief   Status stage handling method.

--- a/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
@@ -142,9 +142,9 @@ offset_loop:
 unaligned:
   ldr     r4, =0x40060000
   ldr     r5, [r4, #16]
-  movs    r3, #128 
-  lsls    r3, r3, #3 /* USBD_ATTR_BYTEM_Msk */
-  orrs    r5, r3
+  movs    r7, #128 
+  lsls    r7, r7, #3 /* USBD_ATTR_BYTEM_Msk */
+  orrs    r5, r7
   str     r5, [r4, #16]
 
 unaligned_loop_top:


### PR DESCRIPTION
@fishman without knowing the exact configuration you're using to build QMK it's hard to say anything for certain, but here are a couple of things I've fixed that may help.

1. For the moment, I've removed all support for HW endpoints 6 & 7. Endpoint 6 suffers from a known hardware error where in certain configurations it will incorrectly mirror the behavior of endpoint 5. More can be found in the [errata from Nuvoton](http://nuvoton.com/export/resource-files/ER_6000_NUC123AN_EN_Rev.1.04.pdf). The long term solution here is to make the HW endpoint allocation more sophisticated, so that a working configuration is used, but short term, this is safer than leaving it enabled. This was causing a hard fault for me in my QMK build, so this seems like the most likely candidate.
~~2. I reverted the wake-up/suspend/resume handling to the way the driver handled it previously. My QMK build was (and continues to) having some issues where it was getting stuck asleep. I don't think this is a USB issue, and This more likely has something to do with the dummy matrix scan function I injected not waking the board properly, but on the off chance it might help you, I've changed this back.~~
~~3. I changed the order of handling bus events & endpoint events. There were situations where the ISR was too slow, which would cause some zero-length packets to get handled out of order, which messes with the EP0 state machine. This probably needs some continued attention, but this tweak might help in the mean time. This problem for me has been very intermittent, however, and so if your computer is categorically not recognizing the keyboard then I would guess this is not what your problem is.~~

If ~~one of these~~ this works, we'll get it committed here. If not, I'll probably need to see your full QMK config files to really be of any additional help.

EDIT: Either 2 or 3 caused something to break. I'm pretty sure those weren't your problem though