### PR TITLE
[RISC-V] Update RISC-V ECLIC port for chibios-21.6.x

### DIFF
--- a/demos/GD32VF103/USB_CDC_IAD/cfg/chconf.h
+++ b/demos/GD32VF103/USB_CDC_IAD/cfg/chconf.h
@@ -1,5 +1,5 @@
 /*
-    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2006..2020 Giovanni Di Sirio
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,27 @@
 #define CHCONF_H
 
 #define _CHIBIOS_RT_CONF_
-#define _CHIBIOS_RT_CONF_VER_6_1_
+#define _CHIBIOS_RT_CONF_VER_7_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/** @} */
 
 /*===========================================================================*/
 /**
@@ -40,7 +60,7 @@
 
 /**
  * @brief   System time counter resolution.
- * @note    Allowed values are 16 or 32 bits.
+ * @note    Allowed values are 16, 32 or 64 bits.
  */
 #if !defined(CH_CFG_ST_RESOLUTION)
 #define CH_CFG_ST_RESOLUTION                16
@@ -158,6 +178,17 @@
  */
 #if !defined(CH_CFG_USE_TM)
 #define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time time stamps APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
 #endif
 
 /**
@@ -631,7 +662,7 @@
  * @details User fields added to the end of the @p ch_system_t structure.
  */
 #define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
-  /* Add threads custom fields here.*/
+  /* Add system custom fields here.*/
 
 /**
  * @brief   System initialization hook.
@@ -639,7 +670,23 @@
  *          just before interrupts are enabled globally.
  */
 #define CH_CFG_SYSTEM_INIT_HOOK() {                                         \
-  /* Add threads initialization code here.*/                                \
+  /* Add system initialization code here.*/                                 \
+}
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) {                                 \
+  /* Add OS instance initialization code here.*/                            \
 }
 
 /**
@@ -655,6 +702,8 @@
  *
  * @note    It is invoked from within @p _thread_init() and implicitly from all
  *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
  */
 #define CH_CFG_THREAD_INIT_HOOK(tp) {                                       \
   /* Add threads initialization code here.*/                                \
@@ -663,6 +712,8 @@
 /**
  * @brief   Threads finalization hook.
  * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
  */
 #define CH_CFG_THREAD_EXIT_HOOK(tp) {                                       \
   /* Add threads finalization code here.*/                                  \
@@ -671,6 +722,9 @@
 /**
  * @brief   Context switch hook.
  * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
  */
 #define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) {                              \
   /* Context switch code here.*/                                            \
@@ -743,6 +797,14 @@
  */
 #define CH_CFG_TRACE_HOOK(tep) {                                            \
   /* Trace code here.*/                                                     \
+}
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) {                                  \
+  /* Faults handling code here.*/                                           \
 }
 
 /** @} */

--- a/demos/GD32VF103/USB_CDC_IAD/cfg/halconf.h
+++ b/demos/GD32VF103/USB_CDC_IAD/cfg/halconf.h
@@ -1,5 +1,5 @@
 /*
-    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2006..2020 Giovanni Di Sirio
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -413,6 +413,26 @@
  */
 #if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
 #define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
 #endif
 
 /*===========================================================================*/

