### PR TITLE
MIMXRT1062/LLD/USBHSv1: Fix `USB_USE_WAIT` support

### DIFF
--- a/os/hal/ports/MIMXRT1062/LLD/USBHSv1/hal_usb_lld.c
+++ b/os/hal/ports/MIMXRT1062/LLD/USBHSv1/hal_usb_lld.c
@@ -308,7 +308,6 @@ static usb_status_t device_ep0_control_callback(usb_device_handle handle,
 
   if (direction == USB_OUT) {
     printf_debug("    complete, OUT ep=%d (OUT), rxbuf=%x", ep, epc->out_state->rxbuf);
-    (usbp)->receiving &= ~(1 << ep);
 
     USBOutEndpointState *osp = epc->out_state;
     osp->rxcnt = message->length;
@@ -317,19 +316,14 @@ static usb_status_t device_ep0_control_callback(usb_device_handle handle,
 
     /* Endpoint Receive Complete Event */
     /* Transfer Direction OUT */
-    if (epc->out_cb != NULL) {
-      printf_debug("    invoking out_cb for ep %d", ep);
-      _usb_isr_invoke_out_cb(usbp, ep);
-    }
+    printf_debug("    invoking out_cb for ep %d", ep);
+    _usb_isr_invoke_out_cb(usbp, ep);
   } else if (direction == USB_IN) {
     printf_debug("    complete, IN ep=%d (IN), txbuf=%x", ep, epc->in_state->txbuf);
-    (usbp)->transmitting &= ~(1 << ep);
     /* Endpoint Transmit Complete Event */
     /* Transfer Direction IN */
-    if (epc->in_cb != NULL) {
-      printf_debug("    invoking in_cb for ep %d", ep);
-      _usb_isr_invoke_in_cb(usbp, ep);
-    }
+    printf_debug("    invoking in_cb for ep %d", ep);
+    _usb_isr_invoke_in_cb(usbp, ep);
   }
 
   return kStatus_USB_Success;
@@ -468,7 +462,6 @@ static usb_status_t device_epN_control_callback(usb_device_handle handle,
 
   if (direction == USB_OUT) {
     printf_debug("    complete, OUT ep=%d (OUT), rxbuf=%x", ep, epc->out_state->rxbuf);
-    (usbp)->receiving &= ~(1 << ep);
 
     USBOutEndpointState *osp = epc->out_state;
     osp->rxcnt = message->length;
@@ -476,19 +469,14 @@ static usb_status_t device_epN_control_callback(usb_device_handle handle,
 
     /* Endpoint Receive Complete Event */
     /* Transfer Direction OUT */
-    if (epc->out_cb != NULL) {
-      printf_debug("    invoking out_cb for ep %d", ep);
-      _usb_isr_invoke_out_cb(usbp, ep);
-    }
+    printf_debug("    invoking out_cb for ep %d", ep);
+    _usb_isr_invoke_out_cb(usbp, ep);
   } else if (direction == USB_IN) {
     printf_debug("    complete, IN ep=%d (IN), txbuf=%x", ep, epc->in_state->txbuf);
-    (usbp)->transmitting &= ~(1 << ep);
     /* Endpoint Transmit Complete Event */
     /* Transfer Direction IN */
-    if (epc->in_cb != NULL) {
-      printf_debug("    invoking in_cb for ep %d", ep);
-      _usb_isr_invoke_in_cb(usbp, ep);
-    }
+    printf_debug("    invoking in_cb for ep %d", ep);
+    _usb_isr_invoke_in_cb(usbp, ep);
   }
   return kStatus_USB_Success;
 }


### PR DESCRIPTION
The USBHSv1 LLD for MIMXRT1062 was checking `epc->in_cb` and `epc->out_cb` to be non-NULL before calling `_usb_isr_invoke_in_cb()` and `_usb_isr_invoke_out_cb()`.  This is not correct, because if the `USB_USE_WAIT` option is enabled, those ChibiOS macros do more than just invoking the callback - they also resume the thread that may be waiting for the transfer completion, and omitting the call results in that thread never getting resumed.  The macros also perform the same pointer check internally before invoking the callback.

Remove the unneeded checks to make the driver work properly with any APIs enabled by `USB_USE_WAIT`.  Also remove the manipulation of `(usbp)->receiving` and `(usbp)->transmitting`, because the `_usb_isr_invoke_in_cb()` and `_usb_isr_invoke_out_cb()` macros handle that part too.

------

This change is **NOT** tested yet (I don't have the corresponding hardware); maybe @jtojnar (the reporter of https://github.com/qmk/qmk_firmware/issues/18805) could test whether it fixes their problem instead of using a workaround which puts a dummy function pointer into `in_cb` (https://github.com/qmk/qmk_firmware/pull/18811).

The error was uncovered by https://github.com/qmk/qmk_firmware/pull/18631 — the cleanup part of that PR removed some `in_cb` callback functions that were doing nothing, and the resulting code worked fine on most supported chips (e.g, various STM32 and RP2040), but broke on Arm-based Teensy boards (#342 fixes the same problem in the KINETIS driver).

Cc: @stapelberg 