### PR TITLE
HT32: TIMv1: fix bftm1 typo

### DIFF
--- a/os/hal/ports/HT32/LLD/TIMv1/hal_gpt_lld.c
+++ b/os/hal/ports/HT32/LLD/TIMv1/hal_gpt_lld.c
@@ -101,7 +101,7 @@ void gpt_lld_init(void) {
 #endif
 #if HT32_GPT_USE_BFTM1 == TRUE
     gptObjectInit(&GPTD_BFTM1);
-    GPTD_BFTM0.BFTM = BFTM1;
+    GPTD_BFTM1.BFTM = BFTM1;
 #endif
 }
 


### PR DESCRIPTION
BFTM0 was incorrectly referenced when using only BFTM1 (only HT32_GPT_USE_BFTM1 is defined as TRUE).

Fixes the following error:
```
os/hal/ports/HT32/LLD/TIMv1/hal_gpt_lld.c:104:5:
error: 'GPTD_BFTM0' undeclared (first use in this function); did you
mean 'GPTD_BFTM1'?
  104 |     GPTD_BFTM0.BFTM = BFTM1;
      |     ^~~~~~~~~~
      |     GPTD_BFTM1
```