--- a/demos/GD32VF103/USB_CDC_IAD/cfg/halconf_community.h
+++ b/demos/GD32VF103/USB_CDC_IAD/cfg/halconf_community.h
@@ -1,0 +1,180 @@
+/*
+    ChibiOS - Copyright (C) 2014 Uladzimir Pylinsky aka barthess
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef HALCONF_COMMUNITY_H
+#define HALCONF_COMMUNITY_H
+
+/**
+ * @brief   Enables the community overlay.
+ */
+#if !defined(HAL_USE_COMMUNITY) || defined(__DOXYGEN__)
+#define HAL_USE_COMMUNITY           FALSE
+#endif
+
+/**
+ * @brief   Enables the FSMC subsystem.
+ */
+#if !defined(HAL_USE_FSMC) || defined(__DOXYGEN__)
+#define HAL_USE_FSMC                FALSE
+#endif
+
+/**
+ * @brief   Enables the NAND subsystem.
+ */
+#if !defined(HAL_USE_NAND) || defined(__DOXYGEN__)
+#define HAL_USE_NAND                FALSE
+#endif
+
+/**
+ * @brief   Enables the 1-wire subsystem.
+ */
+#if !defined(HAL_USE_ONEWIRE) || defined(__DOXYGEN__)
+#define HAL_USE_ONEWIRE             FALSE
+#endif
+
+/**
+ * @brief   Enables the EICU subsystem.
+ */
+#if !defined(HAL_USE_EICU) || defined(__DOXYGEN__)
+#define HAL_USE_EICU                FALSE
+#endif
+
+/**
+ * @brief   Enables the CRC subsystem.
+ */
+#if !defined(HAL_USE_CRC) || defined(__DOXYGEN__)
+#define HAL_USE_CRC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the RNG subsystem.
+ */
+#if !defined(HAL_USE_RNG) || defined(__DOXYGEN__)
+#define HAL_USE_RNG                 FALSE
+#endif
+
+/**
+ * @brief   Enables the EEPROM subsystem.
+ */
+#if !defined(HAL_USE_EEPROM) || defined(__DOXYGEN__)
+#define HAL_USE_EEPROM              FALSE
+#endif
+
+/**
+ * @brief   Enables the TIMCAP subsystem.
+ */
+#if !defined(HAL_USE_TIMCAP) || defined(__DOXYGEN__)
+#define HAL_USE_TIMCAP              FALSE
+#endif
+
+/**
+ * @brief   Enables the COMP subsystem.
+ */
+#if !defined(HAL_USE_COMP) || defined(__DOXYGEN__)
+#define HAL_USE_COMP                FALSE
+#endif
+
+/**
+ * @brief   Enables the OPAMP subsystem.
+ */
+#if !defined(HAL_USE_OPAMP) || defined(__DOXYGEN__)
+#define HAL_USE_OPAMP               FALSE
+#endif
+
+/**
+ * @brief   Enables the QEI subsystem.
+ */
+#if !defined(HAL_USE_QEI) || defined(__DOXYGEN__)
+#define HAL_USE_QEI                 FALSE
+#endif
+
+/**
+ * @brief   Enables the USBH subsystem.
+ */
+#if !defined(HAL_USE_USBH) || defined(__DOXYGEN__)
+#define HAL_USE_USBH                FALSE
+#endif
+
+/**
+ * @brief   Enables the USB_MSD subsystem.
+ */
+#if !defined(HAL_USE_USB_MSD) || defined(__DOXYGEN__)
+#define HAL_USE_USB_MSD             FALSE
+#endif
+
+/*===========================================================================*/
+/* FSMCNAND driver related settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the @p nandAcquireBus() and @p nanReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(NAND_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define NAND_USE_MUTUAL_EXCLUSION   TRUE
+#endif
+
+/*===========================================================================*/
+/* 1-wire driver related settings.                                           */
+/*===========================================================================*/
+/**
+ * @brief   Enables strong pull up feature.
+ * @note    Disabling this option saves both code and data space.
+ */
+#define ONEWIRE_USE_STRONG_PULLUP   FALSE
+
+/**
+ * @brief   Enables search ROM feature.
+ * @note    Disabling this option saves both code and data space.
+ */
+#define ONEWIRE_USE_SEARCH_ROM      TRUE
+
+/*===========================================================================*/
+/* QEI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables discard of overlow
+ */
+#if !defined(QEI_USE_OVERFLOW_DISCARD) || defined(__DOXYGEN__)
+#define QEI_USE_OVERFLOW_DISCARD    FALSE
+#endif
+
+/**
+ * @brief   Enables min max of overlow
+ */
+#if !defined(QEI_USE_OVERFLOW_MINMAX) || defined(__DOXYGEN__)
+#define QEI_USE_OVERFLOW_MINMAX     FALSE
+#endif
+
+/*===========================================================================*/
+/* EEProm driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables 24xx series I2C eeprom device driver.
+ * @note    Disabling this option saves both code and data space.
+ */
+#define EEPROM_USE_EE24XX FALSE
+ /**
+ * @brief   Enables 25xx series SPI eeprom device driver.
+ * @note    Disabling this option saves both code and data space.
+ */
+#define EEPROM_USE_EE25XX FALSE
+
+#endif /* HALCONF_COMMUNITY_H */
+
+/** @} */

