### PR TITLE
[RP2040] Fix usb endpoint handling on RP2040

### DIFF
--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
@@ -135,7 +135,7 @@ typedef struct {
 #endif
   /* End of the mandatory fields.*/
   /**
-   * @brief   Last received size of data.
+   * @brief   Size of the last transmitted packet.
    */
   size_t                        txlast;
   /**


### PR DESCRIPTION
After cross referencing the driver with the official tinyusb driver and the rp2040 datasheet, I noticed some deviations especially in the handling of reset, stall and setup packets.

Also the old behaviour was that endpoints have already been armed to receive or send usb packets after they have been initialized. This should only be done by the `usb_lld_start_in()` and `usb_lld_start_out()` functions that are invoked by the higher level usb driver functions.