### PR TITLE
[GD32VF103] Rename missed AFIO registers and free B4 pin on Longan Nano

### DIFF
--- a/os/hal/boards/SIPEED_LONGAN_NANO/board.c
+++ b/os/hal/boards/SIPEED_LONGAN_NANO/board.c
@@ -44,4 +44,6 @@ void __early_init(void) {
  * Board-specific initialization code.
  */
 void boardInit(void) {
+    /* Free B4 pin by disabling JTAG NJTRST. */
+    AFIO->PCF0 |= AFIO_PCF0_SWJ_CFG_NOJNTRST;
 }

--- a/os/hal/ports/GD/GD32VF103/GPIO/hal_pal_lld.c
+++ b/os/hal/ports/GD/GD32VF103/GPIO/hal_pal_lld.c
@@ -215,7 +215,7 @@ void _pal_lld_enablepadevent(ioportid_t port,
   portidx = (((uint32_t)port - (uint32_t)GPIOA) >> 10U) & 0xFU;
 
   /* Port selection in SYSCFG.*/
-  AFIO->EXTICR[cridx] = (AFIO->EXTICR[cridx] & crmask) | (portidx << croff);
+  AFIO->EXTISS[cridx] = (AFIO->EXTISS[cridx] & crmask) | (portidx << croff);
 
   /* Programming edge registers.*/
   if (mode & PAL_EVENT_MODE_RISING_EDGE)
@@ -262,7 +262,7 @@ void _pal_lld_disablepadevent(ioportid_t port, iopadid_t pad) {
        0x400 intervals in memory space. So far this is true for all devices.*/
     portidx = (((uint32_t)port - (uint32_t)GPIOA) >> 10U) & 0xFU;
 
-    crport = (AFIO->EXTICR[cridx] >> croff) & 0xFU;
+    crport = (AFIO->EXTISS[cridx] >> croff) & 0xFU;
 
     osalDbgAssert(crport == portidx, "channel mapped on different port");
 

--- a/os/hal/ports/GD/GD32VF103/gd32vf103.h
+++ b/os/hal/ports/GD/GD32VF103/gd32vf103.h
@@ -327,11 +327,11 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t EVCR;
-  __IO uint32_t MAPR;
-  __IO uint32_t EXTICR[4];
+  __IO uint32_t EC;
+  __IO uint32_t PCF0;
+  __IO uint32_t EXTISS[4];
   uint32_t RESERVED0;
-  __IO uint32_t MAPR2;  
+  __IO uint32_t PCF1;  
 } AFIO_TypeDef;
 /** 
   * @brief Inter Integrated Circuit Interface


### PR DESCRIPTION
I forgot to rename the AFIO registers in the struct, this PR corrects that. 

Also the PIN B4 has the JTAG NJRST signal with a pull up enabled by default. On the longan Nano this PIN is broken out as a regular pin. So we just disable NJRST by default and make it available as a regular GPIO.