--- a/demos/GD32VF103/USB_CDC_IAD/mcuconf.h
+++ b/demos/GD32VF103/USB_CDC_IAD/mcuconf.h
@@ -37,241 +37,255 @@
 
 /*
  * HAL driver system settings.
- */
-#define GD32_NO_INIT                       FALSE
-#define GD32_IRC8M_ENABLED                 TRUE
-#define GD32_IRC40K_ENABLED                FALSE
-#define GD32_HXTAL_ENABLED                 TRUE
-#define GD32_LXTAL_ENABLED                 TRUE
-#define GD32_SCS                           GD32_SCS_PLL
-#define GD32_PLLSEL                        GD32_PLLSEL_PREDV0
-#define GD32_PREDV0SEL                     GD32_PREDV0SEL_HXTAL
-#define GD32_PREDV0_VALUE                  2
-#define GD32_PLLMF_VALUE                   18
-#define GD32_PREDV1_VALUE                  2
-#define GD32_PLL1MF_VALUE                  14
-#define GD32_PLL2MF_VALUE                  13
-#define GD32_AHBPSC                        GD32_AHBPSC_DIV1
-#define GD32_APB1PSC                       GD32_APB1PSC_DIV2
-#define GD32_APB2PSC                       GD32_APB2PSC_DIV1
-#define GD32_ADCPSC                        GD32_ADCPSC_DIV6
-#define GD32_USB_CLOCK_REQUIRED            TRUE
-#define GD32_USBFSPSC                      GD32_USBFSPSC_DIV1P5
-#define GD32_I2S_CLOCK_REQUIRED            FALSE
-#define GD32_CKOUT0SEL                     GD32_CKOUT0SEL_NOCLOCK
-#define GD32_RTCSRC                        GD32_RTCSRC_LXTAL
-#define GD32_PVD_ENABLE                    FALSE
-#define GD32_LVDT                          GD32_LVDT_LEV0
+*/
+#define GD32_PLLMF_VALUE                     24
+#define GD32_USBFSPSC                        GD32_USBFSPSC_DIV2
+#define GD32_NO_INIT                         FALSE
+#define GD32_IRC8M_ENABLED                   TRUE
+#define GD32_IRC40K_ENABLED                  FALSE
+#define GD32_HXTAL_ENABLED                   TRUE
+#define GD32_LXTAL_ENABLED                   FALSE
+#define GD32_SCS                             GD32_SCS_PLL
+#define GD32_PLLSEL                          GD32_PLLSEL_PREDV0
+#define GD32_PREDV0SEL                       GD32_PREDV0SEL_HXTAL
+#define GD32_PREDV0_VALUE                    2
+#define GD32_PREDV1_VALUE                    2
+#define GD32_PLL1MF_VALUE                    14
+#define GD32_PLL2MF_VALUE                    13
+#define GD32_AHBPSC                          GD32_AHBPSC_DIV1
+#define GD32_APB1PSC                         GD32_APB1PSC_DIV2
+#define GD32_APB2PSC                         GD32_APB2PSC_DIV1
+#define GD32_ADCPSC                          GD32_ADCPSC_DIV16
+#define GD32_USB_CLOCK_REQUIRED              TRUE
+#define GD32_I2S_CLOCK_REQUIRED              FALSE
+#define GD32_CKOUT0SEL                       GD32_CKOUT0SEL_NOCLOCK
+#define GD32_RTCSRC                          GD32_RTCSRC_NOCLOCK
+#define GD32_PVD_ENABLE                      FALSE
+#define GD32_LVDT                            GD32_LVDT_LEV0
 
 /*
  * ECLIC system settings.
  */
-#define ECLIC_TRIGGER_DEFAULT              ECLIC_POSTIVE_EDGE_TRIGGER
-#define ECLIC_DMA_TRIGGER                  ECLIC_TRIGGER_DEFAULT
+#define ECLIC_TRIGGER_DEFAULT                ECLIC_POSTIVE_EDGE_TRIGGER
+#define ECLIC_DMA_TRIGGER                    ECLIC_TRIGGER_DEFAULT
 
 /*
  * IRQ system settings.
  */
