### PR TITLE
[RP2040] usb: fix usb_lld_get_status functions

### DIFF
--- a/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
+++ b/os/hal/ports/RP/LLD/USBDv1/hal_usb_lld.h
@@ -132,14 +132,6 @@ typedef struct {
    */
   size_t                        txlast;
   /**
-   * @brief   Endpoint is active.
-   */
-  bool                          active;
-  /**
-   * @brief   Endpoint is stalled.
-   */
-  bool                          stalled;
-  /**
    * @brief   Data PID used by next transfer.
    */
   uint8_t                       next_pid;
@@ -180,14 +172,6 @@ typedef struct {
    * @brief   Number of packets to receive.
    */
   uint16_t                      rxpkts;
-  /**
-   * @brief   Endpoint is active.
-   */
-  bool                          active;
-  /**
-   * @brief   Endpoint is stalled.
-   */
-  bool                          stalled;
   /**
    * @brief   Data PID used by next transfer.
    */


### PR DESCRIPTION
This fixes the USB endpoint get status functions; previously the (wrong) assumptions were the following:

* `active` was toggled depending on whether a transaction was currently ongoing on the endpoint e.g., if the endpoint is "busy." What is actually requested is if this endpoint is enabled at all. Therefore, we check the `enabled` flag in the endpoint control register.
* `stalled` was toggled by the device itself, although this property is completely controlled by the host via the SET and CLEAR feature requests. Therefore, we check the `stalled` flag in the endpoint buffer control register.