### PR TITLE
RP2040: Add linker script for FLASH with boot2

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_FLASH.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_FLASH.ld
@@ -1,0 +1,117 @@
+/*
+    ChibiOS - Copyright (C) 2006..2021 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2040 memory setup.
+ */
+MEMORY
+{
+    flash0 (rx) : org = 0x00000000, len = 16k   /* ROM                  */
+    flash1 (rx) : org = 0x10000000, len = DEFINED(FLASH_LEN) ? FLASH_LEN : 2048k /* XIP */
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x20000000, len = 256k  /* SRAM0 striped        */
+    ram1   (wx) : org = 0x00000000, len = 256k  /* SRAM0 non striped    */
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x20040000, len = 4k    /* SRAM4                */
+    ram5   (wx) : org = 0x20041000, len = 4k    /* SRAM5                */
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x20041f00, len = 256   /* SRAM5 boot           */
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Flash region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", flash1);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash1);
+
+/* Flash region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", flash1);
+REGION_ALIAS("XTORS_FLASH_LMA", flash1);
+
+/* Flash region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", flash1);
+REGION_ALIAS("TEXT_FLASH_LMA", flash1);
+
+/* Flash region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", flash1);
+REGION_ALIAS("RODATA_FLASH_LMA", flash1);
+
+/* Flash region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", flash1);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash1);
+
+/* Flash region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash1);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("MAIN_STACK_RAM", ram4);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram4);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("C1_MAIN_STACK_RAM", ram5);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("C1_PROCESS_STACK_RAM", ram5);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash1);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+SECTIONS
+{
+   .flash_begin : {
+      __flash_binary_start = .;
+   } > flash1
+
+   .boot2 : {
+      __boot2_start__ = .;
+      KEEP (*(.boot2))
+      __boot2_end__ = .;
+   } > flash1
+}
+
+/* Generic rules inclusion.*/
+INCLUDE rules_stacks.ld
+INCLUDE rules_stacks_c1.ld
+INCLUDE RP2040_rules_code_with_boot2.ld
+INCLUDE rules_data.ld
+INCLUDE rules_memory.ld
+
+SECTIONS
+{
+   .flash_end : {
+      __flash_binary_end = .;
+   } > flash1
+}

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_rules_code_with_boot2.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_rules_code_with_boot2.ld
@@ -1,0 +1,80 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .vectors : ALIGN(256)
+    {
+        KEEP(*(.vectors))
+    } > VECTORS_FLASH AT > VECTORS_FLASH_LMA
+
+    .xtors : ALIGN(4)
+    {
+        __init_array_base__ = .;
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        __init_array_end__ = .;
+        __fini_array_base__ = .;
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        __fini_array_end__ = .;
+    } > XTORS_FLASH AT > XTORS_FLASH_LMA
+
+    .text : ALIGN_WITH_INPUT
+    {
+        __text_base__ = .;
+        *(.text)
+        *(.text.*)
+        *(.glue_7t)
+        *(.glue_7)
+        *(.gcc*)
+        __text_end__ = .;
+    } > TEXT_FLASH AT > TEXT_FLASH_LMA
+
+    .rodata : ALIGN(4)
+    {
+        __rodata_base__ = .;
+        *(.rodata)
+        *(.rodata.*)
+        . = ALIGN(4);
+        __rodata_end__ = .;
+    } > RODATA_FLASH AT > RODATA_FLASH_LMA
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .ARM.exidx : {
+        __exidx_base__ = .;
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end__ = .;
+        __exidx_end = .;
+     } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .eh_frame_hdr :
+    {
+        *(.eh_frame_hdr)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .eh_frame : ONLY_IF_RO
+    {
+        *(.eh_frame)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+}


### PR DESCRIPTION
Pico sdk has boot2 section to load vector at XIP + 256. Therefore vector section have to be placed at the specific location.
The linker script from ChibiOS specifies 1024 alignment in rules_code.ld script. We can not use this with boot2 loader.

The boot2 can be linked as follows in Makefile:
```
ULIBS = $(PICOSDKROOT)/build/src/rp2_common/boot_stage2/bs2_default_padded_checksummed.S
```

RP2040 does not have any internal flash. RPi pico has external 2M flash for code. But other variant has different size of flash.
If we can change length of the XIP section, flash1. For this purpose, FLASH_LEN variable is defined which can be specified in user's custom linker script.

```
/* custom.ld */
/* Specifies flash size. */
"FLASH_LEN" = 16M;

INCLUDE RP2040_FLASH.ld
```

In Makefile: 
```
STARTUPLD_CONTRIB = $(CHIBIOS_CONTRIB)/os/common/startup/ARMCMx/compilers/GCC/ld

LDSCRIPT = ./custom.ld

ULIBS += -L$(STARTUPLD_CONTRIB)
```