-#define GD32_IRQ_EXTI0_PRIORITY            6
-#define GD32_IRQ_EXTI1_PRIORITY            6
-#define GD32_IRQ_EXTI2_PRIORITY            6
-#define GD32_IRQ_EXTI3_PRIORITY            6
-#define GD32_IRQ_EXTI4_PRIORITY            6
-#define GD32_IRQ_EXTI5_9_PRIORITY          6
-#define GD32_IRQ_EXTI10_15_PRIORITY        6
-#define GD32_IRQ_EXTI0_TRIGGER             ECLIC_TRIGGER_DEFAULT
-#define GD32_IRQ_EXTI1_TRIGGER             ECLIC_TRIGGER_DEFAULT
-#define GD32_IRQ_EXTI2_TRIGGER             ECLIC_TRIGGER_DEFAULT
-#define GD32_IRQ_EXTI3_TRIGGER             ECLIC_TRIGGER_DEFAULT
-#define GD32_IRQ_EXTI4_TRIGGER             ECLIC_TRIGGER_DEFAULT
-#define GD32_IRQ_EXTI5_9_TRIGGER           ECLIC_TRIGGER_DEFAULT
-#define GD32_IRQ_EXTI10_15_TRIGGER         ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI0_PRIORITY              6
+#define GD32_IRQ_EXTI1_PRIORITY              6
+#define GD32_IRQ_EXTI2_PRIORITY              6
+#define GD32_IRQ_EXTI3_PRIORITY              6
+#define GD32_IRQ_EXTI4_PRIORITY              6
+#define GD32_IRQ_EXTI5_9_PRIORITY            6
+#define GD32_IRQ_EXTI10_15_PRIORITY          6
+#define GD32_IRQ_EXTI0_TRIGGER               ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI1_TRIGGER               ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI2_TRIGGER               ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI3_TRIGGER               ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI4_TRIGGER               ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI5_9_TRIGGER             ECLIC_TRIGGER_DEFAULT
+#define GD32_IRQ_EXTI10_15_TRIGGER           ECLIC_TRIGGER_DEFAULT
 
 /*
  * ADC driver system settings.
  */
-#define GD32_ADC_USE_ADC0                  FALSE
-#define GD32_ADC_ADC0_DMA_PRIORITY         2
-#define GD32_ADC_ADC0_IRQ_PRIORITY         6
+#define GD32_ADC_USE_ADC0                    FALSE
+#define GD32_ADC_ADC0_DMA_PRIORITY           2
+#define GD32_ADC_ADC0_IRQ_PRIORITY           6
 
 /*
  * CAN driver system settings.
  */
-#define GD32_CAN_USE_CAN0                  FALSE
-#define GD32_CAN_CAN0_IRQ_PRIORITY         11
-#define GD32_CAN_USE_CAN1                  FALSE
-#define GD32_CAN_CAN1_IRQ_PRIORITY         11
-#define GD32_CAN_CAN0_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_CAN_CAN1_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_CAN_USE_CAN0                    FALSE
+#define GD32_CAN_CAN0_IRQ_PRIORITY           11
+#define GD32_CAN_USE_CAN1                    FALSE
+#define GD32_CAN_CAN1_IRQ_PRIORITY           11
+#define GD32_CAN_CAN0_IRQ_TRIGGER            ECLIC_TRIGGER_DEFAULT
+#define GD32_CAN_CAN1_IRQ_TRIGGER            ECLIC_TRIGGER_DEFAULT
+
+/*
+ * CRC driver system settings.
+ */
+#define GD32_CRC_USE_CRC0                   FALSE
+#define GD32_CRC_CRC0_DMA_IRQ_PRIORITY      14
+#define GD32_CRC_CRC0_DMA_PRIORITY          2
+#define GD32_CRC_CRC0_DMA_STREAM            GD32_DMA_STREAM_ID(0, 0)
+#define CRC_USE_DMA                         FALSE
+#define CRCSW_USE_CRC1                      FALSE
+#define CRCSW_CRC32_TABLE                   FALSE
+#define CRCSW_CRC16_TABLE                   FALSE
+#define CRCSW_PROGRAMMABLE                  FALSE
 
 /*
  * DAC driver system settings.
  */
-#define GD32_DAC_USE_DAC_CH1              FALSE
-#define GD32_DAC_USE_DAC_CH2              FALSE
+#define GD32_DAC_USE_DAC_CH1                FALSE
+#define GD32_DAC_USE_DAC_CH2                FALSE
 
 /*
  * GPT driver system settings.
  */
