### PR TITLE
HT32: SPI: avoid write collisions when SPI FIFO is disabled

### DIFF
--- a/os/common/ext/CMSIS/HT32/HT32F165x/ht32f165x_reg.h
+++ b/os/common/ext/CMSIS/HT32/HT32F165x/ht32f165x_reg.h
@@ -495,6 +495,7 @@ typedef struct {
 #define SPI_CR1_FORMAT_MODE2        (0x6U << 8)
 #define SPI_CR1_FORMAT_MODE3        (0x5U << 8)
 #define SPI_IER_RXBNEIEN            (1U << 2)
+#define SPI_IER_TXEIEN              (1U << 1)
 #define SPI_IER_TXBEIEN             (1U << 0)
 #define SPI_SR_RXBNE                (1U << 2)
 #define SPI_SR_TXE                  (1U << 1)

--- a/os/common/ext/CMSIS/HT32/HT32F523xx/ht32f523x2_reg.h
+++ b/os/common/ext/CMSIS/HT32/HT32F523xx/ht32f523x2_reg.h
@@ -477,6 +477,7 @@ typedef struct {
 #define SPI_CR1_FORMAT_MODE2        (0x6U << 8)
 #define SPI_CR1_FORMAT_MODE3        (0x5U << 8)
 #define SPI_IER_RXBNEIEN            (1U << 2)
+#define SPI_IER_TXEIEN              (1U << 1)
 #define SPI_IER_TXBEIEN             (1U << 0)
 #define SPI_SR_RXBNE                (1U << 2)
 #define SPI_SR_TXE                  (1U << 1)


### PR DESCRIPTION
This improves SPI transmission reliability when SPI FIFO is not used. Without this change, I experienced hangups when frequently transmitting data to SPI flash.

For reference:
When SPI FIFO is enabled, a write collision occurs when writing to SPIDR register while both the TX buffer and SPI shift register are full (which is when TXE flag is not asserted).

When SPI FIFO is disabled, a write collision occurs when writing to SPIDR register while both TX FIFO and TX shift register are full. Here, the TXBE flag remains appropriate since it is used to check when TX buffer is empty and when the TX FIFO is below a set threshold value.