### PR TITLE
RP2040: Init buffer position in adc_lld_start_conversion()

### DIFF
--- a/os/hal/ports/RP/LLD/ADCv1/hal_adc_lld.c
+++ b/os/hal/ports/RP/LLD/ADCv1/hal_adc_lld.c
@@ -260,6 +260,11 @@ void adc_lld_stop(ADCDriver *adcp) {
  */
 void adc_lld_start_conversion(ADCDriver *adcp) {
 
+  /* Initialize the buffer position. */
+  adcp->current_buffer_position = 0;
+  adcp->current_channel = 0;
+  adcp->current_iteration = 0;
+
   /* Clear error flags. */
   adcp->adc->CLR.CS = ADC_CS_ERR_STICKY;
 


### PR DESCRIPTION
The RP2040 ADC driver was initializing `adcp->current_buffer_position` and friends only in `adc_lld_start()`, therefore a simple `adcConvert()` call did not work when called a second time (only the circular mode worked, because the interrupt handler was resetting the position in that case after the whole buffer was filled).  Reset the buffer position variables in `adc_lld_start_conversion()` to make the one-time conversion work.

This fix is needed to make the ADC support in QMK work (the QMK code does not use any fancy modes except blocking `adcConvert()` with a single channel and a single sample).