### PR TITLE
[RISC-V ECLIC] Illegal instruction exception on MSTATUS access

### DIFF
--- a/os/common/ports/RISCV-ECLIC/chcore.h
+++ b/os/common/ports/RISCV-ECLIC/chcore.h
@@ -377,9 +377,7 @@ static inline void port_init(void) {}
  * @return              The interrupts status.
  */
 static inline syssts_t port_get_irq_status(void) {
-  syssts_t mstatus = __RV_CSR_READ(CSR_MSTATUS);
-  __RWMB();
-  return mstatus;
+  return (syssts_t)__RV_CSR_READ(CSR_MSTATUS);
 }
 
 /**
@@ -401,9 +399,7 @@ static inline bool port_irq_enabled(syssts_t sts) { return sts & MSTATUS_MIE; }
  * @retval true         running in ISR mode.
  */
 static inline bool port_is_isr_context(void) {
-  bool is_irq_context = (__RV_CSR_READ(CSR_MSUBM) & MSUBM_TYP) != 0;
-  __RWMB();
-  return is_irq_context;
+  return __RV_CSR_READ(CSR_MSUBM) & MSUBM_TYP;
 }
 
 /**
@@ -411,22 +407,14 @@ static inline bool port_is_isr_context(void) {
  * @details Usually this function just disables interrupts but may perform more
  *          actions.
  */
-static inline void port_lock(void) {
-  __disable_irq(); 
-  __RWMB();
-  __FENCE_I();
-}
+static inline void port_lock(void) { __disable_irq(); }
 
 /**
  * @brief   Kernel-unlock action.
  * @details Usually this function just enables interrupts but may perform more
  *          actions.
  */
-static inline void port_unlock(void) {
-  __enable_irq();
-  __RWMB();
-  __FENCE_I();
-}
+static inline void port_unlock(void) { __enable_irq(); }
 
 /**
  * @brief   Kernel-lock action from an interrupt handler.
@@ -448,18 +436,18 @@ static inline void port_unlock_from_isr(void) { port_unlock(); }
  * @brief   Disables all the interrupt sources.
  * @note    Of course non-maskable interrupt sources are not included.
  */
-static inline void port_disable(void) { port_lock(); }
+static inline void port_disable(void) { __disable_irq(); }
 
 /**
  * @brief   Disables the interrupt sources below kernel-level priority.
  * @note    Interrupt sources above kernel level remains enabled.
  */
-static inline void port_suspend(void) { port_lock(); }
+static inline void port_suspend(void) { __disable_irq(); }
 
 /**
  * @brief   Enables all the interrupt sources.
  */
