### PR TITLE
[RP2040] Add `vectors_base` and `end` symbol to RP2040 linker script

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_rules_code_with_boot2.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_rules_code_with_boot2.ld
@@ -20,7 +20,10 @@ SECTIONS
 {
     .vectors : ALIGN(256)
     {
+        __textvectors_base__ = LOADADDR(.vectors);
+        __vectors_base__ = .;
         KEEP(*(.vectors))
+        __vectors_end__ = .;
     } > VECTORS_FLASH AT > VECTORS_FLASH_LMA
 
     .xtors : ALIGN(4)


### PR DESCRIPTION
...to allow copying the vector table to RAM on startup.