### PR TITLE
[GD32VF103] Correct linker scripts

### DIFF
--- a/os/common/startup/RISCV-ECLIC/compilers/GCC/crt0.S
+++ b/os/common/startup/RISCV-ECLIC/compilers/GCC/crt0.S
@@ -103,7 +103,7 @@
 
 #include "riscv_encoding.h"
 
-.text
+.section .crt0, "ax"
 .global _start
 .type _start, @function
 _start:

--- a/os/common/startup/RISCV-ECLIC/compilers/GCC/ld/rules_code.ld
+++ b/os/common/startup/RISCV-ECLIC/compilers/GCC/ld/rules_code.ld
@@ -20,6 +20,10 @@ SECTIONS
 {
     .vectors : ALIGN(4)
     {
+        KEEP (*(SORT_NONE(.crt0)))
+        /* For 65 to 128 interrupts, the vector table must be 512 byte aligned.
+         * See: https://doc.nucleisys.com/nuclei_spec/isa/core_csr.html#mtvt */
+        . = ALIGN(512);
         KEEP (*(SORT_NONE(.vectors)))
     } > VECTORS_FLASH AT > VECTORS_FLASH_LMA
 

--- a/os/common/startup/RISCV-ECLIC/compilers/GCC/vectors.S
+++ b/os/common/startup/RISCV-ECLIC/compilers/GCC/vectors.S
@@ -37,14 +37,11 @@
 /*===========================================================================*/
 
 #if !defined(__DOXYGEN__)
-.section vectors, "a", %progbits
+.section .vectors, "a", %progbits
 .globl vector_base
 .type vector_base, %object
 .option push
 .option norelax
-# For 65 to 128 interrupts, the base address must have 512 byte alignment. 
-# https://doc.nucleisys.com/nuclei_spec/isa/core_csr.html#mtvt
-.align 9
 vector_base:
     .word vector0
     .word vector1


### PR DESCRIPTION
The startup code that initializes the mcu is moved to be the first entry in the vectors section, so it will always be the first to run after a reset.

Because of a typo (vectors instead of .vectors) the vector table would have been there, but was relocated into the text section. So this setup compiled by sheer luck into a working executable that had the `_start` function at the flash base `0x8000000` up to this point.