### PR TITLE
Small patch up for AT32F415

### DIFF
--- a/demos/AT32/RT-AT-START-F415/cfg/mcuconf.h
+++ b/demos/AT32/RT-AT-START-F415/cfg/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415cx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415cx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f415cx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian
-  * @version v2.1.4
-  * @date    01-February-2024
+  * @version v2.1.6
+  * @date    13-December-2024
   * @brief   AT32F415Cx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.4
+  * @brief CMSIS Device version number V2.1.6
   */
 #define __AT32F415_LIBRARY_VERSION_MAJOR   (0x02) /*!< [31:24] major version */
 #define __AT32F415_LIBRARY_VERSION_MIDDLE  (0x01) /*!< [23:16] middle version */
-#define __AT32F415_LIBRARY_VERSION_MINOR   (0x04) /*!< [15:8]  minor version */
+#define __AT32F415_LIBRARY_VERSION_MINOR   (0x06) /*!< [15:8]  minor version */
 #define __AT32F415_LIBRARY_VERSION_RC      (0x00) /*!< [7:0]   release candidate */
 #define __AT32F415_LIBRARY_VERSION         ((__AT32F415_LIBRARY_VERSION_MAJOR  << 24)\
                                            |(__AT32F415_LIBRARY_VERSION_MIDDLE << 16)\

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415cx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415cx.h
@@ -3019,7 +3019,7 @@ typedef struct
 #define IOMUX_REMAP3_TMR11_GMUX_3           (0x8U << IOMUX_REMAP3_TMR11_GMUX_Pos)   /*!< 0x00000800 */
 
 #define IOMUX_REMAP3_TMR11_GMUX_MUX0        0x00000000U                             /*!< CH1/PB9 */
-#define IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos    (9U)                                    /*!< 0x00000002 */
+#define IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos    (9U)                                    /*!< 0x00000200 */
 #define IOMUX_REMAP3_TMR11_GMUX_MUX2_Msk    (0x1U << IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos)
 #define IOMUX_REMAP3_TMR11_GMUX_MUX2        IOMUX_REMAP3_TMR11_GMUX_MUX2_Msk        /*!< CH1/PA7 */
 
@@ -3266,9 +3266,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_Pos)  /*!< 0x00000002 */
 
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR1_GMUX IO signal is connected to TMR1 BRK channel 1 */
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Pos (0U)                                    /*!< 0x00000001 */
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Msk /*!< TMR1_GMUX IO signal is connected to TMR1 BRK channel 1 */
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Pos (1U)                                    /*!< 0x00000002 */
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR1 BRK channel 1 */
@@ -3284,9 +3281,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_Pos)  /*!< 0x00000008 */
 
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR1_GMUX IO signal is connected to TMR1 channel 1 */
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Pos (2U)                                    /*!< 0x00000004 */
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Msk /*!< TMR1_GMUX IO signal is connected to TMR1 channel 1 */
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Pos (3U)                                    /*!< 0x00000008 */
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR1 channel 1 */
@@ -3302,9 +3296,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_Pos)  /*!< 0x00000020 */
 
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR2_GMUX IO signal is connected to TMR2 channel 4 */
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Pos (4U)                                    /*!< 0x00000010 */
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Msk /*!< TMR2_GMUX IO signal is connected to TMR2 channel 4 */
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Pos (5U)                                    /*!< 0x00000020 */
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR2 channel 4 */
@@ -3320,9 +3311,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_Pos)  /*!< 0x00000080 */
 
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR3_GMUX IO signal is connected to TMR3 channel 1 */
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Pos (6U)                                    /*!< 0x00000040 */
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Msk /*!< TMR3_GMUX IO signal is connected to TMR3 channel 1 */
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Pos (7U)                                    /*!< 0x00000080 */
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR3 channel 1 */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415kx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415kx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f415kx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian
-  * @version v2.1.4
-  * @date    01-February-2024
+  * @version v2.1.6
+  * @date    13-December-2024
   * @brief   AT32F415Kx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.4
+  * @brief CMSIS Device version number V2.1.6
   */
 #define __AT32F415_LIBRARY_VERSION_MAJOR   (0x02) /*!< [31:24] major version */
 #define __AT32F415_LIBRARY_VERSION_MIDDLE  (0x01) /*!< [23:16] middle version */
