### PR TITLE
SN32: PAL and GPT hotfixes

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/CT/hal_gpt_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/CT/hal_gpt_lld.h
@@ -139,7 +139,7 @@ typedef uint32_t gptfreq_t;
 /**
  * @brief   GPT counter type.
  */
-typedef uint16_t gptcnt_t;
+typedef uint32_t gptcnt_t;
 
 /**
  * @brief   Driver configuration structure.

--- a/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.c
@@ -103,43 +103,40 @@ void _pal_lld_setpadmode(ioportid_t port,
                            uint32_t pad,
                            iomode_t mode) {
 
-    switch (mode)
-    {
+  switch (mode) {
 
-    case PAL_MODE_UNCONNECTED:
+    case PAL_MODE_INPUT_ANALOG:
+        //set MODE as INPUT
+        port->MODE &= ~(1 << pad);
+        // disable pull up resistor
+        // disable Schmitt trigger
+        // keep DATA low
+        port->CFG |= (3 << (pad * 2));
         break;
 
     case PAL_MODE_INPUT:
+        //set MODE as INPUT
         port->MODE &= ~(1 << pad);
+        // disable pull up resistor
+        // enable Schmitt trigger
+        port->CFG |= (2 << (pad * 2));
         break;
 
     case PAL_MODE_INPUT_PULLUP:
+        //set MODE as INPUT
         port->MODE &= ~(1 << pad);
-        port->CFG &= ~(3 << (pad * 2));
-        // port->BSET = (1 << pad); // High 1
-        break;
-
-    case PAL_MODE_INPUT_PULLDOWN:
-        port->MODE &= ~(1 << pad);
-        port->CFG &= ~(3 << (pad * 2));
-        // port->BCLR = (1 << pad); // Low 0
-        break;
-
-    case PAL_MODE_INPUT_ANALOG:
-        port->MODE &= ~(1 << pad);
+        //enable pull up resistor
         port->CFG &= ~(3 << (pad * 2));
         break;
 
     case PAL_MODE_OUTPUT_PUSHPULL:
+        //set MODE as OUTPUT
         port->MODE |= (1 << pad);
-        break;
-
-    case 7:
         break;
 
     default:
         break;
-    }
+  }
 }
 
 #endif /* HAL_USE_PAL */

--- a/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.h
@@ -76,10 +76,22 @@
 #define PAL_WHOLE_PORT ((ioportmask_t)0xFFFF)
 /** @} */
 
-// GPIO0 = 40044000
-// pad = 5
+/**
+ * @name    Standard I/O mode flags
+ * @{
+ */
+#undef PAL_MODE_RESET
+#undef PAL_MODE_UNCONNECTED
 
-// line = 40044005
+/**
+ * @brief   Implemented as input.
+ */
+#define PAL_MODE_RESET                  PAL_MODE_INPUT
+
+/**
+ * @brief   Implemented as input with DATA keep low.
+ */
+#define PAL_MODE_UNCONNECTED            PAL_MODE_INPUT_ANALOG
 
 /**
  * @name    Line handling macros

--- a/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.h
@@ -356,7 +356,10 @@ typedef SN_GPIO0_Type * ioportid_t;
  *
  * @notapi
  */
-#define pal_lld_writepad(port, pad, bit) ((port)->DATA = (bit << pad))
+#define pal_lld_writepad(port, pad, bit) do {    \
+    if(bit > PAL_LOW) pal_lld_setpad(port, pad); \
+    else pal_lld_clearpad(port, pad);            \
+} while(0)
 
 /**
  * @brief   Sets a pad logical state to @p PAL_HIGH.


### PR DESCRIPTION
- tidy up the PAL modes definition and handling
- correct `pal_lld_writepad` behavior
- cleanup GPT configuration