### PR TITLE
Fix I2C Fallback inclusion and build on more platforms

### DIFF
--- a/os/hal/ports/KINETIS/LLD/I2Cv1/driver.mk
+++ b/os/hal/ports/KINETIS/LLD/I2Cv1/driver.mk
@@ -1,9 +1,21 @@
-ifeq ($(USE_SMART_BUILD),yes)
-ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
-PLATFORMSRC_CONTRIB += ${CHIBIOS_CONTRIB}/os/hal/ports/KINETIS/LLD/I2Cv1/hal_i2c_lld.c
-endif
+ifeq ($(USE_HAL_I2C_FALLBACK),yes)
+  # Fallback SW driver.
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC_CONTRIB += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC_CONTRIB += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+  endif
+  PLATFORMINC_CONTRIB += $(CHIBIOS)/os/hal/lib/fallback/I2C
 else
-PLATFORMSRC_CONTRIB += ${CHIBIOS_CONTRIB}/os/hal/ports/KINETIS/LLD/I2Cv1/hal_i2c_lld.c
-endif
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC_CONTRIB += ${CHIBIOS_CONTRIB}/os/hal/ports/KINETIS/LLD/I2Cv1/hal_i2c_lld.c
+    endif
+  else
+      PLATFORMSRC_CONTRIB += ${CHIBIOS_CONTRIB}/os/hal/ports/KINETIS/LLD/I2Cv1/hal_i2c_lld.c
+  endif
 
-PLATFORMINC_CONTRIB += ${CHIBIOS_CONTRIB}/os/hal/ports/KINETIS/LLD/I2Cv1
+  PLATFORMINC_CONTRIB += ${CHIBIOS_CONTRIB}/os/hal/ports/KINETIS/LLD/I2Cv1
+endif

--- a/os/hal/ports/NUMICRO/LLD/I2Cv1/driver.mk
+++ b/os/hal/ports/NUMICRO/LLD/I2Cv1/driver.mk
@@ -1,9 +1,21 @@
-ifeq ($(USE_SMART_BUILD),yes)
-ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
-PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/NUMICRO/LLD/I2Cv1/hal_i2c_lld.c
-endif
+ifeq ($(USE_HAL_I2C_FALLBACK),yes)
+  # Fallback SW driver.
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+  endif
+  PLATFORMINC += $(CHIBIOS)/os/hal/lib/fallback/I2C
 else
-PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/NUMICRO/LLD/I2Cv1/hal_i2c_lld.c
-endif
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/NUMICRO/LLD/I2Cv1/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/NUMICRO/LLD/I2Cv1/hal_i2c_lld.c
+  endif
 
-PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/NUMICRO/LLD/I2Cv1
+  PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/NUMICRO/LLD/I2Cv1
+endif

--- a/os/hal/ports/RP/LLD/I2Cv1/driver.mk
+++ b/os/hal/ports/RP/LLD/I2Cv1/driver.mk
@@ -1,9 +1,21 @@
-ifeq ($(USE_SMART_BUILD),yes)
-ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
-PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
-endif
+ifeq ($(USE_HAL_I2C_FALLBACK),yes)
+  # Fallback SW driver.
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+  endif
+  PLATFORMINC += $(CHIBIOS)/os/hal/lib/fallback/I2C
 else
-PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
-endif
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+  endif
 
-PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/RP/LLD/I2Cv1
+  PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/RP/LLD/I2Cv1
+endif

--- a/os/hal/ports/TIVA/LLD/I2C/driver.mk
+++ b/os/hal/ports/TIVA/LLD/I2C/driver.mk
@@ -1,9 +1,21 @@
-ifeq ($(USE_SMART_BUILD),yes)
-ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
-PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/TIVA/LLD/I2C/hal_i2c_lld.c
-endif
+ifeq ($(USE_HAL_I2C_FALLBACK),yes)
+  # Fallback SW driver.
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+  endif
+  PLATFORMINC += $(CHIBIOS)/os/hal/lib/fallback/I2C
 else
-PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/TIVA/LLD/I2C/hal_i2c_lld.c
-endif
+  ifeq ($(USE_SMART_BUILD),yes)
+    ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+      PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/TIVA/LLD/I2C/hal_i2c_lld.c
+    endif
+  else
+    PLATFORMSRC += $(CHIBIOS_CONTRIB)/os/hal/ports/TIVA/LLD/I2C/hal_i2c_lld.c
+  endif
 
-PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/TIVA/LLD/I2C
+  PLATFORMINC += $(CHIBIOS_CONTRIB)/os/hal/ports/TIVA/LLD/I2C
+endif

--- a/os/hal/ports/WB32/LLD/I2Cv1/driver.mk
+++ b/os/hal/ports/WB32/LLD/I2Cv1/driver.mk
@@ -2,12 +2,12 @@ ifeq ($(USE_HAL_I2C_FALLBACK),yes)
   # Fallback SW driver.
   ifeq ($(USE_SMART_BUILD),yes)
     ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
-      PLATFORMSRC_CONTRIB += $(CHIBIOS_CONTRIB)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+      PLATFORMSRC_CONTRIB += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
     endif
   else
-    PLATFORMSRC_CONTRIB += $(CHIBIOS_CONTRIB)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+    PLATFORMSRC_CONTRIB += $(CHIBIOS)/os/hal/lib/fallback/I2C/hal_i2c_lld.c
   endif
-  PLATFORMINC_CONTRIB += $(CHIBIOS_CONTRIB)/os/hal/lib/fallback/I2C
+  PLATFORMINC_CONTRIB += $(CHIBIOS)/os/hal/lib/fallback/I2C
 else
   # Default HW driver.
   ifeq ($(USE_SMART_BUILD),yes)


### PR DESCRIPTION
Some platforms implementations were missing the relevant inclusion logic for the software I2C driver. Fix them