-#define __AT32F415_LIBRARY_VERSION_MINOR   (0x04) /*!< [15:8]  minor version */
+#define __AT32F415_LIBRARY_VERSION_MINOR   (0x06) /*!< [15:8]  minor version */
 #define __AT32F415_LIBRARY_VERSION_RC      (0x00) /*!< [7:0]   release candidate */
 #define __AT32F415_LIBRARY_VERSION         ((__AT32F415_LIBRARY_VERSION_MAJOR  << 24)\
                                            |(__AT32F415_LIBRARY_VERSION_MIDDLE << 16)\

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415kx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415kx.h
@@ -2995,7 +2995,7 @@ typedef struct
 #define IOMUX_REMAP3_TMR11_GMUX_3           (0x8U << IOMUX_REMAP3_TMR11_GMUX_Pos)   /*!< 0x00000800 */
 
 #define IOMUX_REMAP3_TMR11_GMUX_MUX0        0x00000000U                             /*!< CH1/PB9 */
-#define IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos    (9U)                                    /*!< 0x00000002 */
+#define IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos    (9U)                                    /*!< 0x00000200 */
 #define IOMUX_REMAP3_TMR11_GMUX_MUX2_Msk    (0x1U << IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos)
 #define IOMUX_REMAP3_TMR11_GMUX_MUX2        IOMUX_REMAP3_TMR11_GMUX_MUX2_Msk        /*!< CH1/PA7 */
 
@@ -3225,9 +3225,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_Pos)  /*!< 0x00000002 */
 
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR1_GMUX IO signal is connected to TMR1 BRK channel 1 */
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Pos (0U)                                    /*!< 0x00000001 */
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Msk /*!< TMR1_GMUX IO signal is connected to TMR1 BRK channel 1 */
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Pos (1U)                                    /*!< 0x00000002 */
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR1 BRK channel 1 */
@@ -3243,9 +3240,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_Pos)  /*!< 0x00000008 */
 
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR1_GMUX IO signal is connected to TMR1 channel 1 */
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Pos (2U)                                    /*!< 0x00000004 */
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Msk /*!< TMR1_GMUX IO signal is connected to TMR1 channel 1 */
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Pos (3U)                                    /*!< 0x00000008 */
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR1 channel 1 */
@@ -3261,9 +3255,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_Pos)  /*!< 0x00000020 */
 
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR2_GMUX IO signal is connected to TMR2 channel 4 */
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Pos (4U)                                    /*!< 0x00000010 */
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Msk /*!< TMR2_GMUX IO signal is connected to TMR2 channel 4 */
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Pos (5U)                                    /*!< 0x00000020 */
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR2 channel 4 */
@@ -3279,9 +3270,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_Pos)  /*!< 0x00000080 */
 
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR3_GMUX IO signal is connected to TMR3 channel 1 */
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Pos (6U)                                    /*!< 0x00000040 */
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Msk /*!< TMR3_GMUX IO signal is connected to TMR3 channel 1 */
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Pos (7U)                                    /*!< 0x00000080 */
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR3 channel 1 */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415rx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415rx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f415rx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian
-  * @version v2.1.4
-  * @date    01-February-2024
+  * @version v2.1.6
+  * @date    13-December-2024
   * @brief   AT32F415Rx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.4
+  * @brief CMSIS Device version number V2.1.6
   */
 #define __AT32F415_LIBRARY_VERSION_MAJOR   (0x02) /*!< [31:24] major version */
 #define __AT32F415_LIBRARY_VERSION_MIDDLE  (0x01) /*!< [23:16] middle version */
-#define __AT32F415_LIBRARY_VERSION_MINOR   (0x04) /*!< [15:8]  minor version */
+#define __AT32F415_LIBRARY_VERSION_MINOR   (0x06) /*!< [15:8]  minor version */
 #define __AT32F415_LIBRARY_VERSION_RC      (0x00) /*!< [7:0]   release candidate */
 #define __AT32F415_LIBRARY_VERSION         ((__AT32F415_LIBRARY_VERSION_MAJOR  << 24)\
                                            |(__AT32F415_LIBRARY_VERSION_MIDDLE << 16)\

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415rx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415rx.h
@@ -3037,7 +3037,7 @@ typedef struct
 #define IOMUX_REMAP3_TMR11_GMUX_3           (0x8U << IOMUX_REMAP3_TMR11_GMUX_Pos)   /*!< 0x00000800 */
 
 #define IOMUX_REMAP3_TMR11_GMUX_MUX0        0x00000000U                             /*!< CH1/PB9 */
