### PR TITLE
HT32: TIMv1: gpt_lld_init: Fix reference to GPTD_BFTM1

### DIFF
--- a/os/hal/ports/HT32/LLD/TIMv1/hal_gpt_lld.c
+++ b/os/hal/ports/HT32/LLD/TIMv1/hal_gpt_lld.c
@@ -101,7 +101,7 @@ void gpt_lld_init(void) {
 #endif
 #if HT32_GPT_USE_BFTM1 == TRUE
     gptObjectInit(&GPTD_BFTM1);
-    GPTD_BFTM0.BFTM = BFTM1;
+    GPTD_BFTM1.BFTM = BFTM1;
 #endif
 }
 


### PR DESCRIPTION
Same as #340, but with updated commit message.

This commit is necessary to utilize both BFTM0 and BFTM1 timers (although I no longer need both timers in my project).

I have tested that BFTM1 is working correctly in my project with this change: https://github.com/hansemro/qmk_firmware/blob/36253c450a5dba8c3e9311a56e79aaa4e8c7d84a/keyboards/masterkeys/prosrgb/mbia043.c#L177-L180.