### PR TITLE
[RP2040] Fix host remote wakeup

### DIFF
--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.c
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.c
@@ -426,15 +426,22 @@ OSAL_IRQ_HANDLER(RP_USBCTRL_IRQ_HANDLER) {
     _usb_wakeup(usbp);
   }
 
-#if RP_USB_USE_SOF_INTR == TRUE
   /* SOF handling.*/
   if (ints & USB_INTS_DEV_SOF) {
+    /* SOF interrupt was used to detect resume of the USB bus after issuing a
+     * remote wake up of the host, therefore we disable it again. */
+    if (usbp->config->sof_cb == NULL) {
+      USB->INTE &= ~USB_INTE_DEV_SOF;
+    }
+    if (usbp->state == USB_SUSPENDED) {
+      _usb_wakeup(usbp);
+    }
+
     _usb_isr_invoke_sof_cb(usbp);
 
     /* Clear SOF flag by reading SOF_RD */
     (void)USB->SOFRD;
   }
-#endif /* RP_USB_USE_SOF_INTR */
 
   /* Endpoint events handling.*/
   if (ints & USB_INTS_BUFF_STATUS) {
@@ -534,12 +541,14 @@ void usb_lld_start(USBDriver *usbp) {
                   USB_INTE_DEV_SUSPEND |
                   USB_INTE_BUS_RESET |
                   USB_INTE_BUFF_STATUS;
+
+      if (usbp->config->sof_cb != NULL) {
+        USB->INTE |= USB_INTE_DEV_SOF;
+      }
+
 #if RP_USB_USE_ERROR_DATA_SEQ_INTR == TRUE
       USB->INTE |= USB_INTE_ERROR_DATA_SEQ;
 #endif /* RP_USB_USE_ERROR_DATA_SEQ_INTR */
-#if RP_USB_USE_SOF_INTR == TRUE
-      USB->INTE |= USB_INTE_DEV_SOF;
-#endif /* RP_USB_USE_SOF_INTR */
 
       /* Enable USB interrupt. */
       nvicEnableVector(RP_USBCTRL_IRQ_NUMBER, RP_IRQ_USB0_PRIORITY);

--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
@@ -6,7 +6,7 @@
     You may obtain a copy of the License at
 
         http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -86,13 +86,6 @@
 
 #if RP_USE_EXTERNAL_VBUS_DETECT == TRUE
 extern bool usb_vbus_detect(void);
-#endif
-
-/**
- * @brief Enables the SOF interrupt.
- */
-#if !defined(RP_USB_USE_SOF_INTR) || defined(__DOXYGEN__)
-#define RP_USB_USE_SOF_INTR                 FALSE
 #endif
 
 /**
@@ -438,6 +431,9 @@ struct USBDriver {
  */
 #define usb_lld_wakeup_host(usbp)                                           \
   do {                                                                      \
+    /* remote wakeup doesn't trigger the wakeup interrupt, therefore        \
+     * we use the SOF interrupt to detect resume of the bus. */             \
+    USB->INTE |= USB_INTE_DEV_SOF;                                          \
     USB->SET.SIECTRL = USB_SIE_CTRL_RESUME;                                 \
   } while (false)
 

--- a/testhal/RP/RP2040/RT-RP2040-PICO-ADC/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-ADC/cfg/mcuconf.h
@@ -90,7 +90,6 @@
 #define RP_USB_USE_USBD1                    FALSE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 TRUE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      TRUE
 
 /*

--- a/testhal/RP/RP2040/RT-RP2040-PICO-HID/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-HID/cfg/mcuconf.h
@@ -90,7 +90,6 @@
 #define RP_USB_USE_USBD0                    TRUE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 FALSE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      TRUE
 
 #endif /* MCUCONF_H */

--- a/testhal/RP/RP2040/RT-RP2040-PICO-I2C-24AA01/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-I2C-24AA01/cfg/mcuconf.h
@@ -92,7 +92,6 @@
 #define RP_USB_USE_USBD1                    FALSE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 TRUE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      TRUE
 
 /*

--- a/testhal/RP/RP2040/RT-RP2040-PICO-SERIAL/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-SERIAL/cfg/mcuconf.h
@@ -90,7 +90,6 @@
 #define RP_USB_USE_USBD0                    TRUE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 TRUE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      TRUE
 
 #endif /* MCUCONF_H */


### PR DESCRIPTION
Previously a device which attempted to wake a sleeping host would not be notified about the resumed operation and thus stay suspended for ever. This is due to the fact that only a host initiated wakeup would trigger a interrupt. As a workaround we use the SOF interrupt which is enabled for a short amount of time to detect the resume of the bus and wakeup the device.