-#define IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos    (9U)                                    /*!< 0x00000002 */
+#define IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos    (9U)                                    /*!< 0x00000200 */
 #define IOMUX_REMAP3_TMR11_GMUX_MUX2_Msk    (0x1U << IOMUX_REMAP3_TMR11_GMUX_MUX2_Pos)
 #define IOMUX_REMAP3_TMR11_GMUX_MUX2        IOMUX_REMAP3_TMR11_GMUX_MUX2_Msk        /*!< CH1/PA7 */
 
@@ -3298,9 +3298,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_Pos)  /*!< 0x00000002 */
 
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR1_GMUX IO signal is connected to TMR1 BRK channel 1 */
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Pos (0U)                                    /*!< 0x00000001 */
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX1_Msk /*!< TMR1_GMUX IO signal is connected to TMR1 BRK channel 1 */
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Pos (1U)                                    /*!< 0x00000002 */
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR1_BK1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR1 BRK channel 1 */
@@ -3316,9 +3313,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_Pos)  /*!< 0x00000008 */
 
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR1_GMUX IO signal is connected to TMR1 channel 1 */
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Pos (2U)                                    /*!< 0x00000004 */
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX1_Msk /*!< TMR1_GMUX IO signal is connected to TMR1 channel 1 */
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Pos (3U)                                    /*!< 0x00000008 */
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR1_CH1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR1 channel 1 */
@@ -3334,9 +3328,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_Pos)  /*!< 0x00000020 */
 
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR2_GMUX IO signal is connected to TMR2 channel 4 */
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Pos (4U)                                    /*!< 0x00000010 */
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX1_Msk /*!< TMR2_GMUX IO signal is connected to TMR2 channel 4 */
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Pos (5U)                                    /*!< 0x00000020 */
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR2_CH4_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR2 channel 4 */
@@ -3352,9 +3343,6 @@ typedef struct
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_1    (0x2U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_Pos)  /*!< 0x00000080 */
 
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX0     0x00000000U                             /*!< TMR3_GMUX IO signal is connected to TMR3 channel 1 */
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Pos (6U)                                    /*!< 0x00000040 */
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Msk (0x1U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Pos)
-#define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1     IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX1_Msk /*!< TMR3_GMUX IO signal is connected to TMR3 channel 1 */
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Pos (7U)                                    /*!< 0x00000080 */
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Msk (0x1U << IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Pos)
 #define IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2     IOMUX_REMAP8_TMR3_CH1_CMP_GMUX_MUX2_Msk /*!< CMP output signal is connected to TMR3 channel 1 */

--- a/os/hal/ports/AT32/AT32F415/at32_isr.h
+++ b/os/hal/ports/AT32/AT32F415/at32_isr.h
@@ -210,15 +210,6 @@
 #define AT32_TMR4_NUMBER             30
 #define AT32_TMR5_NUMBER             50
 
-/* Aliases.*/
-#define AT32_TMR9_HANDLER            VectorA0
-#define AT32_TMR10_HANDLER           VectorA4
-#define AT32_TMR11_HANDLER           VectorA8
-
-#define AT32_TMR9_NUMBER             24
-#define AT32_TMR10_NUMBER            25
-#define AT32_TMR11_NUMBER            26
-
 /*
  * USART units.
  */

--- a/os/hal/ports/AT32/AT32F415/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F415/at32_registry.h
@@ -73,11 +73,11 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
-#define AT32_ADVANCED_DMA                  FALSE
-
 #if (AT32_DMA_USE_DMAMUX == TRUE) || defined(__DOXYGEN__)
+#define AT32_ADVANCED_DMA                  TRUE
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
 #else
+#define AT32_ADVANCED_DMA                  FALSE
 #define AT32_DMA_SUPPORTS_DMAMUX           FALSE
 #endif
 
@@ -101,8 +101,11 @@
 #define AT32_HAS_GPIOB                     TRUE
 #define AT32_HAS_GPIOD                     TRUE
 
+#if !defined(AT32_HAS_GPIOC) || defined(__DOXYGEN__)
 #define AT32_HAS_GPIOC                     FALSE
+#elif !defined(AT32_HAS_GPIOF)
 #define AT32_HAS_GPIOF                     FALSE
+#endif
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
@@ -298,11 +301,11 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
-#define AT32_ADVANCED_DMA                  FALSE
-
 #if (AT32_DMA_USE_DMAMUX == TRUE) || defined(__DOXYGEN__)
+#define AT32_ADVANCED_DMA                  TRUE
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
 #else
+#define AT32_ADVANCED_DMA                  FALSE
 #define AT32_DMA_SUPPORTS_DMAMUX           FALSE
 #endif
 
