### PR TITLE
KINETIS/LLD/USBHSv1: Fix `USB_USE_WAIT` support

### DIFF
--- a/os/hal/ports/KINETIS/LLD/USBHSv1/hal_usb_lld.c
+++ b/os/hal/ports/KINETIS/LLD/USBHSv1/hal_usb_lld.c
@@ -278,8 +278,7 @@ OSAL_IRQ_HANDLER(KINETIS_USB_IRQ_VECTOR) {
         }
         else
         {
-          if(epc->in_cb != NULL)
-            _usb_isr_invoke_in_cb(usbp,ep);
+          _usb_isr_invoke_in_cb(usbp,ep);
         }
       } break;
       case BDT_PID_OUT:                                                // OUT
@@ -304,8 +303,7 @@ OSAL_IRQ_HANDLER(KINETIS_USB_IRQ_VECTOR) {
              has been received or the current packet is a short packet.*/
           if ((rxed < epc->out_maxsize) || (epc->out_state->rxpkts == 0))
           {
-            if(epc->out_cb != NULL)
-              _usb_isr_invoke_out_cb(usbp, ep);
+            _usb_isr_invoke_out_cb(usbp, ep);
           }
         }
       } break;


### PR DESCRIPTION
The USBHSv1 LLD for KINETIS was checking `epc->in_cb` and `epc->out_cb` to be non-NULL before calling `_usb_isr_invoke_in_cb()` and `_usb_isr_invoke_out_cb()`.  This is not correct, because if the `USB_USE_WAIT` option is enabled, those ChibiOS macros do more than just invoking the callback - they also resume the thread that may be waiting for the transfer completion, and omitting the call results in that thread never getting resumed.  The macros also perform the same pointer check internally before invoking the callback.

Remove the unneeded checks to make the driver work properly with any APIs enabled by `USB_USE_WAIT`.

------

Tested on Teensy 3.2 (MK20DX256) in QMK.  The error was uncovered by https://github.com/qmk/qmk_firmware/pull/18631 — the cleanup part of that PR removed some `in_cb` callback functions that were doing nothing, and the resulting code worked fine on most supported chips (e.g, various STM32 and RP2040); however, on Teensy 3.2 that change resulted in a lockup immediately after sending a single keyboard event, because the main thread waiting for the USB transfer completion was not getting resumed when the `in_cb` pointer was NULL.