-static inline void port_enable(void) { port_unlock(); }
+static inline void port_enable(void) { __enable_irq(); }
 
 /**
  * @details The function is meant to return when an interrupt becomes pending.

--- a/os/common/ports/RISCV-ECLIC/compilers/GCC/chcoreasm.S
+++ b/os/common/ports/RISCV-ECLIC/compilers/GCC/chcoreasm.S
@@ -56,34 +56,26 @@
 
 # Disable Interrupts globally.
 .macro DISABLE_MIE
-    csrc  CSR_MSTATUS, MSTATUS_MIE
-    fence iorw, iorw
-    fence.i
+    csrc CSR_MSTATUS, MSTATUS_MIE
 .endm
 
 # Enable Interrupts globally.
 .macro ENABLE_MIE
-    csrs  CSR_MSTATUS, MSTATUS_MIE
-    fence iorw, iorw
-    fence.i
+    csrs CSR_MSTATUS, MSTATUS_MIE
 .endm
 
 # Clear previous machine interrupt enable bit in mstatus (mstatus.mpie).
 # On machine return (mret) mstatus.mie is assigned this value.
 # Clearing this bit disables interrupts when leaving interrupt processing mode.
 .macro DISABLE_MPIE
-    li    a0, MSTATUS_MPIE
-    csrc  CSR_MSTATUS, a0
-    fence iorw, iorw
-    fence.i
+    li a0, MSTATUS_MPIE
+    csrc CSR_MSTATUS, a0
 .endm
 
 # Set previous machine interrupt enable bit in mstatus (mstatus.mpie).
 .macro ENABLE_MPIE
-    li    a0, MSTATUS_MPIE
-    csrs  CSR_MSTATUS, a0
-    fence iorw, iorw
-    fence.i
+    li a0, MSTATUS_MPIE
+    csrs CSR_MSTATUS, a0
 .endm
 
 # --------------------------------------------------------------------------

--- a/os/common/ports/RISCV-ECLIC/compilers/GCC/chcoreasm.S
+++ b/os/common/ports/RISCV-ECLIC/compilers/GCC/chcoreasm.S
@@ -64,20 +64,6 @@
     csrs CSR_MSTATUS, MSTATUS_MIE
 .endm
 
-# Clear previous machine interrupt enable bit in mstatus (mstatus.mpie).
-# On machine return (mret) mstatus.mie is assigned this value.
-# Clearing this bit disables interrupts when leaving interrupt processing mode.
-.macro DISABLE_MPIE
-    li a0, MSTATUS_MPIE
-    csrc CSR_MSTATUS, a0
-.endm
-
-# Set previous machine interrupt enable bit in mstatus (mstatus.mpie).
-.macro ENABLE_MPIE
-    li a0, MSTATUS_MPIE
-    csrs CSR_MSTATUS, a0
-.endm
-
 # --------------------------------------------------------------------------
 # Interrupt context save macro. Saves all caller save registers
 # and status csr registers on the stack.
@@ -175,6 +161,31 @@
 .option pop
 
 # --------------------------------------------------------------------------
+# Start a thread by invoking its work function.
+# 
+# Threads execution starts here, the code leaves the system critical zone
+# and then jumps into the thread function passed in register S0. The
+# register S1 contains the thread parameter. The function chThdExit() is
+# called on thread function return.
+# --------------------------------------------------------------------------
+.globl  _port_thread_start
+_port_thread_start:
+#if CH_DBG_SYSTEM_STATE_CHECK
+    jal     ra, _dbg_check_unlock
+#endif
+#if CH_DBG_STATISTICS
+    jal     ra, _stats_stop_measure_crit_thd
+#endif
+    ENABLE_MIE
+    mv      a0, s1
+    jalr    ra, s0
+    li      a0, 0              # MSG_OK
+    jal     ra, chThdExit
+
+_zombies:
+       j       _zombies
+
+# --------------------------------------------------------------------------
 # Performs a context switch between two threads.
 # a0 = ntp, a1 = otp
 # --------------------------------------------------------------------------
@@ -234,31 +245,6 @@ _port_switch:
 .option pop
 
 # --------------------------------------------------------------------------
-# Start a thread by invoking its work function.
-# 
-# Threads execution starts here, the code leaves the system critical zone
-# and then jumps into the thread function passed in register S0. The
-# register S1 contains the thread parameter. The function chThdExit() is
-# called on thread function return.
-# --------------------------------------------------------------------------
-.globl  _port_thread_start
-_port_thread_start:
-#if CH_DBG_SYSTEM_STATE_CHECK
-    jal     ra, _dbg_check_unlock
-#endif
-#if CH_DBG_STATISTICS
-    jal     ra, _stats_stop_measure_crit_thd
-#endif
-    ENABLE_MIE
-    mv      a0, s1
-    jalr    ra, s0
-    li      a0, 0              # MSG_OK
-    jal     ra, chThdExit
-
-_zombies:
-       j       _zombies
-
-# --------------------------------------------------------------------------
 # IRQ entry point
 # --------------------------------------------------------------------------
 .section .text
@@ -285,8 +271,20 @@ _irq_handler:
     la      a0, _port_switch_from_isr
     csrw    mepc, a0
 
+    # Interrupt handling and context restoring is handled differently in nucleisys cores.
+    # mstatus.mpie and mstatus.mpp are mirror fields of mcause.mpie and mcause.mpp.
+    # Therefore we directly set the bits in mcause and not mstatus.
+    # See https://doc.nucleisys.com/nuclei_spec/isa/core_csr.html#mcause
+
     # Context switch is a critical section, so disable interrupts on return.
-    DISABLE_MPIE
+    # Clear mcause.mpie.
+    li a0, 0x8000000
+    csrc mcause, a0
+
+    # Set previous privelege mode to machine mode to enforce it on return.
+    # Set mcause.mpp to 0x3 (== machine mode).
+    li a0, 0x30000000
+    csrs mcause, a0
 
     mret
 
@@ -323,15 +321,12 @@ _port_switch_from_isr:
     jal     ra, _stats_stop_measure_crit_thd
 #endif
 
-    # Enable interrupts after leaving the interrupt handler
-    ENABLE_MPIE
-
 .globl _port_exit_from_isr
 _port_exit_from_isr:
     # Restore caller registers and csr registers from the thread stack
     RESTORE_CONTEXT
 
-    # Leave machine mode and return to address stored in mepc
+    # Leave interrupt handling and return to address stored in mepc.
     mret
 
 .option pop


### PR DESCRIPTION
The first attempt to solve illegal instruction exceptions was made in #274. It seemed as this "fixed" the issue, but merely added delays in the code which prevented the error to appear in lucky circumstances. Interesting that this code worked in the first place.
    
Root cause for the expection where write attempts to `mstatus` in user privilege mode which raised the illegal instruction exception which is in spec with the risc-v privileged isa and documented by [nucleisys](https://doc.nucleisys.com/nuclei_spec/isa/core_csr.html#accessibility-of-csrs-in-the-nuclei-processor-core). The solution is to never enter user mode by forcing `mcause.mpp` to 0x3 before calling `mret` when exiting the interrupt handler for context switching.