### PR TITLE
don't deref null pointer on MSD LUN request

### DIFF
--- a/os/hal/src/hal_usb_msd.c
+++ b/os/hal/src/hal_usb_msd.c
@@ -284,7 +284,8 @@ bool msd_request_hook(USBDriver *usbp) {
   } else if (usbp->setup[0] == (USB_RTYPE_TYPE_CLASS | USB_RTYPE_RECIPIENT_INTERFACE | USB_RTYPE_DIR_DEV2HOST)
     && usbp->setup[1] == MSD_REQ_GET_MAX_LUN) {
     /* Return the maximum supported LUN. */
-    usbSetupTransfer(usbp, 0, 1, NULL);
+    static uint8_t zero = 0;
+    usbSetupTransfer(usbp, &zero, 1, NULL);
     return true;
     /* OR */
     /* Return false to stall to indicate that we don't support LUN */


### PR DESCRIPTION
Calling `usbSetupTransfer(usbp, 0, 1, NULL);` will deference a null pointer.  On an STM32 this silently actually works because `0x00000000` is a valid address to read - it reads the very bottom of flash or RAM, but it might not contain the `0` we want to transmit!