### PR TITLE
Fix unused parameter in EEPROM driver

### DIFF
--- a/os/hal/src/hal_eeprom.c
+++ b/os/hal/src/hal_eeprom.c
@@ -136,7 +136,7 @@ size_t EepromWriteWord(EepromFileStream *efs, uint32_t data) {
 }
 
 msg_t eepfs_getsize(void *ip, fileoffset_t *offset) {
-
+  (void)offset;
   uint32_t h, l;
 
   osalDbgCheck((ip != NULL) && (((EepromFileStream *)ip)->vmt != NULL) &&
@@ -148,7 +148,7 @@ msg_t eepfs_getsize(void *ip, fileoffset_t *offset) {
 }
 
 msg_t eepfs_getposition(void *ip, fileoffset_t *offset) {
-
+  (void)offset;
   osalDbgCheck((ip != NULL) && (((EepromFileStream *)ip)->vmt != NULL));
 
   return ((EepromFileStream *)ip)->position;


### PR DESCRIPTION
GCC fails to build for me, because I have warnings as errors, and warnings for unused parameters.
This fixes the build of the EEPROM driver module.