### PR TITLE
Expansion to nand flash driver

### DIFF
--- a/os/hal/include/hal_fsmc.h
+++ b/os/hal/include/hal_fsmc.h
@@ -38,6 +38,8 @@
  */
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+     defined(STM32F722xx) || defined(STM32F723xx) || \
+     defined(STM32F732xx) || defined(STM32F733xx) || \
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \
@@ -321,7 +323,7 @@ struct FSMCDriver {
   #if STM32_NAND_USE_NAND1
   FSMC_NAND_TypeDef         *nand1;
   #endif
-  #if STM32_NAND_USE_NAND1
+  #if STM32_NAND_USE_NAND2
   FSMC_NAND_TypeDef         *nand2;
   #endif
 #endif

--- a/os/hal/include/hal_nand.h
+++ b/os/hal/include/hal_nand.h
@@ -108,22 +108,34 @@ extern "C" {
   void nandObjectInit(NANDDriver *nandp);
   void nandStart(NANDDriver *nandp, const NANDConfig *config, bitmap_t *bb_map);
   void nandStop(NANDDriver *nandp);
-  uint8_t nandErase(NANDDriver *nandp, uint32_t block);
-  void nandReadPageWhole(NANDDriver *nandp, uint32_t block, uint32_t page,
+  uint8_t nandErase(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                    uint32_t plane, uint32_t block);
+  void nandReadPageWhole(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                         uint32_t plane, uint32_t block, uint32_t page,
                          void *data, size_t datalen);
-  void nandReadPageData(NANDDriver *nandp, uint32_t block, uint32_t page,
+  void nandReadPageData(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                        uint32_t plane, uint32_t block, uint32_t page,
                         void *data, size_t datalen, uint32_t *ecc);
-  void nandReadPageSpare(NANDDriver *nandp, uint32_t block, uint32_t page,
+  void nandReadPageSpare(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                         uint32_t plane, uint32_t block, uint32_t page,
                          void *spare, size_t sparelen);
-  uint8_t nandWritePageWhole(NANDDriver *nandp, uint32_t block, uint32_t page,
+  uint8_t nandWritePageWhole(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                             uint32_t plane, uint32_t block, uint32_t page,
                              const void *data, size_t datalen);
-  uint8_t nandWritePageData(NANDDriver *nandp, uint32_t block, uint32_t page,
+  uint8_t nandWritePageData(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                            uint32_t plane, uint32_t block, uint32_t page,
                             const void *data, size_t datalen, uint32_t *ecc);
-  uint8_t nandWritePageSpare(NANDDriver *nandp, uint32_t block, uint32_t page,
+  uint8_t nandWritePageSpare(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                             uint32_t plane, uint32_t block, uint32_t page,
                              const void *spare, size_t sparelen);
-  uint16_t nandReadBadMark(NANDDriver *nandp, uint32_t block, uint32_t page);
-  void nandMarkBad(NANDDriver *nandp, uint32_t block);
-  bool nandIsBad(NANDDriver *nandp, uint32_t block);
+  uint16_t nandReadBadMark(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                           uint32_t plane, uint32_t block, uint32_t page);
+  void nandMarkBad(NANDDriver *nandp, uint32_t die, uint32_t logun, 
+                   uint32_t plane, uint32_t block);
+  bool nandIsBad(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                 uint32_t plane, uint32_t block, uint32_t page);
+  bool readIsBlockBad(NANDDriver *nandp, uint32_t die, uint32_t logun,
+                         uint32_t plane, size_t block);
 #if NAND_USE_MUTUAL_EXCLUSION
   void nandAcquireBus(NANDDriver *nandp);
   void nandReleaseBus(NANDDriver *nandp);

--- a/os/hal/ports/STM32/LLD/FSMCv1/hal_nand_lld.h
+++ b/os/hal/ports/STM32/LLD/FSMCv1/hal_nand_lld.h
@@ -140,6 +140,18 @@ typedef void (*nandisrhandler_t)(NANDDriver *nandp);
  */
 typedef struct {
   /**
+   * @brief   Number of dies in NAND device.
+   */
+  uint32_t                  dies;
+  /**
+   * @brief   Number of logical units in NAND device.
+   */
+  uint32_t                  loguns;
+  /**
+   * @brief   Number of planes in NAND device.
+   */
+  uint32_t                  planes;
+  /**
    * @brief   Number of erase blocks in NAND device.
    */
   uint32_t                  blocks;
@@ -232,15 +244,15 @@ struct NANDDriver {
   /**
    * @brief     Memory mapping for data.
    */
-  uint16_t                  *map_data;
+  uint8_t                  *map_data;
   /**
    * @brief     Memory mapping for commands.
    */
-  uint16_t                  *map_cmd;
+  uint8_t                  *map_cmd;
   /**
    * @brief     Memory mapping for addresses.
    */
-  uint16_t                  *map_addr;
+  uint8_t                  *map_addr;
   /**
    * @brief   Pointer to bad block map.
    * @details One bit per block. All memory allocation is user's responsibility.
@@ -279,6 +291,7 @@ extern "C" {
                 size_t datalen, uint8_t *addr, size_t addrlen, uint32_t *ecc);
   uint8_t nand_lld_read_status(NANDDriver *nandp);
   void nand_lld_reset(NANDDriver *nandp);
+  uint32_t nand_lld_read_id(NANDDriver *nandp);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This expansion helps support higher density devices which have multiple
dies, logical units and planes on top of the standard block and page
structures of standard nand flash ICs.

- Included stm32f723xx targets
- Bug fix (STM32_NAND_USE_NAND1)
- changed map_cmd and map_addr to 8 bits in struct NANDDriver
- Bug fix (dmaStreamAlloc returns dma_stream_t)
- DSB assembly instruction added for fixing issues with M7 processor
- added nand_lld_read_id() function