### PR TITLE
Teensy 4.1: implement USB remote wakeup

### DIFF
--- a/os/hal/ports/MIMXRT1062/LLD/USBHSv1/hal_usb_lld.c
+++ b/os/hal/ports/MIMXRT1062/LLD/USBHSv1/hal_usb_lld.c
@@ -116,12 +116,16 @@ static usb_status_t usb_device_callback(usb_device_handle handle, uint32_t callb
     break;
 
   case kUSB_DeviceEventSuspend:
-    printf_debug("  suspend");
+    printf_debug("  suspend--nxp");
+    // Call USB_DeviceSetStatus() to enable the “detect resume” interrupt.
+    usb_device_struct_t *dev_handle = (usb_device_struct_t *)handle;
+    (void)USB_DeviceSetStatus(dev_handle, kUSB_DeviceStatusBusSuspend, NULL);
+    printf_debug("  suspend--chibi");
     _usb_suspend(usbp);
     break;
 
   case kUSB_DeviceEventResume:
-    printf_debug("  resume");
+    printf_debug("  resume--chibi");
     _usb_wakeup(usbp);
     break;
   }

--- a/os/hal/ports/MIMXRT1062/LLD/USBHSv1/hal_usb_lld.h
+++ b/os/hal/ports/MIMXRT1062/LLD/USBHSv1/hal_usb_lld.h
@@ -408,8 +408,10 @@ struct USBDriver {
  * @notapi
  */
 #define usb_lld_wakeup_host(usbp)                                     \
-  do{                                                                 \
-  } while (false)
+  do{ \
+    usb_device_struct_t *dev_handle = (usb_device_struct_t *)handle; \
+    (void)USB_DeviceSetStatus(dev_handle, kUSB_DeviceStatusBusResume, NULL); \
+  } while (0)
 
 
 /*===========================================================================*/

--- a/os/hal/ports/MIMXRT1062/LLD/USBHSv1/usb_device_config.h
+++ b/os/hal/ports/MIMXRT1062/LLD/USBHSv1/usb_device_config.h
@@ -154,11 +154,11 @@
 #define USB_DEVICE_CONFIG_BUFFER_PROPERTY_CACHEABLE (0U)
 #endif
 /*! @brief Whether the low power mode is enabled or not. */
-#define USB_DEVICE_CONFIG_LOW_POWER_MODE (0U)
+#define USB_DEVICE_CONFIG_LOW_POWER_MODE (1U)
 
 #if ((defined(USB_DEVICE_CONFIG_LOW_POWER_MODE)) && (USB_DEVICE_CONFIG_LOW_POWER_MODE > 0U))
 /*! @brief Whether device remote wakeup supported. 1U supported, 0U not supported */
-#define USB_DEVICE_CONFIG_REMOTE_WAKEUP (0U)
+#define USB_DEVICE_CONFIG_REMOTE_WAKEUP (1U)
 
 /*! @brief Whether LPM is supported. 1U supported, 0U not supported */
 #define USB_DEVICE_CONFIG_LPM_L1 (0U)


### PR DESCRIPTION
This allows waking up a computer from Suspend-to-RAM by pressing a key on the keyboard (with the QMK keyboard firmware, which uses ChibiOS for the Teensy).

related to https://github.com/kinx-project/kint/issues/59

related to https://github.com/qmk/qmk_firmware/issues/16934