### PR TITLE
SN32 USB LLD: flexibility updates

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
@@ -526,7 +526,7 @@ void usb_lld_stop(USBDriver *usbp) {
  */
 void usb_lld_reset(USBDriver *usbp) {
     /* Post reset initialization.*/
-    SN32_USB->INSTSC = (0xFFFFFFFF);
+    SN32_USB->INSTSC = (UINT32_MAX);
 
     /* Set the address to zero during enumeration.*/
     usbp->address = 0;

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
@@ -460,6 +460,9 @@ void usb_lld_start(USBDriver *usbp) {
       /* Powers up the transceiver while holding the USB in reset state.*/
       SN32_USB->SGCTL = (mskBUS_DRVEN|mskBUS_J_STATE);
       SN32_USB->CFG = (mskVREG33_EN|mskPHY_EN|mskDPPU_EN|mskSIE_EN|mskESD_EN);
+#   if defined(SN32F240)
+      SN32_USB->CFG |= (mskUSBRAM_EN|mskVREG33DIS_EN);
+#   endif
       /* Set up hardware configuration.*/
       SN32_USB->PHYPRM = 0x80000000;
       SN32_USB->PHYPRM2 = 0x00004004;

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
@@ -546,7 +546,7 @@ void usb_lld_reset(USBDriver *usbp) {
  */
 void usb_lld_set_address(USBDriver *usbp) {
 
-    SN32_USB->ADDR = usbp->address & 0x7F;
+    SN32_USB->ADDR = usbp->address & mskUADDR;
 }
 
 /**

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.h
@@ -83,6 +83,13 @@
 #if !defined(SN32_USB_HOST_WAKEUP_DURATION) || defined(__DOXYGEN__)
 #define SN32_USB_HOST_WAKEUP_DURATION        2
 #endif
+
+/**
+ * @brief   USB driver using SRAM direct.
+ */
+#if !defined(SN32_USB_DIRECT_SRAM) || defined(__DOXYGEN__)
+#define SN32_USB_DIRECT_SRAM                FALSE
+#endif
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
@@ -34,13 +34,16 @@
  */
 #define HAL_MAX_ENDPOINTS                  7
 #if (defined(SN32F240B) || defined(SN32F260))
-#define USB_ENDPOINTS_NUMBER               4
-#define SN32_USB_PMA_SIZE                  256
-#elif (defined(SN32F280) || defined(SN32F290))
-#define USB_ENDPOINTS_NUMBER               6
-#define SN32_USB_PMA_SIZE                  512
+#   define USB_ENDPOINTS_NUMBER               4
+#   define SN32_USB_PMA_SIZE                  256
+#elif defined(SN32F240C)
+#   define USB_ENDPOINTS_NUMBER               HAL_MAX_ENDPOINTS
+#   define SN32_USB_PMA_SIZE                  512
+#elif (defined(SN32F240) || defined(SN32F280) || defined(SN32F290))
+#   define USB_ENDPOINTS_NUMBER               6
+#   define SN32_USB_PMA_SIZE                  512
 #else
-#error "USB driver not supported in the selected device"
+#   error "USB driver not supported in the selected device"
 #endif
 
 /**

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
@@ -48,25 +48,25 @@
  */
   typedef struct {
   volatile uint32_t INTEN;                          /*!< (@ 0x00000000) Offset:0x00 USB Interrupt Enable Register                  */
-  volatile uint32_t INSTS;                          /*!< (@ 0x00000004) Offset:0x04 USB Interrupt Event Status Register            */
+  volatile const uint32_t INSTS;                    /*!< (@ 0x00000004) Offset:0x04 USB Interrupt Event Status Register            */
   volatile uint32_t INSTSC;                         /*!< (@ 0x00000008) Offset:0x08 USB Interrupt Event Status Clear Register      */
   volatile uint32_t ADDR;                           /*!< (@ 0x0000000C) Offset:0x0C USB Device Address Register                    */
   volatile uint32_t CFG;                            /*!< (@ 0x00000010) Offset:0x10 USB Configuration Register                     */
   volatile uint32_t SGCTL;                          /*!< (@ 0x00000014) Offset:0x14 USB Signal Control Register                    */
   volatile uint32_t EPCTL[USB_ENDPOINTS_NUMBER +1]; /*!< (@ 0x00000018) Offset:0x18 USB Endpoint 0-7 Control Registers             */
-  volatile uint32_t  RESERVED[HAL_MAX_ENDPOINTS - USB_ENDPOINTS_NUMBER + 1];
+  volatile const uint32_t  RESERVED[HAL_MAX_ENDPOINTS - USB_ENDPOINTS_NUMBER + 1];
   volatile uint32_t EPTOGGLE;                       /*!< (@ 0x0000003C) Offset:0x3C USB Endpoint Data Toggle Register              */
-  volatile uint32_t  RESERVED1[2];
+  volatile const uint32_t  RESERVED1[2];
   volatile uint32_t EPBUFOS[USB_ENDPOINTS_NUMBER];  /*!< (@ 0x00000048) Offset:0x48 USB Endpoint 1-7 Buffer Offset Registers       */
 #if (USB_ENDPOINTS_NUMBER != HAL_MAX_ENDPOINTS)
   volatile uint32_t  RESERVED2[HAL_MAX_ENDPOINTS - USB_ENDPOINTS_NUMBER - 1];
 #endif
-  volatile uint32_t FRMNO;                          /*!< (@ 0x00000060) Offset:0x60 USB Frame Number Register                      */
+  volatile const uint32_t FRMNO;                    /*!< (@ 0x00000060) Offset:0x60 USB Frame Number Register                      */
   volatile uint32_t PHYPRM;                         /*!< (@ 0x00000064) Offset:0x64 USB PHY Parameter Register                     */
-  volatile uint32_t  RESERVED3;
+  volatile const uint32_t  RESERVED3;
   volatile uint32_t PHYPRM2;                        /*!< (@ 0x0000006C) Offset:0x6C USB PHY Parameter 2 Register                   */
   volatile uint32_t PS2CTL;                         /*!< (@ 0x00000070) Offset:0x70 PS/2 Control Register                          */
-  volatile uint32_t  RESERVED4;
+  volatile const uint32_t  RESERVED4;
   volatile uint32_t RWADDR;                         /*!< (@ 0x00000078) Offset:0x78 USB Read/Write Address Register                */
   volatile uint32_t RWDATA;                         /*!< (@ 0x0000007C) Offset:0x7C USB Read/Write Data Register                   */
   volatile uint32_t RWSTATUS;                       /*!< (@ 0x00000080) Offset:0x80 USB Read/Write Status Register                 */

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
@@ -96,10 +96,19 @@
  * @brief   Pointer to the USB RAM.
  */
 #define SN32_USBRAM            ((sn32_usb_pma_t *)SN32_USBRAM_BASE)
-#define mskEPn_NAK(ep)          (0x1<<(ep -1))
-#define mskEPn_ACK(ep)          (0x1<<(8+(ep-1)))
-#define mskEPn_DIR(ep)          (0x1<<(ep-1))
-#define mskEPn_DATA_TOGGLE(ep)      (0x1<<(ep-1))
+/**
+ * @brief USB EP handling.
+ */
+/* USB Interrupt Event Status Bit Definitions <USB_INSTS/USB_INSTSC> */
+#define mskEPn_NAK(ep)         (0x1<<(ep -1))
+#define mskEPn_ACK(ep)         (0x1<<(8+(ep-1)))
+/* USB Configuration Bit Definitions <USB_CFG> */
+#define mskEPn_DIR(ep)         (0x1<<(ep-1))
+/* USB Endpoint Data Toggle Bit Definitions <USB_EPTOGGLE> */
+#define mskEPn_DATA_TOGGLE(ep) (0x1<<(ep-1))
+/* USB Interrupt Enable Bit Definitions <USB_INTEN> */
+#define mskEPn_NAK_EN(ep)      mskEPn_NAK(ep)
+#define mskEPnACK_EN           (0x1<<USB_ENDPOINTS_NUMBER)
 
 #define EPCTL_SET_STAT_ACK(ep, bBytecnt)                                  \
   SN32_USB->EPCTL[ep] = (mskEPn_ENDP_EN|mskEPn_ENDP_STATE_ACK|bBytecnt)

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/sn32_usb.h
@@ -32,12 +32,12 @@
  * @brief   Number of the available endpoints.
  * @details This value does not include the endpoint 0 which is always present.
  */
-#define HAL_MAX_ENDPOINTS                  6
+#define HAL_MAX_ENDPOINTS                  7
 #if (defined(SN32F240B) || defined(SN32F260))
 #define USB_ENDPOINTS_NUMBER               4
 #define SN32_USB_PMA_SIZE                  256
 #elif (defined(SN32F280) || defined(SN32F290))
-#define USB_ENDPOINTS_NUMBER               HAL_MAX_ENDPOINTS
+#define USB_ENDPOINTS_NUMBER               6
 #define SN32_USB_PMA_SIZE                  512
 #else
 #error "USB driver not supported in the selected device"
@@ -47,30 +47,33 @@
  * @brief   USB registers block.
  */
   typedef struct {
-  volatile uint32_t INTEN;                       /*!< (@ 0x00000000) Offset:0x00 USB Interrupt Enable Register                  */
-  volatile uint32_t INSTS;                       /*!< (@ 0x00000004) Offset:0x04 USB Interrupt Event Status Register            */
-  volatile uint32_t INSTSC;                      /*!< (@ 0x00000008) Offset:0x08 USB Interrupt Event Status Clear Register      */
-  volatile uint32_t ADDR;                        /*!< (@ 0x0000000C) Offset:0x0C USB Device Address Register                    */
-  volatile uint32_t CFG;                         /*!< (@ 0x00000010) Offset:0x10 USB Configuration Register                     */
-  volatile uint32_t SGCTL;                       /*!< (@ 0x00000014) Offset:0x14 USB Signal Control Register                    */
-  volatile uint32_t EPCTL[HAL_MAX_ENDPOINTS +1]; /*!< (@ 0x00000018) Offset:0x18 USB Endpoint 0-6 Control Registers             */
-  volatile uint32_t  RESERVED[2];
-  volatile uint32_t EPTOGGLE;                    /*!< (@ 0x0000003C) Offset:0x3C USB Endpoint Data Toggle Register              */
+  volatile uint32_t INTEN;                          /*!< (@ 0x00000000) Offset:0x00 USB Interrupt Enable Register                  */
+  volatile uint32_t INSTS;                          /*!< (@ 0x00000004) Offset:0x04 USB Interrupt Event Status Register            */
+  volatile uint32_t INSTSC;                         /*!< (@ 0x00000008) Offset:0x08 USB Interrupt Event Status Clear Register      */
+  volatile uint32_t ADDR;                           /*!< (@ 0x0000000C) Offset:0x0C USB Device Address Register                    */
+  volatile uint32_t CFG;                            /*!< (@ 0x00000010) Offset:0x10 USB Configuration Register                     */
+  volatile uint32_t SGCTL;                          /*!< (@ 0x00000014) Offset:0x14 USB Signal Control Register                    */
+  volatile uint32_t EPCTL[USB_ENDPOINTS_NUMBER +1]; /*!< (@ 0x00000018) Offset:0x18 USB Endpoint 0-7 Control Registers             */
+  volatile uint32_t  RESERVED[HAL_MAX_ENDPOINTS - USB_ENDPOINTS_NUMBER + 1];
+  volatile uint32_t EPTOGGLE;                       /*!< (@ 0x0000003C) Offset:0x3C USB Endpoint Data Toggle Register              */
   volatile uint32_t  RESERVED1[2];
-  volatile uint32_t EPBUFOS[HAL_MAX_ENDPOINTS];  /*!< (@ 0x00000048) Offset:0x48 USB Endpoint 1-6 Buffer Offset Registers       */
-  volatile uint32_t FRMNO;                       /*!< (@ 0x00000060) Offset:0x60 USB Frame Number Register                      */
-  volatile uint32_t PHYPRM;                      /*!< (@ 0x00000064) Offset:0x64 USB PHY Parameter Register                     */
+  volatile uint32_t EPBUFOS[USB_ENDPOINTS_NUMBER];  /*!< (@ 0x00000048) Offset:0x48 USB Endpoint 1-7 Buffer Offset Registers       */
+#if (USB_ENDPOINTS_NUMBER != HAL_MAX_ENDPOINTS)
+  volatile uint32_t  RESERVED2[HAL_MAX_ENDPOINTS - USB_ENDPOINTS_NUMBER - 1];
+#endif
+  volatile uint32_t FRMNO;                          /*!< (@ 0x00000060) Offset:0x60 USB Frame Number Register                      */
+  volatile uint32_t PHYPRM;                         /*!< (@ 0x00000064) Offset:0x64 USB PHY Parameter Register                     */
   volatile uint32_t  RESERVED3;
-  volatile uint32_t PHYPRM2;                     /*!< (@ 0x0000006C) Offset:0x6C USB PHY Parameter 2 Register                   */
-  volatile uint32_t PS2CTL;                      /*!< (@ 0x00000070) Offset:0x70 PS/2 Control Register                          */
+  volatile uint32_t PHYPRM2;                        /*!< (@ 0x0000006C) Offset:0x6C USB PHY Parameter 2 Register                   */
+  volatile uint32_t PS2CTL;                         /*!< (@ 0x00000070) Offset:0x70 PS/2 Control Register                          */
   volatile uint32_t  RESERVED4;
-  volatile uint32_t RWADDR;                      /*!< (@ 0x00000078) Offset:0x78 USB Read/Write Address Register                */
-  volatile uint32_t RWDATA;                      /*!< (@ 0x0000007C) Offset:0x7C USB Read/Write Data Register                   */
-  volatile uint32_t RWSTATUS;                    /*!< (@ 0x00000080) Offset:0x80 USB Read/Write Status Register                 */
-  volatile uint32_t RWADDR2;                     /*!< (@ 0x00000084) Offset:0x84 USB Read/Write Address Register 2              */
-  volatile uint32_t RWDATA2;                     /*!< (@ 0x00000088) Offset:0x88 USB Read/Write Data Register 2                 */
-  volatile uint32_t RWSTATUS2;                   /*!< (@ 0x0000008C) Offset:0x8C USB Read/Write Status Register 2               */
-} sn32_usb_t;                                  /*!< Size = 144 (0x90)                                                         */
+  volatile uint32_t RWADDR;                         /*!< (@ 0x00000078) Offset:0x78 USB Read/Write Address Register                */
+  volatile uint32_t RWDATA;                         /*!< (@ 0x0000007C) Offset:0x7C USB Read/Write Data Register                   */
+  volatile uint32_t RWSTATUS;                       /*!< (@ 0x00000080) Offset:0x80 USB Read/Write Status Register                 */
+  volatile uint32_t RWADDR2;                        /*!< (@ 0x00000084) Offset:0x84 USB Read/Write Address Register 2              */
+  volatile uint32_t RWDATA2;                        /*!< (@ 0x00000088) Offset:0x88 USB Read/Write Data Register 2                 */
+  volatile uint32_t RWSTATUS2;                      /*!< (@ 0x0000008C) Offset:0x8C USB Read/Write Status Register 2               */
+} sn32_usb_t;                                     /*!< Size = 144 (0x90)                                                         */
 
 /** @} */
 

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/usbhw.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/usbhw.h
@@ -29,6 +29,8 @@
 #define mskUADDR                    (0x7F<<0)
 
 /* USB Configuration Bit Definitions <USB_CFG> */
+#define mskVREG33DIS_EN             (0x1<<24)
+#define mskUSBRAM_EN                (0x1<<25)
 #define mskDIS_PDEN                 (0x1<<26)
 #define mskESD_EN                   (0x1<<27)
 #define mskSIE_EN                   (0x1<<28)

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/usbhw.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/usbhw.h
@@ -5,35 +5,12 @@
 #define __USBHW_H__
 
 /* USB Interrupt Enable Bit Definitions <USB_INTEN> */
-#define mskEP1_NAK_EN               (0x1<<0)
-#define mskEP2_NAK_EN               (0x1<<1)
-#define mskEP3_NAK_EN               (0x1<<2)
-#define mskEP4_NAK_EN               (0x1<<3)
-#define mskEP5_NAK_EN               (0x1<<4)
-#define mskEP6_NAK_EN               (0x1<<5)
-#define mskEPnACK_EN                (0x1<<6)
-
 #define mskBUSWK_IE                 (0x1<<28)
 #define mskUSB_IE                   (0x1<<29)
 #define mskUSB_SOF_IE               (0x1<<30)
 #define mskBUS_IE                   (0x1U<<31)
 
 /* USB Interrupt Event Status Bit Definitions <USB_INSTS/USB_INSTSC> */
-#define mskEP1_NAK                  (0x1<<0)
-#define mskEP2_NAK                  (0x1<<1)
-#define mskEP3_NAK                  (0x1<<2)
-#define mskEP4_NAK                  (0x1<<3)
-#define mskEP5_NAK                  (0x1<<4)
-#define mskEP6_NAK                  (0x1<<5)
-
-#define mskEP1_ACK                  (0x1<<8)
-#define mskEP2_ACK                  (0x1<<9)
-#define mskEP3_ACK                  (0x1<<10)
-#define mskEP4_ACK                  (0x1<<11)
-#define mskEP5_ACK                  (0x1<<12)
-#define mskEP6_ACK                  (0x1<<13)
-
-
 #define mskERR_TIMEOUT              (0x1<<17)
 #define mskERR_SETUP                (0x1<<18)
 #define mskEP0_OUT_STALL            (0x1<<19)
@@ -52,13 +29,6 @@
 #define mskUADDR                    (0x7F<<0)
 
 /* USB Configuration Bit Definitions <USB_CFG> */
-#define mskEP1_DIR                  (0x1<<0)
-#define mskEP2_DIR                  (0x1<<1)
-#define mskEP3_DIR                  (0x1<<2)
-#define mskEP4_DIR                  (0x1<<3)
-#define mskEP5_DIR                  (0x1<<4)
-#define mskEP6_DIR                  (0x1<<5)
-
 #define mskDIS_PDEN                 (0x1<<26)
 #define mskESD_EN                   (0x1<<27)
 #define mskSIE_EN                   (0x1<<28)
@@ -84,12 +54,6 @@
 #define mskEPn_ENDP_STATE_NAK       (0x0<<29)
 #define mskEPn_ENDP_STATE_STALL     (0x3<<29)
 #define mskEPn_ENDP_EN              (0x1U<<31)
-
-/* USB Endpoint Data Toggle Bit Definitions <USB_EPTOGGLE> */
-#define mskEP1_CLEAR_DATA0          (0x1<<0)
-#define mskEP2_CLEAR_DATA0          (0x1<<1)
-#define mskEP3_CLEAR_DATA0          (0x1<<2)
-#define mskEP4_CLEAR_DATA0          (0x1<<3)
 
 /* USB Endpoint n Buffer Offset Bit Definitions <USB_EPnBUFOS> */
 #define mskEPn_OFFSET               (0x1FF<<0)


### PR DESCRIPTION
Refactor the USB LLD to be compatible with the whole sn32f2 family of chips