-#define GD32_GPT_USE_TIM0                  FALSE
-#define GD32_GPT_USE_TIM1                  FALSE
-#define GD32_GPT_USE_TIM2                  FALSE
-#define GD32_GPT_USE_TIM3                  FALSE
-#define GD32_GPT_USE_TIM4                  FALSE
-#define GD32_GPT_TIM0_IRQ_PRIORITY         7
-#define GD32_GPT_TIM1_IRQ_PRIORITY         7
-#define GD32_GPT_TIM2_IRQ_PRIORITY         7
-#define GD32_GPT_TIM3_IRQ_PRIORITY         7
-#define GD32_GPT_TIM4_IRQ_PRIORITY         7
-#define GD32_GPT_TIM0_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_GPT_TIM1_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_GPT_TIM2_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_GPT_TIM3_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_GPT_TIM4_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_GPT_TIM5_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_GPT_TIM6_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_USE_TIM0                   FALSE
+#define GD32_GPT_USE_TIM1                   FALSE
+#define GD32_GPT_USE_TIM2                   FALSE
+#define GD32_GPT_USE_TIM3                   FALSE
+#define GD32_GPT_USE_TIM4                   FALSE
+#define GD32_GPT_TIM0_IRQ_PRIORITY          7
+#define GD32_GPT_TIM1_IRQ_PRIORITY          7
+#define GD32_GPT_TIM2_IRQ_PRIORITY          7
+#define GD32_GPT_TIM3_IRQ_PRIORITY          7
+#define GD32_GPT_TIM4_IRQ_PRIORITY          7
+#define GD32_GPT_TIM0_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_TIM1_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_TIM2_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_TIM3_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_TIM4_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_TIM5_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_GPT_TIM6_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
 
 /*
  * I2S driver system settings.
  */
-#define GD32_I2S_USE_SPI1                  FALSE
-#define GD32_I2S_USE_SPI2                  FALSE
-#define GD32_I2S_SPI1_IRQ_PRIORITY         10
-#define GD32_I2S_SPI2_IRQ_PRIORITY         10
-#define GD32_I2S_SPI1_DMA_PRIORITY         1
-#define GD32_I2S_SPI2_DMA_PRIORITY         1
-#define GD32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+#define GD32_I2S_USE_SPI1                   FALSE
+#define GD32_I2S_USE_SPI2                   FALSE
+#define GD32_I2S_SPI1_IRQ_PRIORITY          10
+#define GD32_I2S_SPI2_IRQ_PRIORITY          10
+#define GD32_I2S_SPI1_DMA_PRIORITY          1
+#define GD32_I2S_SPI2_DMA_PRIORITY          1
+#define GD32_I2S_DMA_ERROR_HOOK(i2sp)       osalSysHalt("DMA failure")
 
 /*
  * I2C driver system settings.
  */
-#define GD32_I2C_USE_I2C0                  FALSE
-#define GD32_I2C_USE_I2C1                  FALSE
-#define GD32_I2C_BUSY_TIMEOUT              50
-#define GD32_I2C_I2C0_IRQ_PRIORITY         10
-#define GD32_I2C_I2C1_IRQ_PRIORITY         5
-#define GD32_I2C_I2C0_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_I2C_I2C1_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_I2C_I2C0_DMA_PRIORITY         2
-#define GD32_I2C_I2C1_DMA_PRIORITY         2
-#define GD32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
+#define GD32_I2C_USE_I2C0                   FALSE
+#define GD32_I2C_USE_I2C1                   FALSE
+#define GD32_I2C_BUSY_TIMEOUT               50
+#define GD32_I2C_I2C0_IRQ_PRIORITY          10
+#define GD32_I2C_I2C1_IRQ_PRIORITY          5
+#define GD32_I2C_I2C0_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_I2C_I2C1_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_I2C_I2C0_DMA_PRIORITY          2
+#define GD32_I2C_I2C1_DMA_PRIORITY          2
+#define GD32_I2C_DMA_ERROR_HOOK(i2cp)       osalSysHalt("DMA failure")
 
 /*
  * ICU driver system settings.
  */
