### PR TITLE
Fix compilation issue with newer binutils

### DIFF
--- a/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
+++ b/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.S
@@ -33,6 +33,7 @@
     .global     usb_memcpy
 
 /* size_t usb_memcpy(volatile void* destination, const volatile void* source, size_t num); */
+.type usb_memcpy, %function
 usb_memcpy:
   cmp     r2, #0
   beq.n   zero_return


### PR DESCRIPTION
While compiling QMK for a NUMICRO target, I stumbled upon the following error

```
Linking: .build/das_keyboard_4_professional_default.elf                                             [ERRORS]
 | 
 | /usr/lib/gcc/arm-none-eabi/14.2.1/../../../arm-none-eabi/bin/ld: .build/obj_das_keyboard_4_professional_default/./lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.o(usb_memcpy): Unknown destination type (ARM/Thumb) in .build/obj_das_keyboard_4_professional_default/lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.o
 | .build/obj_das_keyboard_4_professional_default/lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.o: in function `usb_serve_out_endpoint':
 | hal_usb_lld.c:(.text.usb_serve_out_endpoint+0x32): dangerous relocation: unsupported relocation
 | /usr/lib/gcc/arm-none-eabi/14.2.1/../../../arm-none-eabi/bin/ld: .build/obj_das_keyboard_4_professional_default/./lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.o(usb_memcpy): Unknown destination type (ARM/Thumb) in .build/obj_das_keyboard_4_professional_default/lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.o
 | .build/obj_das_keyboard_4_professional_default/lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.o: in function `usb_serve_in_endpoint':
 | hal_usb_lld.c:(.text.usb_serve_in_endpoint+0x68): dangerous relocation: unsupported relocation
 | /usr/lib/gcc/arm-none-eabi/14.2.1/../../../arm-none-eabi/bin/ld: .build/obj_das_keyboard_4_professional_default/./lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/usb_memcpy.o(usb_memcpy): Unknown destination type (ARM/Thumb) in .build/obj_das_keyboard_4_professional_default/lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.o
 | .build/obj_das_keyboard_4_professional_default/lib/chibios-contrib/os/hal/ports/NUMICRO/LLD/USBv1/hal_usb_lld.o: in function `usb_lld_start_in':
 | hal_usb_lld.c:(.text.usb_lld_start_in+0x2a): dangerous relocation: unsupported relocation
 | collect2: error: ld returned 1 exit status
 | 
gmake: *** [builddefs/common_rules.mk:269: .build/das_keyboard_4_professional_default.elf] Error 1
```

which seems to be related to a change in a recent version of binutils (https://community.arm.com/support-forums/f/compilers-and-libraries-forum/57077/binutils-2-44-and-gcc-15-1-0---dangerous-relocation-unsupported-relocation-error-when-trying-to-build-u-boot)

The proposed patch fixes the issue, but I have _zero_ knowledge of chibios, so I'm wondering if a similar change needs to be applied to more functions, and how to test it.