### PR TITLE
Teensy 3.6: do not restart USB stack after wakeup

### DIFF
--- a/os/hal/boards/PJRC_TEENSY_3_6/board.c
+++ b/os/hal/boards/PJRC_TEENSY_3_6/board.c
@@ -214,3 +214,9 @@ void __early_init(void) {
  */
 void boardInit(void) {
 }
+
+void restart_usb_driver(USBDriver *usbp) {
+    // Do nothing. Restarting the USB driver on the Teensy 3.6 breaks it,
+    // resulting in a keyboard which can wake up a PC from Suspend-to-RAM, but
+    // does not actually produce any keypresses until you un-plug and re-plug.
+}


### PR DESCRIPTION
Without this change, the Teensy 3.6 (with QMK firmware) can wake a computer from Suspend-to-RAM, but the keyboard does not actually produce any keypresses until you un-plug and re-plug it.

A similar change was needed for the Teensy 4.x as well: https://github.com/ChibiOS/ChibiOS-Contrib/pull/345

related to https://github.com/kinx-project/kint/issues/59

related to https://github.com/qmk/qmk_firmware/issues/16934