-#define GD32_ICU_USE_TIM0                  FALSE
-#define GD32_ICU_USE_TIM1                  FALSE
-#define GD32_ICU_USE_TIM2                  FALSE
-#define GD32_ICU_USE_TIM3                  FALSE
-#define GD32_ICU_USE_TIM4                  FALSE
-#define GD32_ICU_TIM0_IRQ_PRIORITY         7
-#define GD32_ICU_TIM1_IRQ_PRIORITY         7
-#define GD32_ICU_TIM2_IRQ_PRIORITY         7
-#define GD32_ICU_TIM3_IRQ_PRIORITY         7
-#define GD32_ICU_TIM4_IRQ_PRIORITY         7
-#define GD32_ICU_TIM0_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_ICU_TIM1_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_ICU_TIM2_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_ICU_TIM3_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_ICU_TIM4_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_ICU_USE_TIM0                   FALSE
+#define GD32_ICU_USE_TIM1                   FALSE
+#define GD32_ICU_USE_TIM2                   FALSE
+#define GD32_ICU_USE_TIM3                   FALSE
+#define GD32_ICU_USE_TIM4                   FALSE
+#define GD32_ICU_TIM0_IRQ_PRIORITY          7
+#define GD32_ICU_TIM1_IRQ_PRIORITY          7
+#define GD32_ICU_TIM2_IRQ_PRIORITY          7
+#define GD32_ICU_TIM3_IRQ_PRIORITY          7
+#define GD32_ICU_TIM4_IRQ_PRIORITY          7
+#define GD32_ICU_TIM0_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_ICU_TIM1_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_ICU_TIM2_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_ICU_TIM3_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_ICU_TIM4_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
 
 /*
  * PWM driver system settings.
  */
-#define GD32_PWM_USE_ADVANCED              FALSE
-#define GD32_PWM_USE_TIM0                  FALSE
-#define GD32_PWM_USE_TIM1                  FALSE
-#define GD32_PWM_USE_TIM2                  FALSE
-#define GD32_PWM_USE_TIM3                  FALSE
-#define GD32_PWM_USE_TIM4                  FALSE
-#define GD32_PWM_TIM1_IRQ_PRIORITY         7
-#define GD32_PWM_TIM2_IRQ_PRIORITY         7
-#define GD32_PWM_TIM3_IRQ_PRIORITY         7
-#define GD32_PWM_TIM4_IRQ_PRIORITY         7
-#define GD32_PWM_TIM0_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_PWM_TIM1_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_PWM_TIM2_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_PWM_TIM3_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_PWM_TIM4_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_PWM_USE_ADVANCED               FALSE
+#define GD32_PWM_USE_TIM0                   FALSE
+#define GD32_PWM_USE_TIM1                   FALSE
+#define GD32_PWM_USE_TIM2                   FALSE
+#define GD32_PWM_USE_TIM3                   FALSE
+#define GD32_PWM_USE_TIM4                   FALSE
+#define GD32_PWM_TIM0_IRQ_PRIORITY          10
+#define GD32_PWM_TIM1_IRQ_PRIORITY          10
+#define GD32_PWM_TIM2_IRQ_PRIORITY          10
+#define GD32_PWM_TIM3_IRQ_PRIORITY          10
+#define GD32_PWM_TIM4_IRQ_PRIORITY          10
+#define GD32_PWM_TIM0_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_PWM_TIM1_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_PWM_TIM2_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_PWM_TIM3_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_PWM_TIM4_IRQ_TRIGGER           ECLIC_TRIGGER_DEFAULT
 
 /*
  * RTC driver system settings.
  */
-#define GD32_RTC_IRQ_PRIORITY              15
-#define GD32_RTC_IRQ_TRIGGER               ECLIC_TRIGGER_DEFAULT
+#define GD32_RTC_IRQ_PRIORITY               15
+#define GD32_RTC_IRQ_TRIGGER                ECLIC_TRIGGER_DEFAULT
 
 /*
  * SERIAL driver system settings.
  */
