### PR TITLE
stm32H7 compatibility and fixes to header

### DIFF
--- a/os/hal/ports/STM32/LLD/LTDCv1/hal_stm32_ltdc.c
+++ b/os/hal/ports/STM32/LLD/LTDCv1/hal_stm32_ltdc.c
@@ -233,9 +233,9 @@ void ltdcInit(void) {
   rccResetLTDC();
 
   /* Enable the LTDC clock.*/
-#if defined(STM32H743xx)
-  RCC->D1CFGR = (RCC->D1CFGR & ~(0x3U << 16U)) | (2 << 16);
-#else
+#if defined(STM32H7)
+  RCC->APB3ENR |= RCC_APB3ENR_LTDCEN; /* Enable LTDC clock. */
+#else defined(STM32F4)
   RCC->DCKCFGR = (RCC->DCKCFGR & ~RCC_DCKCFGR_PLLSAIDIVR) | (2 << 16); /* /8 */
 #endif
   rccEnableLTDC(false);
@@ -769,7 +769,7 @@ bool ltdcIsDitheringEnabledI(LTDCDriver *ltdcp) {
   osalDbgCheck(ltdcp == &LTDCD1);
   (void)ltdcp;
 
-#if defined(STM32H743xx)
+#if defined(STM32H7)
   return (LTDC->GCR & LTDC_GCR_DEN) != 0;
 #else
   return (LTDC->GCR & LTDC_GCR_DTEN) != 0;
@@ -809,7 +809,7 @@ void ltdcEnableDitheringI(LTDCDriver *ltdcp) {
   osalDbgCheckClassI();
   osalDbgCheck(ltdcp == &LTDCD1);
   (void)ltdcp;
-#if defined(STM32H743xx)
+#if defined(STM32H7)
   LTDC->GCR |= LTDC_GCR_DEN;
 #else
   LTDC->GCR |= LTDC_GCR_DTEN;
@@ -847,7 +847,7 @@ void ltdcDisableDitheringI(LTDCDriver *ltdcp) {
   osalDbgCheck(ltdcp == &LTDCD1);
   (void)ltdcp;
 
-#if defined(STM32H743xx)
+#if defined(STM32H7)
   LTDC->GCR &= ~LTDC_GCR_DEN;
 #else
   LTDC->GCR &= ~LTDC_GCR_DTEN;

--- a/os/hal/ports/STM32/LLD/LTDCv1/hal_stm32_ltdc.h
+++ b/os/hal/ports/STM32/LLD/LTDCv1/hal_stm32_ltdc.h
@@ -25,6 +25,8 @@
 #ifndef HAL_STM32_LTDC_H_
 #define HAL_STM32_LTDC_H_
 
+#include "hal.h"
+
 /**
  * @brief   Using the LTDC driver.
  */
@@ -285,7 +287,6 @@ typedef struct ltdc_window_t ltdc_window_t;
 typedef struct ltdc_frame_t ltdc_frame_t;
 typedef struct ltdc_laycfg_t ltdc_laycfg_t;
 typedef struct LTDCConfig LTDCConfig;
-typedef enum ltdc_state_t ltdc_state_t;
 typedef struct LTDCDriver LTDCDriver;
 
 /**
@@ -457,7 +458,7 @@ typedef struct LTDCConfig {
 /**
  * @brief   LTDC driver state.
  */
-typedef enum ltdc_state_t {
+typedef enum {
   LTDC_UNINIT   = (0),              /**< Not initialized.*/
   LTDC_STOP     = (1),              /**< Stopped.*/
   LTDC_READY    = (2),              /**< Ready.*/


### PR DESCRIPTION
Fix LTDC clock init to be the same across the H7 lineup.
Fix the header to be usable from CPP, the current enum forward breaks compatibility.