### PR TITLE
HT32: ld: Fix vector table alignment for HT32F523xx

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/ld/HT32F5234x.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/HT32F5234x.ld
@@ -89,5 +89,14 @@ REGION_ALIAS("BSS_RAM", ram0);
 /* RAM region to be used for the default heap.*/
 REGION_ALIAS("HEAP_RAM", ram0);
 
-/* Generic rules inclusion.*/
-INCLUDE rules.ld
+/* Stack rules inclusion.*/
+INCLUDE rules_stacks.ld
+
+/* Code rules inclusion.*/
+INCLUDE HT32F523xx_rules_code.ld
+
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
+
+/* Memory rules inclusion.*/
+INCLUDE rules_memory.ld

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/HT32F5235x.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/HT32F5235x.ld
@@ -89,5 +89,14 @@ REGION_ALIAS("BSS_RAM", ram0);
 /* RAM region to be used for the default heap.*/
 REGION_ALIAS("HEAP_RAM", ram0);
 
-/* Generic rules inclusion.*/
-INCLUDE rules.ld
+/* Stack rules inclusion.*/
+INCLUDE rules_stacks.ld
+
+/* Code rules inclusion.*/
+INCLUDE HT32F523xx_rules_code.ld
+
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
+
+/* Memory rules inclusion.*/
+INCLUDE rules_memory.ld

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/HT32F523xx_rules_code.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/HT32F523xx_rules_code.ld
@@ -1,0 +1,83 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .vectors : ALIGN(512)
+    {
+        __textvectors_base__ = LOADADDR(.vectors);
+        __vectors_base__ = .;
+        KEEP(*(.vectors))
+        __vectors_end__ = .;
+    } > VECTORS_FLASH AT > VECTORS_FLASH_LMA
+
+    .xtors : ALIGN(4)
+    {
+        __init_array_base__ = .;
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        __init_array_end__ = .;
+        __fini_array_base__ = .;
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        __fini_array_end__ = .;
+    } > XTORS_FLASH AT > XTORS_FLASH_LMA
+
+    .text : ALIGN_WITH_INPUT
+    {
+        __text_base__ = .;
+        *(.text)
+        *(.text.*)
+        *(.glue_7t)
+        *(.glue_7)
+        *(.gcc*)
+        __text_end__ = .;
+    } > TEXT_FLASH AT > TEXT_FLASH_LMA
+
+    .rodata : ALIGN(4)
+    {
+        __rodata_base__ = .;
+        *(.rodata)
+        *(.rodata.*)
+        . = ALIGN(4);
+        __rodata_end__ = .;
+    } > RODATA_FLASH AT > RODATA_FLASH_LMA
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .ARM.exidx : {
+        __exidx_base__ = .;
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end__ = .;
+        __exidx_end = .;
+     } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .eh_frame_hdr :
+    {
+        *(.eh_frame_hdr)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .eh_frame : ONLY_IF_RO
+    {
+        *(.eh_frame)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+}


### PR DESCRIPTION
For context, the page size of HT32F523xx is 512 bytes (see page 42 of HT32F52342/HT3252352 User Manual v1.30) and certain bootloaders jump to addresses that are not aligned to 1024 bytes (specified by common rules_code.ld). This commit updates the example ld scripts so that these bootloaders can correctly map the vector table and boot a ChibiOS application firmware.