@@ -326,8 +329,11 @@
 #define AT32_HAS_GPIOB                     TRUE
 #define AT32_HAS_GPIOD                     TRUE
 
+#if !defined(AT32_HAS_GPIOC) || defined(__DOXYGEN__)
 #define AT32_HAS_GPIOC                     FALSE
+#elif !defined(AT32_HAS_GPIOF)
 #define AT32_HAS_GPIOF                     FALSE
+#endif
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
@@ -523,11 +529,11 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
-#define AT32_ADVANCED_DMA                  FALSE
-
 #if (AT32_DMA_USE_DMAMUX == TRUE) || defined(__DOXYGEN__)
+#define AT32_ADVANCED_DMA                  TRUE
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
 #else
+#define AT32_ADVANCED_DMA                  FALSE
 #define AT32_DMA_SUPPORTS_DMAMUX           FALSE
 #endif
 
@@ -758,11 +764,11 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
-#define AT32_ADVANCED_DMA                  FALSE
-
 #if (AT32_DMA_USE_DMAMUX == TRUE) || defined(__DOXYGEN__)
+#define AT32_ADVANCED_DMA                  TRUE
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
 #else
+#define AT32_ADVANCED_DMA                  FALSE
 #define AT32_DMA_SUPPORTS_DMAMUX           FALSE
 #endif
 
@@ -993,11 +999,11 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
-#define AT32_ADVANCED_DMA                  FALSE
-
 #if (AT32_DMA_USE_DMAMUX == TRUE) || defined(__DOXYGEN__)
+#define AT32_ADVANCED_DMA                  TRUE
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
 #else
+#define AT32_ADVANCED_DMA                  FALSE
 #define AT32_DMA_SUPPORTS_DMAMUX           FALSE
 #endif
 
@@ -1247,11 +1253,11 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
-#define AT32_ADVANCED_DMA                  FALSE
-
 #if (AT32_DMA_USE_DMAMUX == TRUE) || defined(__DOXYGEN__)
+#define AT32_ADVANCED_DMA                  TRUE
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
 #else
+#define AT32_ADVANCED_DMA                  FALSE
 #define AT32_DMA_SUPPORTS_DMAMUX           FALSE
 #endif
 

--- a/os/hal/ports/AT32/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/hal/ports/AT32/LLD/I2Cv1/hal_i2c_lld.h
@@ -157,6 +157,23 @@
 #error "Invalid DMA priority assigned to I2C2"
 #endif
 
+/* The following checks are only required when there is a DMA able to
+   reassign streams to different channels.*/
+#if AT32_ADVANCED_DMA
+
+/* Check on the presence of the DMA streams settings in mcuconf.h.*/
+#if AT32_I2C_USE_I2C1 && (!defined(AT32_I2C_I2C1_RX_DMA_STREAM) ||          \
+                          !defined(AT32_I2C_I2C1_TX_DMA_STREAM))
+#error "I2C1 DMA streams not defined"
+#endif
+
+#if AT32_I2C_USE_I2C2 && (!defined(AT32_I2C_I2C2_RX_DMA_STREAM) ||          \
+                          !defined(AT32_I2C_I2C2_TX_DMA_STREAM))
+#error "I2C2 DMA streams not defined"
+#endif
+
+#endif /* AT32_ADVANCED_DMA */
+
 #if !defined(AT32_DMA_REQUIRED)
 #define AT32_DMA_REQUIRED
 #endif

--- a/os/hal/ports/AT32/LLD/OTGv1/hal_usb_lld.c
+++ b/os/hal/ports/AT32/LLD/OTGv1/hal_usb_lld.c
@@ -620,18 +620,13 @@ irq_retry:
       otgp->GINTMSK &= ~GINTMSK_SOFMSK;
     }
     if (usbp->state == USB_SUSPENDED) {
-      /* If clocks are gated off, turn them back on (may be the case if
-         coming out of suspend mode).*/
-      if (otgp->PCGCCTL & PCGCCTL_STOPPCLK) {
-        /* Set to zero to un-gate the USB core clocks.*/
-        otgp->PCGCCTL &= ~PCGCCTL_STOPPCLK;
-      }
-
-      /* Re-enable endpoint irqs if they have been disabled by suspend before. */
-      otg_enable_ep(usbp);
-
+      /* Set to zero to un-gate the USB core clocks.*/
+      otgp->PCGCCTL &= ~PCGCCTL_STOPPCLK;
       _usb_wakeup(usbp);
     }
