### PR TITLE
[RP2040] Fix null dereference in `usb_lld_disable_endpoints`

### DIFF
--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.c
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.c
@@ -153,31 +153,6 @@ static void reset_ep0(USBDriver *usbp) {
   usbp->epc[0]->in_state->stalled = false;
 }
 
-#if 0
-/**
- * @brief   Reset specified endpoint.
- */
-static void reset_endpoint(USBDriver *usbp, usbep_t ep, bool is_in) {
-  const USBEndpointConfig *epcp = usbp->epc[ep];
-
-  if (is_in) {
-    USBInEndpointState *in_state = epcp->in_state;
-    if (in_state) {
-      in_state->active = false;
-      in_state->stalled = false;
-      in_state->next_pid = 0U;
-    }
-  } else {
-    USBOutEndpointState *out_state = epcp->out_state;
-    if (out_state) {
-      out_state->active = false;
-      out_state->stalled = false;
-      out_state->next_pid = 0U;
-    }
-  }
-}
-#endif
-
 /**
  * @brief   Prepare buffer for receiving data.
  */
@@ -689,16 +664,8 @@ void usb_lld_init_endpoint(USBDriver *usbp, usbep_t ep) {
  * @notapi
  */
 void usb_lld_disable_endpoints(USBDriver *usbp) {
-  /* Ignore zero */
   for (uint8_t ep = 1; ep <= USB_ENDOPOINTS_NUMBER; ep++) {
-    usbp->epc[ep]->in_state->active = false;
-    usbp->epc[ep]->in_state->stalled = false;
-    usbp->epc[ep]->in_state->next_pid = 0;
     EP_CTRL(ep).IN &= ~USB_EP_EN;
-
-    usbp->epc[ep]->out_state->active = false;
-    usbp->epc[ep]->out_state->stalled = false;
-    usbp->epc[ep]->out_state->next_pid = 0;
     EP_CTRL(ep).OUT &= ~USB_EP_EN;
   }
 }


### PR DESCRIPTION
`usb_lld_disable_endpoints` is called by `usbDisableEndpointsI`, which already sets all endpoint configurations to [`NULL` before](https://github.com/ChibiOS/ChibiOS/blob/e8243bdb2d066dc4f27dac8eb942c286464d8688/os/hal/src/hal_usb.c#L449). This will always lead to a hardfault. The fix is simple though, just remove the interaction.