### PR TITLE
NUMICRO: Fix trivial but hard to find errors in USB LLD

### DIFF
--- a/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.c
@@ -210,7 +210,7 @@ static void usb_serve_out_endpoint(uint32_t epn)
 {
   USBDriver *const usbp = &USBD1;
   uint32_t mxpld = HW_OUT_EP(epn)->MXPLD;
-  uint32_t rxsize_actual = min(mxpld, usbp->epc[epn]->out_state->rxcnt - usbp->epc[epn]->out_state->rxsize);
+  uint32_t rxsize_actual = min(mxpld, usbp->epc[epn]->out_state->rxsize - usbp->epc[epn]->out_state->rxcnt);
 
   usb_memcpy(usbp->epc[epn]->out_state->rxbuf +
                  usbp->epc[epn]->out_state->rxcnt,

--- a/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
@@ -122,8 +122,8 @@ offset:
   str     r5, [r4, #16]
 
 offset_loop:
-  ldrb r6, [r0, #0]
-  strb r6, [r1, #0]
+  ldrb r6, [r1, #0]
+  strb r6, [r0, #0]
   adds r0, r0, #1
   adds r1, r1, #1
   subs r2, r2, #1

--- a/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
@@ -47,7 +47,7 @@ check_alignment:
   bne.n   unaligned
 
 aligned:
-/* r0: src, r1: dest, r2: num, r3: #3 */
+/* r0: dest, r1: src, r2: num, r3: #3 */
   movs    r4, r2
 
   bics    r4, r3
@@ -79,8 +79,8 @@ leftover_check:
   adds    r0, r0, r6
 
 /*
- * r0: src
- * r1: dest
+ * r0: dest
+ * r1: src
  * r2 is 1, 2, or 3 (# of bytes left)
  * r3: #3
  * r4: &USBD


### PR DESCRIPTION
Fix:
- possible buffer overrun in usb_serve_out_endpoint()
- corner case src-dst confusion in usb_memcpy()