-#define GD32_SERIAL_USE_USART0             FALSE
-#define GD32_SERIAL_USE_USART1             FALSE
-#define GD32_SERIAL_USE_USART2             FALSE
-#define GD32_SERIAL_USE_UART3              FALSE
-#define GD32_SERIAL_USE_UART4              FALSE
-#define GD32_SERIAL_USART0_PRIORITY        12
-#define GD32_SERIAL_USART1_PRIORITY        12
-#define GD32_SERIAL_USART2_PRIORITY        12
-#define GD32_SERIAL_UART3_PRIORITY         12
-#define GD32_SERIAL_UART4_PRIORITY         12
-#define GD32_SERIAL_USART0_TRIGGER         ECLIC_TRIGGER_DEFAULT
-#define GD32_SERIAL_USART1_TRIGGER         ECLIC_TRIGGER_DEFAULT
-#define GD32_SERIAL_USART2_TRIGGER         ECLIC_TRIGGER_DEFAULT
-#define GD32_SERIAL_UART3_TRIGGER          ECLIC_TRIGGER_DEFAULT
-#define GD32_SERIAL_UART4_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_SERIAL_USE_USART0              FALSE
+#define GD32_SERIAL_USE_USART1              FALSE
+#define GD32_SERIAL_USE_USART2              FALSE
+#define GD32_SERIAL_USE_UART3               FALSE
+#define GD32_SERIAL_USE_UART4               FALSE
+#define GD32_SERIAL_USART0_PRIORITY         10
+#define GD32_SERIAL_USART1_PRIORITY         10
+#define GD32_SERIAL_USART2_PRIORITY         10
+#define GD32_SERIAL_UART3_PRIORITY          10
+#define GD32_SERIAL_UART4_PRIORITY          10
+#define GD32_SERIAL_USART0_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_SERIAL_USART1_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_SERIAL_USART2_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_SERIAL_UART3_TRIGGER           ECLIC_TRIGGER_DEFAULT
+#define GD32_SERIAL_UART4_TRIGGER           ECLIC_TRIGGER_DEFAULT
 
 /*
  * SPI driver system settings.
  */
-#define GD32_SPI_USE_SPI0                  FALSE
-#define GD32_SPI_USE_SPI1                  FALSE
-#define GD32_SPI_USE_SPI2                  FALSE
-#define GD32_SPI_SPI0_DMA_PRIORITY         1
-#define GD32_SPI_SPI1_DMA_PRIORITY         1
-#define GD32_SPI_SPI2_DMA_PRIORITY         1
-#define GD32_SPI_SPI0_IRQ_PRIORITY         10
-#define GD32_SPI_SPI1_IRQ_PRIORITY         10
-#define GD32_SPI_SPI2_IRQ_PRIORITY         10
-#define GD32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
+#define GD32_SPI_USE_SPI0                   FALSE
+#define GD32_SPI_USE_SPI1                   FALSE
+#define GD32_SPI_USE_SPI2                   FALSE
+#define GD32_SPI_SPI0_DMA_PRIORITY          1
+#define GD32_SPI_SPI1_DMA_PRIORITY          1
+#define GD32_SPI_SPI2_DMA_PRIORITY          1
+#define GD32_SPI_SPI0_IRQ_PRIORITY          10
+#define GD32_SPI_SPI1_IRQ_PRIORITY          10
+#define GD32_SPI_SPI2_IRQ_PRIORITY          10
+#define GD32_SPI_DMA_ERROR_HOOK(spip)       osalSysHalt("DMA failure")
 
 /*
  * ST driver system settings.
  */
-#define GD32_ST_IRQ_PRIORITY               9
-#define GD32_ST_IRQ_TRIGGER                ECLIC_TRIGGER_DEFAULT
-#define GD32_ST_USE_TIMER                  1
+#define GD32_ST_IRQ_PRIORITY                10
+#define GD32_ST_IRQ_TRIGGER                 ECLIC_TRIGGER_DEFAULT
+#define GD32_ST_USE_TIMER                   1
 
 /*
  * UART driver system settings.
  */
