### PR TITLE
Add missing define to hal_usbh_lld

### DIFF
--- a/os/hal/ports/STM32/LLD/USBHv1/hal_usbh_lld.c
+++ b/os/hal/ports/STM32/LLD/USBHv1/hal_usbh_lld.c
@@ -82,6 +82,9 @@
 #if !defined(STM32_OTG2_USE_HS)
 #define STM32_OTG2_USE_HS FALSE
 #endif
+#if !defined(STM32_OTG1_USE_ULPI)
+#define STM32_OTG1_USE_ULPI FALSE
+#endif
 #if !defined(STM32_OTG2_USE_ULPI)
 #define STM32_OTG2_USE_ULPI FALSE
 #endif


### PR DESCRIPTION
Without this define here, when setting 

`#define STM32_USBH_USE_OTG2                 TRUE`

the build will fail with:

```text
ChibiOS-Contrib/os/hal/ports/STM32/LLD/USBHv1/hal_usbh_lld.c:1611:6: error: "STM32_OTG1_USE_ULPI" is not defined, evaluates to 0 [-Werror=undef]
[build]  1611 | #if !STM32_OTG1_USE_ULPI && !STM32_OTG2_USE_ULPI
[build]       |      ^~~~~~~~~~~~~~~~~~~
```

Because `STM32_OTG1_USE_ULPI` is not defined (this is withe the build option to treat warnings as errors).