### PR TITLE
Certain STM32's dont have programmable CRC registers

### DIFF
--- a/os/hal/include/hal_crc.h
+++ b/os/hal/include/hal_crc.h
@@ -135,7 +135,11 @@ extern "C" {
 #endif
   void crcInit(void);
   void crcObjectInit(CRCDriver *crcp);
+#if (defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L1xx)) // Those MCU dont have programmable CRC registers
+  void crcStart(CRCDriver *crcp);
+#else
   void crcStart(CRCDriver *crcp, const CRCConfig *config);
+#endif
   void crcStop(CRCDriver *crcp);
   void crcReset(CRCDriver *crcp);
   void crcResetI(CRCDriver *crcp);

--- a/os/hal/include/hal_crc.h
+++ b/os/hal/include/hal_crc.h
@@ -135,7 +135,11 @@ extern "C" {
 #endif
   void crcInit(void);
   void crcObjectInit(CRCDriver *crcp);
-#if (defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L1xx)) // Those MCU dont have programmable CRC registers
+#if (defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L1xx) || defined(STM32F07x) || \
+  defined(STM32F030x4) || defined(STM32F030x6) || defined(STM32F030x8) || defined(STM32F030xC) || \
+  defined(STM32F031x6) || defined(STM32F038xx) || \
+  defined(STM32F042x6) || defined(STM32F048xx) || \
+  defined(STM32F051x8) || defined(STM32F058xx) ) // Those MCU dont have programmable CRC registers
   void crcStart(CRCDriver *crcp);
 #else
   void crcStart(CRCDriver *crcp, const CRCConfig *config);

--- a/os/hal/src/hal_crc.c
+++ b/os/hal/src/hal_crc.c
@@ -81,6 +81,19 @@ void crcObjectInit(CRCDriver *crcp) {
  *
  * @api
  */
+
+#if (defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L1xx)) // Those MCU dont have programmable CRC registers
+void crcStart(CRCDriver *crcp) {
+  osalDbgCheck(crcp != NULL);
+
+  osalSysLock();
+  osalDbgAssert((crcp->state == CRC_STOP) || (crcp->state == CRC_READY),
+                "invalid state");
+  crc_lld_start(crcp);
+  crcp->state = CRC_READY;
+  osalSysUnlock();
+}
+#else
 void crcStart(CRCDriver *crcp, const CRCConfig *config) {
   osalDbgCheck(crcp != NULL);
 
@@ -92,6 +105,7 @@ void crcStart(CRCDriver *crcp, const CRCConfig *config) {
   crcp->state = CRC_READY;
   osalSysUnlock();
 }
+#endif
 
 /**
  * @brief   Deactivates the CRC peripheral.

--- a/os/hal/src/hal_crc.c
+++ b/os/hal/src/hal_crc.c
@@ -80,9 +80,12 @@ void crcObjectInit(CRCDriver *crcp) {
  *                      supports a default configuration
  *
  * @api
- */
-
-#if (defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L1xx)) // Those MCU dont have programmable CRC registers
+ */     
+#if (defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32L1xx) || defined(STM32F07x) || \
+  defined(STM32F030x4) || defined(STM32F030x6) || defined(STM32F030x8) || defined(STM32F030xC) || \
+  defined(STM32F031x6) || defined(STM32F038xx) || \
+  defined(STM32F042x6) || defined(STM32F048xx) || \
+  defined(STM32F051x8) || defined(STM32F058xx) ) // Those MCU dont have programmable CRC registers
 void crcStart(CRCDriver *crcp) {
   osalDbgCheck(crcp != NULL);
 


### PR DESCRIPTION
![obraz](https://github.com/user-attachments/assets/2f3e369b-b536-45bb-a2dd-0f514c255333)