-#define GD32_UART_USE_USART0               FALSE
-#define GD32_UART_USE_USART1               FALSE
-#define GD32_UART_USE_USART2               FALSE
-#define GD32_UART_USE_UART3                FALSE
-#define GD32_UART_USE_UART4                FALSE
-#define GD32_UART_USART0_IRQ_PRIORITY      13
-#define GD32_UART_USART1_IRQ_PRIORITY      13
-#define GD32_UART_USART2_IRQ_PRIORITY      13
-#define GD32_UART_UART3_IRQ_PRIORITY       13
-#define GD32_UART_UART4_IRQ_PRIORITY       13
-#define GD32_UART_USART0_IRQ_TRIGGER       ECLIC_TRIGGER_DEFAULT
-#define GD32_UART_USART1_IRQ_TRIGGER       ECLIC_TRIGGER_DEFAULT
-#define GD32_UART_USART2_IRQ_TRIGGER       ECLIC_TRIGGER_DEFAULT
-#define GD32_UART_UART3_IRQ_TRIGGER        ECLIC_TRIGGER_DEFAULT
-#define GD32_UART_UART4_IRQ_TRIGGER        ECLIC_TRIGGER_DEFAULT
-#define GD32_UART_USART0_DMA_PRIORITY      0
-#define GD32_UART_USART1_DMA_PRIORITY      0
-#define GD32_UART_USART2_DMA_PRIORITY      0
-#define GD32_UART_UART3_DMA_PRIORITY       0
-#define GD32_UART_UART4_DMA_PRIORITY       0
-#define GD32_UART_DMA_ERROR_HOOK(uartp)    osalSysHalt("DMA failure")
+#define GD32_UART_USE_USART0                FALSE
+#define GD32_UART_USE_USART1                FALSE
+#define GD32_UART_USE_USART2                FALSE
+#define GD32_UART_USE_UART3                 FALSE
+#define GD32_UART_USE_UART4                 FALSE
+#define GD32_UART_USART0_IRQ_PRIORITY       10
+#define GD32_UART_USART1_IRQ_PRIORITY       10
+#define GD32_UART_USART2_IRQ_PRIORITY       10
+#define GD32_UART_UART3_IRQ_PRIORITY        10
+#define GD32_UART_UART4_IRQ_PRIORITY        10
+#define GD32_UART_USART0_IRQ_TRIGGER        ECLIC_TRIGGER_DEFAULT
+#define GD32_UART_USART1_IRQ_TRIGGER        ECLIC_TRIGGER_DEFAULT
+#define GD32_UART_USART2_IRQ_TRIGGER        ECLIC_TRIGGER_DEFAULT
+#define GD32_UART_UART3_IRQ_TRIGGER         ECLIC_TRIGGER_DEFAULT
+#define GD32_UART_UART4_IRQ_TRIGGER         ECLIC_TRIGGER_DEFAULT
+#define GD32_UART_USART0_DMA_PRIORITY       3
+#define GD32_UART_USART1_DMA_PRIORITY       3
+#define GD32_UART_USART2_DMA_PRIORITY       3
+#define GD32_UART_UART3_DMA_PRIORITY        3
+#define GD32_UART_UART4_DMA_PRIORITY        3
+#define GD32_UART_DMA_ERROR_HOOK(uartp)     osalSysHalt("DMA failure")
 
 /*
  * USB driver system settings.
  */
-#define GD32_USB_USE_USBFS                 TRUE
-#define GD32_USB_USBFS_IRQ_PRIORITY        5
-#define GD32_USB_USBFS_IRQ_TRIGGER         ECLIC_TRIGGER_DEFAULT
-#define GD32_USB_USBFS_RX_FIFO_SIZE        256
+#define GD32_USB_USE_USBFS                  TRUE
+#define GD32_USB_USBFS_IRQ_PRIORITY         10
+#define GD32_USB_USBFS_IRQ_TRIGGER          ECLIC_TRIGGER_DEFAULT
+#define GD32_USB_USBFS_RX_FIFO_SIZE         256
 
 /*
  * WDG driver system settings.

--- a/os/common/ports/RISCV-ECLIC/chcore.h
+++ b/os/common/ports/RISCV-ECLIC/chcore.h
@@ -78,7 +78,12 @@
 /**
  * @brief   Name of the implemented architecture.
  */
-#define PORT_ARCHITECTURE_NAME "RISC-V RV32IMAC"
+#define PORT_ARCHITECTURE_NAME          "RISC-V"
+
+/**
+ * @brief   Name of the architecture variant.
+ */
+#define PORT_CORE_VARIANT_NAME          "RV32IMAC"
 
 /**
  * @brief   Compiler name and version.
@@ -382,7 +387,7 @@ bool _port_irq_epilogue(void);
 /**
  * @brief   Port-related initialization code.
  */
-static inline void port_init(void) {}
+static inline void port_init(os_instance_t *oip){}
 
 /**
  * @brief   Returns a word encoding the current interrupts status.

--- a/os/common/ports/RISCV-ECLIC/compilers/GCC/chcoreasm.S
+++ b/os/common/ports/RISCV-ECLIC/compilers/GCC/chcoreasm.S
@@ -334,7 +334,7 @@ _port_switch_from_isr:
     jal     ra, _dbg_check_lock
 #endif
     # Calls _port_switch at the end of the function
-    jal     ra, chSchDoReschedule
+    jal     ra, chSchDoPreemption
 #if CH_DBG_SYSTEM_STATE_CHECK
     jal     ra, _dbg_check_unlock
 #endif


### PR DESCRIPTION
As the title states it, update the port for chibios-21.6.x usage and fix some minor things in the usb-cdc demo.