### PR TITLE
In LPC port, alias PUSHPULL to default digital output

### DIFF
--- a/os/hal/ports/LPC/LLD/GPIO/hal_pal_lld.h
+++ b/os/hal/ports/LPC/LLD/GPIO/hal_pal_lld.h
@@ -51,6 +51,9 @@
 #define PAL_MODE_INPUT_PULLUP       (MODE_DIR_IN | MODE_MODE_PULL_UP | MODE_AD_DIGITAL)
 #define PAL_MODE_INPUT_PULLDOWN     (MODE_DIR_IN | MODE_MODE_PULL_DOWN | MODE_AD_DIGITAL)
 #define PAL_MODE_OUTPUT_OPENDRAIN   (MODE_DIR_OUT | MODE_OD_ENABLE | MODE_AD_DIGITAL)
+/* LPC11Uxx does not support true pushpull output, but its non-opendrain output
+ * is sufficient in many use cases, so convenient to alias PUSHPULL to it. */
+#define PAL_MODE_OUTPUT_PUSHPULL    (MODE_DIR_OUT | MODE_AD_DIGITAL)
 
 /*===========================================================================*/
 /* I/O Ports Types and constants.                                            */


### PR DESCRIPTION

LPC11Uxx does not support true pushpull output, but its non-opendrain output is sufficient in many use cases.
It's convenient to alias PUSHPULL to the default digital output, rather than simply undefining it here and leaving it undefined:  This avoids re-working application code that calls for PAL_MODE_OUTPUT_PUSHPULL.