### PR TITLE
[RP2040] Fix I2C lockups, improve error handling and performance

### DIFF
--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
@@ -140,21 +140,17 @@ struct I2CDriver {
    */
   size_t                    rxbytes;
   /**
-   * @brief     Next index of data in TX buffer.
+   * @brief     Send restart on next transmission.
    */
-  size_t                    txindex;
-  /**
-   * @brief     Next index of RX buffer.
-   */
-  size_t                    rxindex;
+  bool                      send_restart;
   /**
    * @brief     Buffer for TX.
    */
-  const uint8_t             *txbuf;
+  const uint8_t             *txptr;
   /**
    * @brief     Buffer for RX.
    */
-  uint8_t                   *rxbuf;
+  uint8_t                   *rxptr;
 };
 
 /*===========================================================================*/


### PR DESCRIPTION
**Problem**

*  in edge-case scenarios the tx empty interrupt was still enabled after a transmission was finished. This would lead to endless interrupt tail chaining that completely starved the system.

**Solution**

*   all irqs are now disabled at the end of a transaction by default

**Error handling**

*  all error condition irqs like over and under-runs of tx and rx fifos are now enabled and handled with an wake-up of the sleeping thread plus disabling of all irqs

**Optimizations**

*  irq status register is only read once for evaluation in the irq  handler
*  better Utilization of the rx fifos during reception, which are now only read if all data has been successfully received.


Fixes https://github.com/qmk/qmk_firmware/issues/17720