### PR TITLE
Allow configuration of MSD thread

### DIFF
--- a/os/hal/include/hal_usb_msd.h
+++ b/os/hal/include/hal_usb_msd.h
@@ -39,6 +39,20 @@
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
 
+/**
+ * @brief Set the size of the USB MSD thread's stack working area
+ */
+#if !defined(USB_MSD_THREAD_WA_SIZE) || defined(__DOXYGEN__)
+#define USB_MSD_THREAD_WA_SIZE          256
+#endif
+
+/**
+ * @brief Set the priority of the USB MSD thread.  Defaults to NORMALPRIO.
+ */
+#if !defined(MSD_THD_PRIO) || defined(__DOXYGEN__)
+#define MSD_THD_PRIO                    NORMALPRIO
+#endif
+
 /*===========================================================================*/
 /* Derived constants and error checks.                                       */
 /*===========================================================================*/
@@ -132,7 +146,7 @@ struct USBMassStorageDriver {
   /**
    * @brief   Thread working area.
    */
-  THD_WORKING_AREA(             waMSDWorker, 512);
+  THD_WORKING_AREA(             waMSDWorker, USB_MSD_THREAD_WA_SIZE);
   /**
    * @brief   Worker thread handler.
    */

--- a/os/hal/src/hal_usb_msd.c
+++ b/os/hal/src/hal_usb_msd.c
@@ -38,8 +38,6 @@
 #define MSD_CBW_SIGNATURE               0x43425355
 #define MSD_CSW_SIGNATURE               0x53425355
 
-#define MSD_THD_PRIO                    NORMALPRIO
-
 #define CBW_FLAGS_RESERVED_MASK         0b01111111
 #define CBW_LUN_RESERVED_MASK           0b11110000
 #define CBW_CMD_LEN_RESERVED_MASK       0b11000000


### PR DESCRIPTION
- Set MSD thread priority
- Set MSD thread stack size.  Some block devices (this one: https://github.com/rusefi/rusefi/pull/2420/files#diff-03042e564d3ce600e21979e4123bd93657ffdb926554e51e0deed52140518b94) might need more memory than the default 256 bytes.