### PR TITLE
HT32: Add low level driver for WDT

### DIFF
--- a/os/common/ext/CMSIS/HT32/HT32F165x/ht32f165x_reg.h
+++ b/os/common/ext/CMSIS/HT32/HT32F165x/ht32f165x_reg.h
@@ -176,6 +176,7 @@ typedef struct {
 #define CKCU_CKST_PLLST_MASK        (0xfU << 8)
 #define CKCU_LPCR_USBSLEEP          (1U << 8)
 #define CKCU_LPCR_BKISO             (1U << 0)
+#define CKCU_MCUDBGCR_DBWDT         (1U << 3)
 
 // Reset Control Unit
 // /////////////////////////////////////////////////////////////////////////////
@@ -378,6 +379,35 @@ typedef struct {
 
 // Watchdog Timer
 // /////////////////////////////////////////////////////////////////////////////
+typedef struct {
+       uint32_t CR;             //!< 0x000          Control Register
+  __IO uint32_t MR0;            //!< 0x004          Mode Register 0
+  __IO uint32_t MR1;            //!< 0x008          Mode Register 1
+  __IO uint32_t SR;             //!< 0x00C          Status Register
+  __IO uint32_t PR;             //!< 0x010          Protection Register
+  __IO uint32_t CNTR;           //!< 0x014          Counter Register
+  __IO uint32_t CSR;            //!< 0x018          Clock Selection Register
+} WDT_TypeDef;
+
+#define WDT_CR_WDTRS                (1U << 0)
+#define WDT_MR0_WDTEN               (1U << 16)
+#define WDT_MR0_WDTSHLT_MASK        (3U << 14)
+#define WDT_MR0_WDTSHLT_MODE0       (0U << 14)
+#define WDT_MR0_WDTSHLT_MODE1       (1U << 14)
+#define WDT_MR0_WDTSHLT_MODE2       (3U << 14)
+#define WDT_MR0_WDTRSTEN            (1U << 13)
+#define WDT_MR0_WDTFIEN             (1U << 12)
+#define WDT_MR0_WDTV_MASK           (0xfffU << 0)
+#define WDT_MR1_WPSC_MASK           (7U << 12)
+#define WDT_MR1_WDTD_MASK           (0xfffU << 0)
+#define WDT_SR_WDTERR               (1U << 1)
+#define WDT_SR_WDTUF                (1U << 0)
+#define WDT_PR_PROTECT_STATUS       (1U << 0)
+#define WDT_CNTR_WDTCNT_MASK        (0xfffU << 0)
+#define WDT_CSR_WDTLOCK             (1U << 4)
+#define WDT_CSR_WDTSRC              (1U << 0)
+#define WDT_CSR_WDTSRC_LSE          (1U << 0)
+#define WDT_CSR_WDTSRC_LSI          (0U << 0)
 
 // I2C
 // /////////////////////////////////////////////////////////////////////////////

--- a/os/common/ext/CMSIS/HT32/HT32F523xx/ht32f523x2_reg.h
+++ b/os/common/ext/CMSIS/HT32/HT32F523xx/ht32f523x2_reg.h
@@ -171,6 +171,7 @@ typedef struct {
 #define CKCU_CKST_PLLST_MASK        (0xfU << 8)
 #define CKCU_LPCR_USBSLEEP          (1U << 8)
 #define CKCU_LPCR_BKISO             (1U << 0)
+#define CKCU_MCUDBGCR_DBWDT         (1U << 3)
 
 // Reset Control Unit
 // /////////////////////////////////////////////////////////////////////////////
@@ -360,6 +361,35 @@ typedef struct {
 
 // Watchdog Timer
 // /////////////////////////////////////////////////////////////////////////////
+typedef struct {
+       uint32_t CR;             //!< 0x000          Control Register
+  __IO uint32_t MR0;            //!< 0x004          Mode Register 0
+  __IO uint32_t MR1;            //!< 0x008          Mode Register 1
+  __IO uint32_t SR;             //!< 0x00C          Status Register
+  __IO uint32_t PR;             //!< 0x010          Protection Register
+  __IO uint32_t CNTR;           //!< 0x014          Counter Register
+  __IO uint32_t CSR;            //!< 0x018          Clock Selection Register
+} WDT_TypeDef;
+
+#define WDT_CR_WDTRS                (1U << 0)
+#define WDT_MR0_WDTEN               (1U << 16)
+#define WDT_MR0_WDTSHLT_MASK        (3U << 14)
+#define WDT_MR0_WDTSHLT_MODE0       (0U << 14)
+#define WDT_MR0_WDTSHLT_MODE1       (1U << 14)
+#define WDT_MR0_WDTSHLT_MODE2       (3U << 14)
+#define WDT_MR0_WDTRSTEN            (1U << 13)
+#define WDT_MR0_WDTFIEN             (1U << 12)
+#define WDT_MR0_WDTV_MASK           (0xfffU << 0)
+#define WDT_MR1_WPSC_MASK           (7U << 12)
+#define WDT_MR1_WDTD_MASK           (0xfffU << 0)
+#define WDT_SR_WDTERR               (1U << 1)
+#define WDT_SR_WDTUF                (1U << 0)
+#define WDT_PR_PROTECT_STATUS       (1U << 0)
+#define WDT_CNTR_WDTCNT_MASK        (0xfffU << 0)
+#define WDT_CSR_WDTLOCK             (1U << 4)
+#define WDT_CSR_WDTSRC              (1U << 0)
+#define WDT_CSR_WDTSRC_LSE          (1U << 0)
+#define WDT_CSR_WDTSRC_LSI          (0U << 0)
 
 // I2C
 // /////////////////////////////////////////////////////////////////////////////

--- a/os/hal/ports/HT32/HT32F165x/platform.mk
+++ b/os/hal/ports/HT32/HT32F165x/platform.mk
@@ -28,6 +28,7 @@ include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/SPIv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/GPIOv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/USBv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/USART_F165x/driver.mk
+include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/WDTv1/driver.mk
 
 
 # Shared variables

--- a/os/hal/ports/HT32/HT32F523xx/platform.mk
+++ b/os/hal/ports/HT32/HT32F523xx/platform.mk
@@ -28,6 +28,7 @@ include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/SPIv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/GPIOv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/USBv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/USART_F5xxxx/driver.mk
+include $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/WDTv1/driver.mk
 
 
 # Shared variables

--- a/os/hal/ports/HT32/LLD/WDTv1/driver.mk
+++ b/os/hal/ports/HT32/LLD/WDTv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_WDG TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/WDTv1/hal_wdg_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/WDTv1/hal_wdg_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/HT32/LLD/WDTv1

--- a/os/hal/ports/HT32/LLD/WDTv1/hal_wdg_lld.c
+++ b/os/hal/ports/HT32/LLD/WDTv1/hal_wdg_lld.c
@@ -1,0 +1,131 @@
+/*
+    Copyright (C) 2022 Hansem Ro <hansemro@outlook.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    WDT/hal_wdg_lld.c
+ * @brief   WDG Driver subsystem low level driver source.
+ *
+ * @addtogroup WDG
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_WDG == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+#if HT32_WDG_USE_WDT || defined(__DOXYGEN__)
+WDGDriver WDGD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level WDG driver initialization.
+ *
+ * @notapi
+ */
+void wdg_lld_init(void) {
+#if HT32_WDG_USE_WDT
+    WDGD1.state = WDG_STOP;
+    WDGD1.wdg   = WDT;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the WDG peripheral.
+ *
+ * @param[in] wdgp      pointer to the @p WDGDriver object
+ *
+ * @notapi
+ */
+void wdg_lld_start(WDGDriver *wdgp) {
+    if (~(wdgp->wdg->CSR & WDT_CSR_WDTLOCK)) {
+        /* Enable WDT clock and disable write protect lock.*/
+        CKCU->APBCCR1 |= CKCU_APBCCR1_WDTREN;
+        wdgp->wdg->PR = WDT_DISABLE_PROTECT_KEY;
+
+        /* Write configuration.*/
+        wdgp->wdg->MR0 = wdgp->config->mr0 & ~WDT_MR0_WDTEN;
+        wdgp->wdg->MR1 = wdgp->config->mr1;
+#if HT32_WDG_USE_LSE == TRUE
+        wdgp->wdg->CSR = WDT_CSR_WDTSRC_LSE;
+#else
+        wdgp->wdg->CSR = WDT_CSR_WDTSRC_LSI;
+#endif
+        CKCU->MCUDBGCR &= ~CKCU_MCUDBGCR_DBWDT;
+        CKCU->MCUDBGCR |= wdgp->config->dbwdt;
+
+        /* Start.*/
+        wdgp->wdg->MR0 |= WDT_MR0_WDTEN;
+
+        /* Enable write protect lock.*/
+        wdgp->wdg->PR = 0;
+    }
+}
+
+/**
+ * @brief   Deactivates the WDG peripheral.
+ *
+ * @param[in] wdgp      pointer to the @p WDGDriver object
+ *
+ * @notapi
+ */
+void wdg_lld_stop(WDGDriver *wdgp) {
+    if (wdgp->state == WDG_READY) {
+        /* Disable write protect lock and stop WDT.*/
+        wdgp->wdg->PR = WDT_DISABLE_PROTECT_KEY;
+        wdgp->wdg->MR0 &= ~WDT_MR0_WDTEN;
+        /* Enable write protect lock.*/
+        wdgp->wdg->PR = 0;
+    }
+}
+
+/**
+ * @brief   Reloads WDG's counter.
+ *
+ * @param[in] wdgp      pointer to the @p WDGDriver object
+ *
+ * @notapi
+ */
+void wdg_lld_reset(WDGDriver * wdgp) {
+    wdgp->wdg->CR = (WDT_RELOAD_KEY | WDT_CR_WDTRS);
+}
+
+#endif /* HAL_USE_WDG == TRUE */
+
+/** @} */

--- a/os/hal/ports/HT32/LLD/WDTv1/hal_wdg_lld.h
+++ b/os/hal/ports/HT32/LLD/WDTv1/hal_wdg_lld.h
@@ -1,0 +1,148 @@
+/*
+    ChibiOS - Copyright (C) 2006..2020 Giovanni Di Sirio
+            - Copyright (C) 2022 Hansem Ro <hansemro@outlook.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    WDT/hal_wdg_lld.h
+ * @brief   WDG Driver subsystem low level driver header.
+ *
+ * @addtogroup WDG
+ * @{
+ */
+
+#ifndef HAL_WDG_LLD_H
+#define HAL_WDG_LLD_H
+
+#if (HAL_USE_WDG == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+//Watchdog register keys
+#define WDT_RELOAD_KEY                      (0x5af0U << 16)
+#define WDT_DISABLE_PROTECT_KEY             0x35ca
+
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   WDT driver enable switch.
+ * @details If set to @p TRUE the support for WDT is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(HT32_WDG_USE_WDT) || defined(__DOXYGEN__)
+#define HT32_WDG_USE_WDT                    FALSE
+#endif
+
+#if HT32_WDG_USE_LSE != TRUE
+#define HT32_WDG_USE_LSI                    TRUE
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if !HT32_WDG_USE_WDT
+#error "WDG driver activated but no WDT peripheral assigned"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Type of a structure representing an WDG driver.
+ */
+typedef struct WDGDriver WDGDriver;
+
+/**
+ * @brief   Driver configuration structure.
+ * @note    It could be empty on some architectures.
+ */
+typedef struct {
+  /**
+   * @brief   Configuration of the WDTMR0 register.
+   * @details See the HT32 reference manual for details.
+   */
+  uint32_t    mr0;
+  /**
+   * @brief   Configuration of the WDTMR1 register.
+   * @details See the HT32 reference manual for details.
+   */
+  uint32_t    mr1;
+  /**
+   * @brief   Configuration of the DBWDT bit in CKCU:MCUDBGCR register.
+   * @details See the HT32 reference manual for details.
+   */
+  bool        dbwdt;
+} WDGConfig;
+
+/**
+ * @brief   Structure representing an WDG driver.
+ */
+struct WDGDriver {
+  /**
+   * @brief   Driver state.
+   */
+  wdgstate_t                state;
+  /**
+   * @brief   Current configuration data.
+   */
+  const WDGConfig           *config;
+  /* End of the mandatory fields.*/
+  /**
+   * @brief   Pointer to the WDT registers block.
+   */
+  WDT_TypeDef               *wdg;
+};
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if HT32_WDG_USE_WDT && !defined(__DOXYGEN__)
+extern WDGDriver WDGD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void wdg_lld_init(void);
+  void wdg_lld_start(WDGDriver *wdgp);
+  void wdg_lld_stop(WDGDriver *wdgp);
+  void wdg_lld_reset(WDGDriver *wdgp);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_WDG == TRUE */
+
+#endif /* HAL_WDG_LLD_H */
+
+/** @} */


### PR DESCRIPTION
This change introduces basic WDT HAL driver functionality (start, stop, reload) for HT32F165x and HT32F523xx.

This has been tested on HT32F1654 and HT32F52352 targets.