### PR TITLE
ht32: fix GCC 11 misleading indentation error

### DIFF
--- a/os/hal/ports/HT32/HT32F523xx/hal_lld.c
+++ b/os/hal/ports/HT32/HT32F523xx/hal_lld.c
@@ -54,7 +54,8 @@ void ht32_clock_init(void) {
     // Enable backup domain. Needed for USB
     CKCU->LPCR = CKCU_LPCR_BKISO;
     CKCU->APBCCR1 |= CKCU_APBCCR1_BKPREN;
-    while (PWRCU->BAKTEST != 0x27);
+    while (PWRCU->BAKTEST != 0x27)
+        ;
 
 #if HT32_CKCU_SW == CKCU_GCCR_SW_HSE
     // Enable HSE


### PR DESCRIPTION
GCC 11 complains about misleading indentation, which in conjunction with ```-Wmisleading-indentation``` throws an error. Changing ```;``` to ```{}``` fixes that.
```
hal_lld.c:56:5: error: this 'while' clause does not guard... [-Werror=misleading-indentation]
56 |     while (PWRCU->BAKTEST != 0x27);
   |     ^~~~~
```