+
+    /* Re-enable endpoint irqs if they have been disabled by suspend before.*/
+    otg_enable_ep(usbp);
 
     _usb_isr_invoke_sof_cb(usbp);
   }

--- a/os/hal/ports/AT32/LLD/SDIOv1/hal_sdc_lld.h
+++ b/os/hal/ports/AT32/LLD/SDIOv1/hal_sdc_lld.h
@@ -108,6 +108,17 @@
 #error "Invalid DMA priority assigned to SDIO"
 #endif
 
+/* The following checks are only required when there is a DMA able to
+   reassign streams to different channels.*/
+#if AT32_ADVANCED_DMA
+
+/* Check on the presence of the DMA streams settings in mcuconf.h.*/
+#if !defined(AT32_SDC_SDIO_DMA_STREAM)
+#error "SDIO DMA streams not defined"
+#endif
+
+#endif /* AT32_ADVANCED_DMA */
+
 #if !defined(AT32_DMA_REQUIRED)
 #define AT32_DMA_REQUIRED
 #endif

--- a/os/hal/ports/AT32/LLD/USARTv1/hal_uart_lld.h
+++ b/os/hal/ports/AT32/LLD/USARTv1/hal_uart_lld.h
@@ -261,6 +261,38 @@
 #error "Invalid DMA priority assigned to UART5"
 #endif
 
+/* The following checks are only required when there is a DMA able to
+   reassign streams to different channels.*/
+#if AT32_ADVANCED_DMA
+
+/* Check on the presence of the DMA streams settings in mcuconf.h.*/
+#if AT32_UART_USE_USART1 && (!defined(AT32_UART_USART1_RX_DMA_STREAM) ||    \
+                             !defined(AT32_UART_USART1_TX_DMA_STREAM))
+#error "USART1 DMA streams not defined"
+#endif
+
+#if AT32_UART_USE_USART2 && (!defined(AT32_UART_USART2_RX_DMA_STREAM) ||    \
+                             !defined(AT32_UART_USART2_TX_DMA_STREAM))
+#error "USART2 DMA streams not defined"
+#endif
+
+#if AT32_UART_USE_USART3 && (!defined(AT32_UART_USART3_RX_DMA_STREAM) ||    \
+                             !defined(AT32_UART_USART3_TX_DMA_STREAM))
+#error "USART3 DMA streams not defined"
+#endif
+
+#if AT32_UART_USE_UART4 && (!defined(AT32_UART_UART4_RX_DMA_STREAM) ||      \
+                            !defined(AT32_UART_UART4_TX_DMA_STREAM))
+#error "UART4 DMA streams not defined"
+#endif
+
+#if AT32_UART_USE_UART5 && (!defined(AT32_UART_UART5_RX_DMA_STREAM) ||      \
+                            !defined(AT32_UART_UART5_TX_DMA_STREAM))
+#error "UART5 DMA streams not defined"
+#endif
+
+#endif /* AT32_ADVANCED_DMA */
+
 #if !defined(AT32_DMA_REQUIRED)
 #define AT32_DMA_REQUIRED
 #endif

--- a/testhal/AT32/multi/ERTC/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/ERTC/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/I2C_HW/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/I2C_HW/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/I2C_SW/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/I2C_SW/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/PWM_ICU/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/PWM_ICU/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/SDC-FATFS/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/SDC-FATFS/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/SDC/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/SDC/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/UART/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/UART/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/USB_CDC/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/USB_CDC/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.

--- a/testhal/AT32/multi/WDT/cfg/at-start-f415/mcuconf.h
+++ b/testhal/AT32/multi/WDT/cfg/at-start-f415/mcuconf.h
@@ -151,8 +151,6 @@
 #define AT32_ICU_USE_TMR4                   FALSE
 #define AT32_ICU_USE_TMR5                   FALSE
 #define AT32_ICU_USE_TMR9                   FALSE
-#define AT32_ICU_USE_TMR10                  FALSE
-#define AT32_ICU_USE_TMR11                  FALSE
 
 /*
  * PWM driver system settings.


### PR DESCRIPTION
### Changelog:
- Enable advanced DMA check when using DMAMUX.
- Added some change on GPIO for small package size, allow to fixed issue on QMK.
- Remove TMR10/11 out of ICU driver in `mcuconf.h`, due to only 1 channel available.
- Remove duplicate multiplexing function on IOMUX_REMAP8.
- Update OTG LLD driver.
- Remove TMR alias for ISR, it no longer needed.
- Update CMSIS version.