### PR TITLE
[RP2040] update i2c drivers to reflect peripheral number

### DIFF
--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -40,14 +40,14 @@
  * @brief   I2C1 driver identifier.
  */
 #if (RP_I2C_USE_I2C0 == TRUE) || defined(__DOXYGEN__)
-I2CDriver I2CD1;
+I2CDriver I2CD0;
 #endif
 
 /**
  * @brief   I2C2 driver identifier.
  */
 #if (RP_I2C_USE_I2C1 == TRUE) || defined(__DOXYGEN__)
-I2CDriver I2CD2;
+I2CDriver I2CD1;
 #endif
 
 /*===========================================================================*/
@@ -354,7 +354,7 @@ static void i2c_lld_serve_interrupt(I2CDriver *i2cp) {
 OSAL_IRQ_HANDLER(RP_I2C0_IRQ_HANDLER) {
   OSAL_IRQ_PROLOGUE();
 
-  i2c_lld_serve_interrupt(&I2CD1);
+  i2c_lld_serve_interrupt(&I2CD0);
 
   OSAL_IRQ_EPILOGUE();
 }
@@ -366,7 +366,7 @@ OSAL_IRQ_HANDLER(RP_I2C0_IRQ_HANDLER) {
 OSAL_IRQ_HANDLER(RP_I2C1_IRQ_HANDLER) {
   OSAL_IRQ_PROLOGUE();
 
-  i2c_lld_serve_interrupt(&I2CD2);
+  i2c_lld_serve_interrupt(&I2CD1);
 
   OSAL_IRQ_EPILOGUE();
 }
@@ -385,18 +385,18 @@ OSAL_IRQ_HANDLER(RP_I2C1_IRQ_HANDLER) {
 void i2c_lld_init(void) {
 
 #if RP_I2C_USE_I2C0 == TRUE
-  i2cObjectInit(&I2CD1);
-  I2CD1.i2c = I2C0;
-  I2CD1.thread = NULL;
+  i2cObjectInit(&I2CD0);
+  I2CD0.i2c = I2C0;
+  I2CD0.thread = NULL;
 
   /* Reset I2C */
   hal_lld_peripheral_reset(RESETS_ALLREG_I2C0);
 #endif
 
 #if RP_I2C_USE_I2C1 == TRUE
-  i2cObjectInit(&I2CD2);
-  I2CD2.i2c = I2C1;
-  I2CD2.thread = NULL;
+  i2cObjectInit(&I2CD1);
+  I2CD1.i2c = I2C1;
+  I2CD1.thread = NULL;
 
   /* Reset I2C */
   hal_lld_peripheral_reset(RESETS_ALLREG_I2C1);
@@ -416,7 +416,7 @@ void i2c_lld_start(I2CDriver *i2cp) {
   if (i2cp->state == I2C_STOP) {
 
 #if RP_I2C_USE_I2C0 == TRUE
-    if (&I2CD1 == i2cp) {
+    if (&I2CD0 == i2cp) {
       hal_lld_peripheral_unreset(RESETS_ALLREG_I2C0);
 
       nvicEnableVector(RP_I2C0_IRQ_NUMBER, RP_IRQ_I2C0_PRIORITY);
@@ -424,7 +424,7 @@ void i2c_lld_start(I2CDriver *i2cp) {
 #endif
 
 #if RP_I2C_USE_I2C1 == TRUE
-    if (&I2CD2 == i2cp) {
+    if (&I2CD1 == i2cp) {
       hal_lld_peripheral_unreset(RESETS_ALLREG_I2C1);
 
       nvicEnableVector(RP_I2C1_IRQ_NUMBER, RP_IRQ_I2C1_PRIORITY);
@@ -477,7 +477,7 @@ void i2c_lld_stop(I2CDriver *i2cp) {
         i2c_lld_abort_transmissionS(i2cp);
       }
 #if RP_I2C_USE_I2C0 == TRUE
-    if (&I2CD1 == i2cp) {
+    if (&I2CD0 == i2cp) {
       nvicDisableVector(RP_I2C0_IRQ_NUMBER);
 
       hal_lld_peripheral_reset(RESETS_ALLREG_I2C0);
@@ -485,7 +485,7 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 #endif
 
 #if RP_I2C_USE_I2C1 == TRUE
-    if (&I2CD2 == i2cp) {
+    if (&I2CD1 == i2cp) {
       nvicDisableVector(RP_I2C1_IRQ_NUMBER);
 
       hal_lld_peripheral_reset(RESETS_ALLREG_I2C1);

--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
@@ -171,11 +171,11 @@ struct I2CDriver {
 /*===========================================================================*/
 
 #if (RP_I2C_USE_I2C0 == TRUE) && !defined(__DOXYGEN__)
-extern I2CDriver I2CD1;
+extern I2CDriver I2CD0;
 #endif
 
 #if (RP_I2C_USE_I2C1 == TRUE) && !defined(__DOXYGEN__)
-extern I2CDriver I2CD2;
+extern I2CDriver I2CD1;
 #endif
 
 #ifdef __cplusplus

--- a/testhal/RP/RP2040/RT-RP2040-PICO-I2C-24AA01/main.c
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-I2C-24AA01/main.c
@@ -27,9 +27,6 @@
 #define I2C0_SDA_PIN   12U
 #define I2C0_SCL_PIN   13U
 
-// This is I2C0
-#define I2CN  I2CD1
-
 /*
  * Green LED blinker thread, times are in milliseconds.
  */
@@ -72,7 +69,7 @@ int main(void) {
   I2CConfig i2cConfig = {
     400000, // baudrate
   };
-  i2cStart(&I2CN, &i2cConfig);
+  i2cStart(&I2CD0, &i2cConfig);
 
   /* Set up I2C pins. */
   palSetLineMode(I2C0_SDA_PIN, PAL_MODE_ALTERNATE_I2C | PAL_RP_PAD_PUE | PAL_RP_PAD_DRIVE4);
@@ -96,7 +93,7 @@ int main(void) {
 
   msg_t msg;
 
-  msg = i2cMasterTransmitTimeout(&I2CN, EEPROM_ADDRESS, (uint8_t*)&initData, sizeof(initData), NULL, 0, 1000);
+  msg = i2cMasterTransmitTimeout(&I2CD0, EEPROM_ADDRESS, (uint8_t *)&initData, sizeof(initData), NULL, 0, 1000);
   chprintf((BaseSequentialStream *)&SIOD0, "write: %d\r\n", msg);
   if (msg == MSG_OK) {
 
@@ -104,7 +101,7 @@ int main(void) {
     memset(readData, 0xAA, 10);
 
     // read 4 bytes
-    msg = i2cMasterTransmitTimeout(&I2CN, EEPROM_ADDRESS, (uint8_t*)&target_address, 1, (uint8_t*)&readData, 4, 1000);
+    msg = i2cMasterTransmitTimeout(&I2CD0, EEPROM_ADDRESS, (uint8_t *)&target_address, 1, (uint8_t *)&readData, 4, 1000);
     chprintf((BaseSequentialStream *)&SIOD0, "write and read: %d\r\n", msg);
     chprintf((BaseSequentialStream *)&SIOD0, "data: %d\r\n",
       readData[0] == initData[1] &&
@@ -116,7 +113,7 @@ int main(void) {
     }
 
     // read next 4 bytes
-    msg = i2cMasterReceiveTimeout(&I2CN, EEPROM_ADDRESS, (uint8_t*)&readData[4], 4, 1000);
+    msg = i2cMasterReceiveTimeout(&I2CD0, EEPROM_ADDRESS, (uint8_t *)&readData[4], 4, 1000);
     chprintf((BaseSequentialStream *)&SIOD0, "read: %d\r\n", msg);
     chprintf((BaseSequentialStream *)&SIOD0, "data: %d\r\n",
       readData[4] == initData[5] &&
@@ -126,9 +123,9 @@ int main(void) {
     for (int i = 0; i < 10; i++) {
       chprintf((BaseSequentialStream *)&SIOD0, "[%d]: 0x%X\r\n", i, readData[i]);
     }
-    if (msg = MSG_OK) {
-      uint32_t error = i2cGetErrors(&I2CN);
-      chprintf((BaseSequentialStream *)&SIOD0, "error: %d\r\n", error);
+    if (msg != MSG_OK) {
+        uint32_t error = i2cGetErrors(&I2CD0);
+        chprintf((BaseSequentialStream *)&SIOD0, "error: %d\r\n", error);
     }
   }
 


### PR DESCRIPTION
RP2040 i2c peripherals are numbered starting from zero, therefore the drivers shall follow the same numbering e.g. I2C0 uses the driver I2CD0. This commit fixes the current miss match.