### PR TITLE
Add STM32G4xx platform

### DIFF
--- a/os/hal/ports/STM32/STM32G4xx/platform.mk
+++ b/os/hal/ports/STM32/STM32G4xx/platform.mk
@@ -1,0 +1,23 @@
+include ${CHIBIOS}/os/hal/ports/STM32/STM32G4xx/platform.mk
+
+ifeq ($(USE_SMART_BUILD),yes)
+
+# Configuration files directory
+ifeq ($(CONFDIR),)
+  CONFDIR = .
+endif
+
+HALCONF := $(strip $(shell cat $(CONFDIR)/halconf.h $(CONFDIR)/halconf_community.h | egrep -e "\#define"))
+
+else
+endif
+
+include ${CHIBIOS_CONTRIB}/os/hal/ports/STM32/LLD/CRCv1/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/STM32/LLD/FSMCv1/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/STM32/LLD/TIMv1/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/STM32/LLD/COMPv1/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/STM32/LLD/OPAMPv1/driver.mk
+
+# Shared variables
+ALLCSRC += $(PLATFORMSRC_CONTRIB)
+ALLINC  += $(PLATFORMINC_CONTRIB)


### PR DESCRIPTION
I need this platform to develop on nucleo G431. I based the makefile on STM32F3xx and added the FSMC driver since the G4 mcus have the peripheral