### PR TITLE
Fixed some issues with usb_msd for stm32l496

### DIFF
--- a/os/hal/include/hal_usb_msd.h
+++ b/os/hal/include/hal_usb_msd.h
@@ -98,6 +98,12 @@ typedef struct {
 } msd_cbw_t;
 
 /**
+ * @brief The size of the command block wrapper structure.
+ * @details The actual size of the structure ignoring data padding.
+*/
+#define USB_MSD_CBW_T_SIZE 31
+
+/**
  * @brief   Represents command status wrapper structure.
  * @details See USB Mass Storage Class Specification.
  */
@@ -107,6 +113,12 @@ typedef struct {
   uint32_t  data_residue;
   uint8_t   status;
 } msd_csw_t;
+
+/**
+ * @brief The size of the command status wrapper structure.
+ * @details The actual size of the structure ignoring data padding.
+*/
+#define USB_MSD_CSW_T_SIZE 13
 
 /**
  * @brief   Transport handler passed to SCSI layer.

--- a/os/hal/include/hal_usb_msd.h
+++ b/os/hal/include/hal_usb_msd.h
@@ -95,13 +95,7 @@ typedef struct {
   uint8_t   lun;
   uint8_t   cmd_len;
   uint8_t   cmd_data[16];
-} msd_cbw_t;
-
-/**
- * @brief The size of the command block wrapper structure.
- * @details The actual size of the structure ignoring data padding.
-*/
-#define USB_MSD_CBW_T_SIZE 31
+} __attribute__((packed)) msd_cbw_t;
 
 /**
  * @brief   Represents command status wrapper structure.
@@ -112,13 +106,7 @@ typedef struct {
   uint32_t  tag;
   uint32_t  data_residue;
   uint8_t   status;
-} msd_csw_t;
-
-/**
- * @brief The size of the command status wrapper structure.
- * @details The actual size of the structure ignoring data padding.
-*/
-#define USB_MSD_CSW_T_SIZE 13
+} __attribute__((packed)) msd_csw_t;
 
 /**
  * @brief   Transport handler passed to SCSI layer.

--- a/os/hal/src/hal_usb_msd.c
+++ b/os/hal/src/hal_usb_msd.c
@@ -116,7 +116,7 @@ static const scsi_unit_serial_number_inquiry_response_t default_scsi_unit_serial
  * @notapi
  */
 static bool cbw_valid(const msd_cbw_t *cbw, msg_t recvd) {
-  if ((sizeof(msd_cbw_t) != recvd) || (cbw->signature != MSD_CBW_SIGNATURE)) {
+  if ((USB_MSD_CBW_T_SIZE != recvd) || (cbw->signature != MSD_CBW_SIGNATURE)) {
     return false;
   }
   else {
@@ -190,7 +190,7 @@ static uint32_t scsi_transport_receive(const SCSITransport *transport,
   usb_scsi_transport_handler_t *trp = transport->handler;
   msg_t status = usbReceive(trp->usbp, trp->ep, data, len);
   if (MSG_RESET != status)
-    return status;
+    return len;
   else
     return 0;
 }
@@ -213,7 +213,7 @@ static void send_csw(USBMassStorageDriver *msdp, uint8_t status,
   msdp->csw.status = status;
 
   usbTransmit(msdp->usbp, USB_MSD_DATA_EP, (uint8_t *)&msdp->csw,
-      sizeof(msd_csw_t));
+      USB_MSD_CSW_T_SIZE);
 }
 
 /**
@@ -229,7 +229,7 @@ static THD_FUNCTION(usb_msd_worker, arg) {
 
   while(! chThdShouldTerminateX()) {
     const msg_t status = usbReceive(msdp->usbp, USB_MSD_DATA_EP,
-                                   (uint8_t *)&msdp->cbw, sizeof(msd_cbw_t));
+                                   (uint8_t *)&msdp->cbw, USB_MSD_CBW_T_SIZE);
     if (MSG_RESET == status) {
       osalThreadSleepMilliseconds(50);
     }

--- a/os/hal/src/hal_usb_msd.c
+++ b/os/hal/src/hal_usb_msd.c
@@ -116,7 +116,7 @@ static const scsi_unit_serial_number_inquiry_response_t default_scsi_unit_serial
  * @notapi
  */
 static bool cbw_valid(const msd_cbw_t *cbw, msg_t recvd) {
-  if ((USB_MSD_CBW_T_SIZE != recvd) || (cbw->signature != MSD_CBW_SIGNATURE)) {
+  if ((sizeof(msd_cbw_t) != recvd) || (cbw->signature != MSD_CBW_SIGNATURE)) {
     return false;
   }
   else {
@@ -213,7 +213,7 @@ static void send_csw(USBMassStorageDriver *msdp, uint8_t status,
   msdp->csw.status = status;
 
   usbTransmit(msdp->usbp, USB_MSD_DATA_EP, (uint8_t *)&msdp->csw,
-      USB_MSD_CSW_T_SIZE);
+      sizeof(msd_csw_t));
 }
 
 /**
@@ -229,7 +229,7 @@ static THD_FUNCTION(usb_msd_worker, arg) {
 
   while(! chThdShouldTerminateX()) {
     const msg_t status = usbReceive(msdp->usbp, USB_MSD_DATA_EP,
-                                   (uint8_t *)&msdp->cbw, USB_MSD_CBW_T_SIZE);
+                                   (uint8_t *)&msdp->cbw, sizeof(msd_cbw_t));
     if (MSG_RESET == status) {
       osalThreadSleepMilliseconds(50);
     }

--- a/os/various/lib_scsi.c
+++ b/os/various/lib_scsi.c
@@ -274,11 +274,11 @@ static bool read_format_capacities(SCSITarget *scsip, const uint8_t *cmd) {
     memcpy(ret.blocknum, &tmp, 4);
 
     uint8_t formatted_media = 0b10;
-    uint16_t blocklen = bdi.blk_size;
+    uint16_t blocklen = (uint16_t)bdi.blk_size;
     ret.blocklen[0] = formatted_media;
     ret.blocklen[1] = 0;
-    ret.blocklen[2] = blocklen >> 8;
-    ret.blocklen[3] = blocklen & 0xFF;
+    ret.blocklen[2] = (uint8_t)blocklen >> 8;
+    ret.blocklen[3] = (uint8_t)blocklen & 0xFF;
 
     ret.header[3] = 1 * 8;
 


### PR DESCRIPTION
Some info:
I'm working with Chibios21.11
I'm using the chibios-21.11x branch. (obviously)
I'm working on an STM32L496

When implementing a mass storage device I've had a few issues:
1. The return value of scsi_transport_receive did not seem right.
2. Implicit casting warnings in read_format_capacities of lib_scsi.c.
3. Since I'm using a 32bit processor msd_cbw_t and msd_csw_t are padded.
    sizeof(msd_cbw_t) does not match the length of the binary data received and
    sizeof(msd_csw_t) does not match the length of the binary data to send.

I've fixed point 3 by providing defines for the size, since these messages should always
have the same length.

Comments are appreciated if this is considered an 'ugly' fix.