### PR TITLE
Don't include SW CRC if not requested

### DIFF
--- a/os/hal/include/hal_crc.h
+++ b/os/hal/include/hal_crc.h
@@ -72,9 +72,13 @@ typedef enum {
   CRC_COMPLETE               /* Asynchronous operation complete.           */
 } crcstate_t;
 
+#if STM32_CRC_USE_CRC1 == TRUE
 #include "hal_crc_lld.h"
-#include "crcsw.h" /* Include software LL driver */
+#endif
 
+#if CRCSW_USE_CRC1 == TRUE
+#include "crcsw.h" /* Include software LL driver */
+#endif
 
 /*===========================================================================*/
 /* Driver macros.                                                            */


### PR DESCRIPTION
I've got build failure when enable CRC module on STM32. The reason is SW CRC header is included by default  but not found by compiler if ChibiOS-Contrib/os/various/ is not included into search path.
The fix includes only requested LL header.