### PR TITLE
ports: riscv-eclic: chcore: add missing port lock functions

### DIFF
--- a/os/common/ports/RISCV-ECLIC/chcore.h
+++ b/os/common/ports/RISCV-ECLIC/chcore.h
@@ -353,6 +353,23 @@ struct port_context {
   }
 #endif
 
+/**
+ * @brief   Returns a word representing a critical section status.
+ *
+ * @return              The critical section status.
+ */
+#define port_get_lock_status() port_get_irq_status()
+
+/**
+ * @brief   Determines if in a critical section.
+ *
+ * @param[in] sts       status word returned by @p port_get_lock_status()
+ * @return              The current status.
+ * @retval false        if running outside a critical section.
+ * @retval true         if running within a critical section.
+ */
+#define port_is_locked(sts) !port_irq_enabled(sts)
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/


### PR DESCRIPTION
These added defines have been introduced in ChibiOS[1] and guard the `CH_PORT_SUPPORTS_RECURSIVE_LOCKS` feature. The needed functionality is already implemented in the port layer, thus the implementation is a simple wrapper.

[1]: git-svn-id: https://svn.code.sf.net/p/chibios/code/branches/stable_21.11.x@16537 085d63ac-f8f8-4fb4-a5e5-c089fd4f3ff4