### PR TITLE
Patch update for Arterytek AT32 series

### DIFF
--- a/os/common/ext/CMSIS/ArteryTek/AT32F402_405/at32f402_405cx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F402_405/at32f402_405cx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f402_405cx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian & Maxjta
-  * @version v2.1.2
-  * @date    20-Jan-2025
+  * @version v2.1.4
+  * @date    24-Nov-2025
   * @brief   AT32F402_405Cx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.2
+  * @brief CMSIS Device version number V2.1.4
   */
 #define __AT32F402_405_LIBRARY_VERSION_MAJOR  (0x02) /*!< [31:24] major version */
 #define __AT32F402_405_LIBRARY_VERSION_MIDDLE (0x01) /*!< [23:16] middle version */
-#define __AT32F402_405_LIBRARY_VERSION_MINOR  (0x02) /*!< [15:8]  minor version */
+#define __AT32F402_405_LIBRARY_VERSION_MINOR  (0x04) /*!< [15:8]  minor version */
 #define __AT32F402_405_LIBRARY_VERSION_RC     (0x00) /*!< [7:0]   release candidate */
 #define __AT32F402_405_LIBRARY_VERSION        ((__AT32F402_405_LIBRARY_VERSION_MAJOR  << 24)\
                                               |(__AT32F402_405_LIBRARY_VERSION_MIDDLE << 16)\
@@ -99,7 +99,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                   */
 
 /******  AT32 specific Interrupt Numbers **********************************************************/
-  WWDT_IRQn                   = 0,      /*!< Window WatchDog Timer Interrupt                      */
+  WWDT_IRQn                   = 0,      /*!< Window WATCHDOG Timer Interrupt                      */
   PVM_IRQn                    = 1,      /*!< PVM Interrupt linked to EXINT16                      */
   TAMPER_IRQn                 = 2,      /*!< Tamper Interrupt linked to EXINT21                   */
   ERTC_WKUP_IRQn              = 3,      /*!< ERTC Wake Up Interrupt linked to EXINT22             */
@@ -190,12 +190,12 @@ typedef enum
 
 typedef struct
 {
-  __IO uint32_t STS;      /*!< ACC Status register,                         Address offset: 0x00 */
-  __IO uint32_t CTRL1;    /*!< ACC Control register 1,                      Address offset: 0x04 */
-  __IO uint32_t CTRL2;    /*!< ACC Control register 2,                      Address offset: 0x08 */
-  __IO uint32_t CP1;      /*!< ACC Compare value 1,                         Address offset: 0x0C */
-  __IO uint32_t CP2;      /*!< ACC Compare value 2,                         Address offset: 0x10 */
-  __IO uint32_t CP3;      /*!< ACC Compare value 3,                         Address offset: 0x14 */
+  __IO uint32_t STS;      /*!< ACC status register,                         Address offset: 0x00 */
+  __IO uint32_t CTRL1;    /*!< ACC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CTRL2;    /*!< ACC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t CP1;      /*!< ACC compare value 1,                         Address offset: 0x0C */
+  __IO uint32_t CP2;      /*!< ACC compare value 2,                         Address offset: 0x10 */
+  __IO uint32_t CP3;      /*!< ACC compare value 3,                         Address offset: 0x14 */
 } ACC_TypeDef;
 
 /**
@@ -282,8 +282,8 @@ typedef struct
   __IO uint32_t ESTS;                                /*!< CAN error status register,                   Address offset: 0x018         */
   __IO uint32_t BTMG;                                /*!< CAN bit timing register,                     Address offset: 0x01C         */
   uint32_t      RESERVED0[88];                       /*!< Reserved,                                    Address offset: 0x020 ~ 0x17C */
-  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX Mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
-  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO Mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
+  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
+  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
   uint32_t      RESERVED1[12];                       /*!< Reserved,                                    Address offset: 0x1D0 ~ 0x1FC */
   __IO uint32_t FCTRL;                               /*!< CAN filter control register,                 Address offset: 0x200         */
   __IO uint32_t FMCFG;                               /*!< CAN filter mode configuration register,      Address offset: 0x204         */
@@ -303,12 +303,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t DT;          /*!< CRC Data register,                           Address offset: 0x00 */
-  __IO uint32_t CDT;         /*!< CRC Common data register,                    Address offset: 0x04 */
-  __IO uint32_t CTRL;        /*!< CRC Control register,                        Address offset: 0x08 */
+  __IO uint32_t DT;          /*!< CRC data register,                           Address offset: 0x00 */
+  __IO uint32_t CDT;         /*!< CRC common data register,                    Address offset: 0x04 */
+  __IO uint32_t CTRL;        /*!< CRC control register,                        Address offset: 0x08 */
   uint32_t      RESERVED;    /*!< Reserved,                                    Address offset: 0x0C */
-  __IO uint32_t IDT;         /*!< CRC Initialization register,                 Address offset: 0x10 */
-  __IO uint32_t POLY;        /*!< CRC Polynomial register,                     Address offset: 0x14 */
+  __IO uint32_t IDT;         /*!< CRC initialization register,                 Address offset: 0x10 */
+  __IO uint32_t POLY;        /*!< CRC polynomial register,                     Address offset: 0x14 */
 } CRC_TypeDef;
 
 /**
@@ -317,10 +317,10 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;            /*!< CRM Clock control register,                  Address offset: 0x00        */
+  __IO uint32_t CTRL;            /*!< CRM clock control register,                  Address offset: 0x00        */
   __IO uint32_t PLLCFG;          /*!< CRM PLL clock configuration register,        Address offset: 0x04        */
-  __IO uint32_t CFG;             /*!< CRM Clock configuration register,            Address offset: 0x08        */
-  __IO uint32_t CLKINT;          /*!< CRM Clock interrupt register,                Address offset: 0x0C        */
+  __IO uint32_t CFG;             /*!< CRM clock configuration register,            Address offset: 0x08        */
+  __IO uint32_t CLKINT;          /*!< CRM clock interrupt register,                Address offset: 0x0C        */
   __IO uint32_t AHBRST1;         /*!< CRM AHB peripheral reset register 1,         Address offset: 0x10        */
   __IO uint32_t AHBRST2;         /*!< CRM AHB peripheral reset register 2,         Address offset: 0x14        */
   __IO uint32_t AHBRST3;         /*!< CRM AHB peripheral reset register 3,         Address offset: 0x18        */
@@ -342,12 +342,12 @@ typedef struct
   __IO uint32_t APB1LPEN;        /*!< CRM APB1 periph clk enable in LP mode reg,   Address offset: 0x60        */
   __IO uint32_t APB2LPEN;        /*!< CRM APB2 periph clk enable in LP mode reg,   Address offset: 0x64        */
   uint32_t      RESERVED5[2];    /*!< Reserved,                                    Address offset: 0x68 ~ 0x6C */
-  __IO uint32_t BPDC;            /*!< CRM Battery powered domain control register, Address offset: 0x70        */
-  __IO uint32_t CTRLSTS;         /*!< CRM Control/status register,                 Address offset: 0x74        */
+  __IO uint32_t BPDC;            /*!< CRM battery powered domain control register, Address offset: 0x70        */
+  __IO uint32_t CTRLSTS;         /*!< CRM control/status register,                 Address offset: 0x74        */
   __IO uint32_t OTGHS;           /*!< CRM OTGHS control register (F405 only),      Address offset: 0x78        */
   uint32_t      RESERVED6[9];    /*!< Reserved,                                    Address offset: 0x7C ~ 0x9C */
-  __IO uint32_t MISC1;           /*!< CRM Additional register 1,                   Address offset: 0xA0        */
-  __IO uint32_t MISC2;           /*!< CRM Additional register 2,                   Address offset: 0xA4        */
+  __IO uint32_t MISC1;           /*!< CRM additional register 1,                   Address offset: 0xA0        */
+  __IO uint32_t MISC2;           /*!< CRM additional register 2,                   Address offset: 0xA4        */
 } CRM_TypeDef;
 
 /**
@@ -460,12 +460,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t INTEN;      /*!< EXINT Interrupt enable register,             Address offset: 0x00 */
-  __IO uint32_t EVTEN;      /*!< EXINT Event enable register,                 Address offset: 0x04 */
-  __IO uint32_t POLCFG1;    /*!< EXINT Polarity configuration register 1,     Address offset: 0x08 */
-  __IO uint32_t POLCFG2;    /*!< EXINT Polarity configuration register 2,     Address offset: 0x0C */
-  __IO uint32_t SWTRG;      /*!< EXINT Software trigger register,             Address offset: 0x10 */
-  __IO uint32_t INTSTS;     /*!< EXINT Interrupt status register,             Address offset: 0x14 */
+  __IO uint32_t INTEN;      /*!< EXINT interrupt enable register,             Address offset: 0x00 */
+  __IO uint32_t EVTEN;      /*!< EXINT event enable register,                 Address offset: 0x04 */
+  __IO uint32_t POLCFG1;    /*!< EXINT polarity configuration register 1,     Address offset: 0x08 */
+  __IO uint32_t POLCFG2;    /*!< EXINT polarity configuration register 2,     Address offset: 0x0C */
+  __IO uint32_t SWTRG;      /*!< EXINT software trigger register,             Address offset: 0x10 */
+  __IO uint32_t INTSTS;     /*!< EXINT interrupt status register,             Address offset: 0x14 */
 } EXINT_TypeDef;
 
 /**
@@ -481,7 +481,7 @@ typedef struct
   __IO uint32_t CTRL;              /*!< FLASH control register,                      Address offset: 0x10         */
   __IO uint32_t ADDR;              /*!< FLASH address register,                      Address offset: 0x14         */
   uint32_t      RESERVED0;         /*!< Reserved,                                    Address offset: 0x18         */
-  __IO uint32_t USD;               /*!< FLASH user system data register,             Address offset: 0x1C         */
+  __IO uint32_t FUSD;              /*!< FLASH user system data register,             Address offset: 0x1C         */
   __IO uint32_t EPPS;              /*!< FLASH erase/program protection status reg,   Address offset: 0x20         */
   uint32_t      RESERVED1[20];     /*!< Reserved,                                    Address offset: 0x24 ~ 0x70  */
   __IO uint32_t SLIB_STS0;         /*!< FLASH security library status register 0,    Address offset: 0x74         */
@@ -505,25 +505,25 @@ typedef struct
 
 typedef struct
 {
-  __IO uint16_t FAP;               /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
-  __IO uint16_t SSB;               /*!< USD System configuration byte,               Address offset: 0x1FFF_F802               */
-  __IO uint16_t DATA0;             /*!< USD User data 0,                             Address offset: 0x1FFF_F804               */
-  __IO uint16_t DATA1;             /*!< USD User data 1,                             Address offset: 0x1FFF_F806               */
-  __IO uint16_t EPP0;              /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
-  __IO uint16_t EPP1;              /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
-  __IO uint16_t EPP2;              /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
-  __IO uint16_t EPP3;              /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
-  uint32_t      RESERVED0[9];      /*!< Reserved,                                    Address offset: 0x1FFF_F810 ~ 0x1FFF_F830 */
-  __IO uint16_t QSPIKEY0;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 0,                       Address offset: 0x1FFF_F834               */
-  __IO uint16_t QSPIKEY1;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 1,                       Address offset: 0x1FFF_F836               */
-  __IO uint16_t QSPIKEY2;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 2,                       Address offset: 0x1FFF_F838               */
-  __IO uint16_t QSPIKEY3;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 3,                       Address offset: 0x1FFF_F83A               */
-  uint32_t      RESERVED1[4];      /*!< Reserved,                                    Address offset: 0x1FFF_F83C ~ 0x1FFF_F848 */
-  __IO uint16_t DATA[218];         /*!< USD User data 2 ~ 219,                       Address offset: 0x1FFF_F84C ~ 0x1FFF_F9FC */
+  __IO uint16_t FAP;             /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
+  __IO uint16_t SSB;             /*!< USD system configuration byte,               Address offset: 0x1FFF_F802               */
+  __IO uint16_t DATA0;           /*!< USD user data 0,                             Address offset: 0x1FFF_F804               */
+  __IO uint16_t DATA1;           /*!< USD user data 1,                             Address offset: 0x1FFF_F806               */
+  __IO uint16_t EPP0;            /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
+  __IO uint16_t EPP1;            /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
+  __IO uint16_t EPP2;            /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
+  __IO uint16_t EPP3;            /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
+  uint32_t      RESERVED0[9];    /*!< Reserved,                                    Address offset: 0x1FFF_F810 ~ 0x1FFF_F830 */
+  __IO uint16_t QSPIKEY0;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 0,                       Address offset: 0x1FFF_F834               */
+  __IO uint16_t QSPIKEY1;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 1,                       Address offset: 0x1FFF_F836               */
+  __IO uint16_t QSPIKEY2;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 2,                       Address offset: 0x1FFF_F838               */
+  __IO uint16_t QSPIKEY3;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 3,                       Address offset: 0x1FFF_F83A               */
+  uint32_t      RESERVED1[4];    /*!< Reserved,                                    Address offset: 0x1FFF_F83C ~ 0x1FFF_F848 */
+  __IO uint16_t DATA[218];       /*!< USD user data 2 ~ 219,                       Address offset: 0x1FFF_F84C ~ 0x1FFF_F9FC */
 } USD_TypeDef;
 
 /**
@@ -546,7 +546,6 @@ typedef struct
   __IO uint32_t TOGR;           /*!< GPIO port bit toggle register,               Address offset: 0x2C        */
   uint32_t      RESERVED[3];    /*!< Reserved,                                    Address offset: 0x30 ~ 0x38 */
   __IO uint32_t HDRV;           /*!< GPIO huge current control register,          Address offset: 0x3C        */
-  __IO uint32_t SRCTR;          /*!< GPIO SRCTR register,                         Address offset: 0x40        */
 } GPIO_TypeDef;
 
 /**
@@ -555,17 +554,17 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL1;      /*!< I2C Control register 1,                      Address offset: 0x00 */
-  __IO uint32_t CTRL2;      /*!< I2C Control register 2,                      Address offset: 0x04 */
-  __IO uint32_t OADDR1;     /*!< I2C Own address register 1,                  Address offset: 0x08 */
-  __IO uint32_t OADDR2;     /*!< I2C Own address register 2,                  Address offset: 0x0C */
-  __IO uint32_t CLKCTRL;    /*!< I2C Clock control register,                  Address offset: 0x10 */
-  __IO uint32_t TIMEOUT;    /*!< I2C Timeout register,                        Address offset: 0x14 */
-  __IO uint32_t STS;        /*!< I2C Status register,                         Address offset: 0x18 */
-  __IO uint32_t CLR;        /*!< I2C Status clear flag register,              Address offset: 0x1C */
+  __IO uint32_t CTRL1;      /*!< I2C control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CTRL2;      /*!< I2C control register 2,                      Address offset: 0x04 */
+  __IO uint32_t OADDR1;     /*!< I2C own address register 1,                  Address offset: 0x08 */
+  __IO uint32_t OADDR2;     /*!< I2C own address register 2,                  Address offset: 0x0C */
+  __IO uint32_t CLKCTRL;    /*!< I2C clock control register,                  Address offset: 0x10 */
+  __IO uint32_t TIMEOUT;    /*!< I2C timeout register,                        Address offset: 0x14 */
+  __IO uint32_t STS;        /*!< I2C status register,                         Address offset: 0x18 */
+  __IO uint32_t CLR;        /*!< I2C status clear flag register,              Address offset: 0x1C */
   __IO uint32_t PEC;        /*!< I2C PEC register,                            Address offset: 0x20 */
-  __IO uint32_t RXDT;       /*!< I2C Receive data register,                   Address offset: 0x24 */
-  __IO uint32_t TXDT;       /*!< I2C Transmit data register,                  Address offset: 0x28 */
+  __IO uint32_t RXDT;       /*!< I2C receive data register,                   Address offset: 0x24 */
+  __IO uint32_t TXDT;       /*!< I2C transmit data register,                  Address offset: 0x28 */
 } I2C_TypeDef;
 
 /**
@@ -574,8 +573,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;           /*!< PWC Power control register,                  Address offset: 0x00        */
-  __IO uint32_t CTRLSTS;        /*!< PWC Power control/status register,           Address offset: 0x04        */
+  __IO uint32_t CTRL;           /*!< PWC power control register,                  Address offset: 0x00        */
+  __IO uint32_t CTRLSTS;        /*!< PWC power control/status register,           Address offset: 0x04        */
   uint32_t      RESERVED[2];    /*!< Reserved,                                    Address offset: 0x08 ~ 0x0C */
   __IO uint32_t LDOOV;          /*!< PWC LDO output voltage select register,      Address offset: 0x10        */
 } PWC_TypeDef;
@@ -586,29 +585,29 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD_W0;           /*!< QSPI Command word 0 register,                Address offset: 0x00        */
-  __IO uint32_t CMD_W1;           /*!< QSPI Command word 1 register,                Address offset: 0x04        */
-  __IO uint32_t CMD_W2;           /*!< QSPI Command word 2 register,                Address offset: 0x08        */
-  __IO uint32_t CMD_W3;           /*!< QSPI Command word 3 register,                Address offset: 0x0C        */
-  __IO uint32_t CTRL;             /*!< QSPI Control register,                       Address offset: 0x10        */
+  __IO uint32_t CMD_W0;           /*!< QSPI command word 0 register,                Address offset: 0x00        */
+  __IO uint32_t CMD_W1;           /*!< QSPI command word 1 register,                Address offset: 0x04        */
+  __IO uint32_t CMD_W2;           /*!< QSPI command word 2 register,                Address offset: 0x08        */
+  __IO uint32_t CMD_W3;           /*!< QSPI command word 3 register,                Address offset: 0x0C        */
+  __IO uint32_t CTRL;             /*!< QSPI control register,                       Address offset: 0x10        */
   uint32_t      RESERVED0;        /*!< Reserved,                                    Address offset: 0x14        */
   __IO uint32_t FIFOSTS;          /*!< QSPI FIFO status register,                   Address offset: 0x18        */
   uint32_t      RESERVED1;        /*!< Reserved,                                    Address offset: 0x1C        */
-  __IO uint32_t CTRL2;            /*!< QSPI Control register 2,                     Address offset: 0x20        */
-  __IO uint32_t CMDSTS;           /*!< QSPI Command status register,                Address offset: 0x24        */
-  __IO uint32_t RSTS;             /*!< QSPI Read status register,                   Address offset: 0x28        */
-  __IO uint32_t FSIZE;            /*!< QSPI Flash size register,                    Address offset: 0x2C        */
+  __IO uint32_t CTRL2;            /*!< QSPI control register 2,                     Address offset: 0x20        */
+  __IO uint32_t CMDSTS;           /*!< QSPI command status register,                Address offset: 0x24        */
+  __IO uint32_t RSTS;             /*!< QSPI read status register,                   Address offset: 0x28        */
+  __IO uint32_t FSIZE;            /*!< QSPI flash size register,                    Address offset: 0x2C        */
   __IO uint32_t XIP_CMD_W0;       /*!< QSPI XIP command word 0 register,            Address offset: 0x30        */
   __IO uint32_t XIP_CMD_W1;       /*!< QSPI XIP command word 1 register,            Address offset: 0x34        */
   __IO uint32_t XIP_CMD_W2;       /*!< QSPI XIP command word 2 register,            Address offset: 0x38        */
   __IO uint32_t XIP_CMD_W3;       /*!< QSPI XIP command word 3 register,            Address offset: 0x3C        */
-  __IO uint32_t CTRL3;            /*!< QSPI Control register 3,                     Address offset: 0x40        */
+  __IO uint32_t CTRL3;            /*!< QSPI control register 3,                     Address offset: 0x40        */
   uint32_t      RESERVED2[3];     /*!< Reserved,                                    Address offset: 0x44 ~ 0x4C */
-  __IO uint32_t REV;              /*!< QSPI Revision register,                      Address offset: 0x50        */
+  __IO uint32_t REV;              /*!< QSPI revision register,                      Address offset: 0x50        */
   uint32_t      RESERVED3[43];    /*!< Reserved,                                    Address offset: 0x54 ~ 0xFC */
-  __IO uint8_t  DT_U8;            /*!< QSPI Data port (8-bit) register,             Address offset: 0x100       */
-  __IO uint16_t DT_U16;           /*!< QSPI Data port (16-bit) register,            Address offset: 0x100       */
-  __IO uint32_t DT;               /*!< QSPI Data port register,                     Address offset: 0x100       */
+  __IO uint8_t  DT_U8;            /*!< QSPI data port (8-bit) register,             Address offset: 0x100       */
+  __IO uint16_t DT_U16;           /*!< QSPI data port (16-bit) register,            Address offset: 0x100       */
+  __IO uint32_t DT;               /*!< QSPI data port register,                     Address offset: 0x100       */
 } QSPI_TypeDef;
 
 /**
@@ -666,7 +665,7 @@ typedef struct
   __IO uint32_t C2DT;       /*!< TMR channel 2 data register,                 Address offset: 0x38 */
   __IO uint32_t C3DT;       /*!< TMR channel 3 data register,                 Address offset: 0x3C */
   __IO uint32_t C4DT;       /*!< TMR channel 4 data register,                 Address offset: 0x40 */
-  __IO uint32_t BRK;        /*!< TMR break register,                          Address offset: 0x44 */
+  __IO uint32_t BRK;        /*!< TMR brake register,                          Address offset: 0x44 */
   __IO uint32_t DMACTRL;    /*!< TMR DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMADT;      /*!< TMR DMA data register,                       Address offset: 0x4C */
   __IO uint32_t RMP;        /*!< TMR channel input remap register,            Address offset: 0x50 */
@@ -695,11 +694,11 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD;    /*!< WDT Command register,                        Address offset: 0x00 */
-  __IO uint32_t DIV;    /*!< WDT Divider register,                        Address offset: 0x04 */
-  __IO uint32_t RLD;    /*!< WDT Reload register,                         Address offset: 0x08 */
-  __IO uint32_t STS;    /*!< WDT Status register,                         Address offset: 0x0C */
-  __IO uint32_t WIN;    /*!< WDT Window register,                         Address offset: 0x10 */
+  __IO uint32_t CMD;    /*!< WDT command register,                        Address offset: 0x00 */
+  __IO uint32_t DIV;    /*!< WDT divider register,                        Address offset: 0x04 */
+  __IO uint32_t RLD;    /*!< WDT reload register,                         Address offset: 0x08 */
+  __IO uint32_t STS;    /*!< WDT status register,                         Address offset: 0x0C */
+  __IO uint32_t WIN;    /*!< WDT window register,                         Address offset: 0x10 */
 } WDT_TypeDef;
 
 /**
@@ -708,9 +707,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;    /*!< WWDT Control register,                       Address offset: 0x00 */
-  __IO uint32_t CFG;     /*!< WWDT Configuration register,                 Address offset: 0x04 */
-  __IO uint32_t STS;     /*!< WWDT Status register,                        Address offset: 0x08 */
+  __IO uint32_t CTRL;    /*!< WWDT control register,                       Address offset: 0x00 */
+  __IO uint32_t CFG;     /*!< WWDT configuration register,                 Address offset: 0x04 */
+  __IO uint32_t STS;     /*!< WWDT status register,                        Address offset: 0x08 */
 } WWDT_TypeDef;
 
 /**
@@ -972,7 +971,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Power Control (PWC)                            */
+/*                             Power control (PWC)                            */
 /*                                                                            */
 /******************************************************************************/
 
@@ -1043,7 +1042,7 @@ typedef struct
 #define PWC_CTRLSTS_SWPEN6                  PWC_CTRLSTS_SWPEN6_Msk                  /*!< Standby wake-up pin 6 enable */
 
 /******************  Bit definition for PWC_LDOOV register  *******************/
-/*!< LDOOVSEL congiguration */
+/*!< LDOOVSEL configuration */
 #define PWC_LDOOV_LDOOVSEL_Pos              (0U)
 #define PWC_LDOOV_LDOOVSEL_Msk              (0x3U << PWC_LDOOV_LDOOVSEL_Pos)        /*!< 0x00000003 */
 #define PWC_LDOOV_LDOOVSEL                  PWC_LDOOV_LDOOVSEL_Msk                  /*!< LDOOVSEL[1:0] bits (Voltage regulator output voltage select) */
@@ -1105,7 +1104,7 @@ typedef struct
 #define CRM_CTRL_PLLUSTBL                   CRM_CTRL_PLLUSTBL_Msk                   /*!< PLLU clock stable */
 
 /******************  Bit definition for CRM_PLLCFG register  ******************/
-/*!< PLL_MS congiguration */
+/*!< PLL_MS configuration */
 #define CRM_PLLCFG_PLL_MS_Pos               (0U)
 #define CRM_PLLCFG_PLL_MS_Msk               (0xFU << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x0000000F */
 #define CRM_PLLCFG_PLL_MS                   CRM_PLLCFG_PLL_MS_Msk                   /*!< PLL_MS[3:0] bits (PLL pre-division) */
@@ -1114,7 +1113,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_MS_2                 (0x4U << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x00000004 */
 #define CRM_PLLCFG_PLL_MS_3                 (0x8U << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x00000008 */
 
-/*!< PLL_NS congiguration */
+/*!< PLL_NS configuration */
 #define CRM_PLLCFG_PLL_NS_Pos               (6U)
 #define CRM_PLLCFG_PLL_NS_Msk               (0x1FFU << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00007FC0 */
 #define CRM_PLLCFG_PLL_NS                   CRM_PLLCFG_PLL_NS_Msk                   /*!< PLL_NS[8:0] bits (PLL multiplication factor) */
@@ -1128,7 +1127,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_NS_7                 (0x080U << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00002000 */
 #define CRM_PLLCFG_PLL_NS_8                 (0x100U << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00004000 */
 
-/*!< PLL_FP congiguration */
+/*!< PLL_FP configuration */
 #define CRM_PLLCFG_PLL_FP_Pos               (16U)
 #define CRM_PLLCFG_PLL_FP_Msk               (0xFU << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x000F0000 */
 #define CRM_PLLCFG_PLL_FP                   CRM_PLLCFG_PLL_FP_Msk                   /*!< PLL_FP[3:0] bits (PLLP post-division) */
@@ -1137,7 +1136,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_FP_2                 (0x4U << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x00040000 */
 #define CRM_PLLCFG_PLL_FP_3                 (0x8U << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x00080000 */
 
-/*!< PLL_FU congiguration */
+/*!< PLL_FU configuration */
 #define CRM_PLLCFG_PLL_FU_Pos               (20U)
 #define CRM_PLLCFG_PLL_FU_Msk               (0x7U << CRM_PLLCFG_PLL_FU_Pos)         /*!< 0x00700000 */
 #define CRM_PLLCFG_PLL_FU                   CRM_PLLCFG_PLL_FU_Msk                   /*!< PLL_FU[2:0] bits (PLLU post-division) */
@@ -1286,7 +1285,7 @@ typedef struct
 #define CRM_CFG_CLKOUTDIV1_1                (0x2U << CRM_CFG_CLKOUTDIV1_Pos)        /*!< 0x10000000 */
 #define CRM_CFG_CLKOUTDIV1_2                (0x4U << CRM_CFG_CLKOUTDIV1_Pos)        /*!< 0x20000000 */
 
-#define CRM_CFG_CLKOUTDIV1_DIV1             0x00000000U                             /*!< No clock output */
+#define CRM_CFG_CLKOUTDIV1_DIV1             0x00000000U                             /*!< No clock output division */
 #define CRM_CFG_CLKOUTDIV1_DIV2             0x20000000U                             /*!< Clock output divided by 2 */
 #define CRM_CFG_CLKOUTDIV1_DIV3             0x28000000U                             /*!< Clock output divided by 3 */
 #define CRM_CFG_CLKOUTDIV1_DIV4             0x30000000U                             /*!< Clock output divided by 4 */
@@ -1313,7 +1312,7 @@ typedef struct
 #define CRM_CFG_CLKSEL1_HEXT                CRM_CFG_CLKOUT_SEL1_HEXT
 #define CRM_CFG_CLKSEL1_PLL                 CRM_CFG_CLKOUT_SEL1_PLL
 
-/*!<***************  Bit definition for CRM_CLKINT register  ******************/
+/******************  Bit definition for CRM_CLKINT register  ******************/
 #define CRM_CLKINT_LICKSTBLF_Pos            (0U)
 #define CRM_CLKINT_LICKSTBLF_Msk            (0x1U << CRM_CLKINT_LICKSTBLF_Pos)      /*!< 0x00000001 */
 #define CRM_CLKINT_LICKSTBLF                CRM_CLKINT_LICKSTBLF_Msk                /*!< LICK stable interrupt flag */
@@ -1794,7 +1793,7 @@ typedef struct
 #define CRM_BPDC_LEXTBYPS_Msk               (0x1U << CRM_BPDC_LEXTBYPS_Pos)         /*!< 0x00000004 */
 #define CRM_BPDC_LEXTBYPS                   CRM_BPDC_LEXTBYPS_Msk                   /*!< External low-speed crystal bypass */
 
-/*!< ERTCSEL congiguration */
+/*!< ERTCSEL configuration */
 #define CRM_BPDC_ERTCSEL_Pos                (8U)
 #define CRM_BPDC_ERTCSEL_Msk                (0x3U << CRM_BPDC_ERTCSEL_Pos)          /*!< 0x00000300 */
 #define CRM_BPDC_ERTCSEL                    CRM_BPDC_ERTCSEL_Msk                    /*!< ERTCSEL[1:0] bits (ERTC clock selection) */
@@ -1861,7 +1860,7 @@ typedef struct
 #define CRM_MISC1_HICKRST_Msk               (0x1U << CRM_MISC1_HICKRST_Pos)         /*!< 0x00008000 */
 #define CRM_MISC1_HICKRST                   CRM_MISC1_HICKRST_Msk                   /*!< HICKRST */
 
-/*!< CLKOUT_SEL2 congiguration */
+/*!< CLKOUT_SEL2 configuration */
 #define CRM_MISC1_CLKOUT_SEL2_Pos           (16U)
 #define CRM_MISC1_CLKOUT_SEL2_Msk           (0xFU << CRM_MISC1_CLKOUT_SEL2_Pos)     /*!< 0x000F0000 */
 #define CRM_MISC1_CLKOUT_SEL2               CRM_MISC1_CLKOUT_SEL2_Msk               /*!< CLKOUT_SEL2[3:0] bits (Clock output selection 2) */
@@ -1888,7 +1887,7 @@ typedef struct
 #define CRM_MISC1_CLKSEL2_LICK              CRM_MISC1_CLKOUT_SEL2_LICK
 #define CRM_MISC1_CLKSEL2_LEXT              CRM_MISC1_CLKOUT_SEL2_LEXT
 
-/*!< CLKOUTDIV2 congiguration */
+/*!< CLKOUTDIV2 configuration */
 #define CRM_MISC1_CLKOUTDIV2_Pos            (28U)
 #define CRM_MISC1_CLKOUTDIV2_Msk            (0xFU << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0xF0000000 */
 #define CRM_MISC1_CLKOUTDIV2                CRM_MISC1_CLKOUTDIV2_Msk                /*!< CLKOUTDIV2[3:0] bits (Clock output division 2) */
@@ -1897,7 +1896,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV2_2              (0x4U << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0x40000000 */
 #define CRM_MISC1_CLKOUTDIV2_3              (0x8U << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0x80000000 */
 
-#define CRM_MISC1_CLKOUTDIV2_DIV1           0x00000000U                             /*!< No clock output */
+#define CRM_MISC1_CLKOUTDIV2_DIV1           0x00000000U                             /*!< No clock output division */
 #define CRM_MISC1_CLKOUTDIV2_DIV2           0x80000000U                             /*!< Clock output divided by 2 */
 #define CRM_MISC1_CLKOUTDIV2_DIV4           0x90000000U                             /*!< Clock output divided by 4 */
 #define CRM_MISC1_CLKOUTDIV2_DIV8           0xA0000000U                             /*!< Clock output divided by 8 */
@@ -1908,7 +1907,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV2_DIV512         0xF0000000U                             /*!< Clock output divided by 512 */
 
 /******************  Bit definition for CRM_MISC2 register  *******************/
-/*!< AUTO_STEP_EN congiguration */
+/*!< AUTO_STEP_EN configuration */
 #define CRM_MISC2_AUTO_STEP_EN_Pos          (4U)
 #define CRM_MISC2_AUTO_STEP_EN_Msk          (0x3U << CRM_MISC2_AUTO_STEP_EN_Pos)    /*!< 0x00000030 */
 #define CRM_MISC2_AUTO_STEP_EN              CRM_MISC2_AUTO_STEP_EN_Msk              /*!< AUTO_STEP_EN[1:0] bits (Auto step-by-step SCLK switch enable) */
@@ -1919,7 +1918,7 @@ typedef struct
 #define CRM_MISC2_PLLU_USB48_SEL_Msk        (0x1U << CRM_MISC2_PLLU_USB48_SEL_Pos)  /*!< 0x00000400 */
 #define CRM_MISC2_PLLU_USB48_SEL            CRM_MISC2_PLLU_USB48_SEL_Msk            /*!< USBFS 48M clock source selection */
 
-/*!< HICK_TO_SCLK_DIV congiguration */
+/*!< HICK_TO_SCLK_DIV configuration */
 #define CRM_MISC2_HICK_TO_SCLK_DIV_Pos      (16U)
 #define CRM_MISC2_HICK_TO_SCLK_DIV_Msk      (0x7U << CRM_MISC2_HICK_TO_SCLK_DIV_Pos) /*!< 0x00070000 */
 #define CRM_MISC2_HICK_TO_SCLK_DIV          CRM_MISC2_HICK_TO_SCLK_DIV_Msk           /*!< HICK_TO_SCLK_DIV[2:0] bits (HICK as SCLK frequency division) */
@@ -1933,7 +1932,7 @@ typedef struct
 #define CRM_MISC2_HICK_TO_SCLK_DIV_DIV8     0x00030000U                              /*!< HICK/8 */
 #define CRM_MISC2_HICK_TO_SCLK_DIV_DIV16    0x00040000U                              /*!< HICK/16 */
 
-/*!< HEXT_TO_SCLK_DIV congiguration */
+/*!< HEXT_TO_SCLK_DIV configuration */
 #define CRM_MISC2_HEXT_TO_SCLK_DIV_Pos      (19U)
 #define CRM_MISC2_HEXT_TO_SCLK_DIV_Msk      (0x7U << CRM_MISC2_HEXT_TO_SCLK_DIV_Pos) /*!< 0x00380000 */
 #define CRM_MISC2_HEXT_TO_SCLK_DIV          CRM_MISC2_HEXT_TO_SCLK_DIV_Msk           /*!< HEXT_TO_SCLK_DIV[2:0] bits (HEXT as SCLK frequency division) */
@@ -1950,12 +1949,12 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                Flash and User System Data Registers (FLASH)                */
+/*                Flash and User System Data registers (FLASH)                */
 /*                                                                            */
 /******************************************************************************/
 
-/*******************  Bit definition for FLASH_PSR register  ******************/
-/*!< WTCYC congiguration */
+/******************  Bit definition for FLASH_PSR register  *******************/
+/*!< WTCYC configuration */
 #define FLASH_PSR_WTCYC_Pos                 (0U)
 #define FLASH_PSR_WTCYC_Msk                 (0x7U << FLASH_PSR_WTCYC_Pos)           /*!< 0x00000007 */
 #define FLASH_PSR_WTCYC                     FLASH_PSR_WTCYC_Msk                     /*!< WTCYC[2:0] bits (Wait cycle) */
@@ -2022,7 +2021,7 @@ typedef struct
 #define FLASH_CTRL_FPRGM                    FLASH_CTRL_FPRGM_Msk                    /*!< Flash program */
 #define FLASH_CTRL_SECERS_Pos               (1U)
 #define FLASH_CTRL_SECERS_Msk               (0x1U << FLASH_CTRL_SECERS_Pos)         /*!< 0x00000002 */
-#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Page erase */
+#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Sector erase */
 #define FLASH_CTRL_BANKERS_Pos              (2U)
 #define FLASH_CTRL_BANKERS_Msk              (0x1U << FLASH_CTRL_BANKERS_Pos)        /*!< 0x00000004 */
 #define FLASH_CTRL_BANKERS                  FLASH_CTRL_BANKERS_Msk                  /*!< Bank erase */
@@ -2061,7 +2060,7 @@ typedef struct
 #define FLASH_USD_FAP_Msk                   (0x1U << FLASH_USD_FAP_Pos)             /*!< 0x00000002 */
 #define FLASH_USD_FAP                       FLASH_USD_FAP_Msk                       /*!< Flash access protection */
 
-/*!< SSB congiguration */
+/*!< SSB configuration */
 #define FLASH_USD_WDT_ATO_EN_Pos            (2U)
 #define FLASH_USD_WDT_ATO_EN_Msk            (0x1U << FLASH_USD_WDT_ATO_EN_Pos)      /*!< 0x00000004 */
 #define FLASH_USD_WDT_ATO_EN                FLASH_USD_WDT_ATO_EN_Msk                /*!< nWDT_ATO_EN */
@@ -2102,7 +2101,7 @@ typedef struct
 #define FLASH_EPPS_EPPS_Msk                 (0xFFFFFFFFU << FLASH_EPPS_EPPS_Pos)    /*!< 0xFFFFFFFF */
 #define FLASH_EPPS_EPPS                     FLASH_EPPS_EPPS_Msk                     /*!< Erase/Program protection status */
 
-/*******************  Bit definition for SLIB_STS0 register *******************/
+/******************  Bit definition for SLIB_STS0 register  *******************/
 #define SLIB_STS0_BTM_AP_ENF_Pos            (0U)
 #define SLIB_STS0_BTM_AP_ENF_Msk            (0x1U << SLIB_STS0_BTM_AP_ENF_Pos)      /*!< 0x00000001 */
 #define SLIB_STS0_BTM_AP_ENF                SLIB_STS0_BTM_AP_ENF_Msk                /*!< Boot memory store application code enabled flag */
@@ -2112,27 +2111,27 @@ typedef struct
 #define SLIB_STS0_SLIB_ENF_Pos              (3U)
 #define SLIB_STS0_SLIB_ENF_Msk              (0x1U << SLIB_STS0_SLIB_ENF_Pos)        /*!< 0x00000008 */
 #define SLIB_STS0_SLIB_ENF                  SLIB_STS0_SLIB_ENF_Msk                  /*!< Security library enable flag */
-#define SLIB_STS0_EM_SLIB_INST_SS_Pos       (16U)                                   /*!< 0x00FF0000 */
-#define SLIB_STS0_EM_SLIB_INST_SS_Msk       (0xFFU << SLIB_STS0_EM_SLIB_INST_SS_Pos)
-#define SLIB_STS0_EM_SLIB_INST_SS           SLIB_STS0_EM_SLIB_INST_SS_Msk           /*!< Extension memory sLib instruction start page */
+#define SLIB_STS0_EM_SLIB_DAT_SS_Pos        (16U)
+#define SLIB_STS0_EM_SLIB_DAT_SS_Msk        (0xFFU << SLIB_STS0_EM_SLIB_DAT_SS_Pos) /*!< 0x00FF0000 */
+#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start sector */
 
-/*******************  Bit definition for SLIB_STS1 register *******************/
+/******************  Bit definition for SLIB_STS1 register  *******************/
 #define SLIB_STS1_SLIB_SS_Pos               (0U)
 #define SLIB_STS1_SLIB_SS_Msk               (0x7FFU << SLIB_STS1_SLIB_SS_Pos)       /*!< 0x000007FF */
-#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start page */
-#define SLIB_STS1_SLIB_INST_SS_Pos          (11U)
-#define SLIB_STS1_SLIB_INST_SS_Msk          (0x7FFU << SLIB_STS1_SLIB_INST_SS_Pos)  /*!< 0x003FF800 */
-#define SLIB_STS1_SLIB_INST_SS              SLIB_STS1_SLIB_INST_SS_Msk              /*!< Security library instruction start page */
+#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start sector */
+#define SLIB_STS1_SLIB_DAT_SS_Pos           (11U)
+#define SLIB_STS1_SLIB_DAT_SS_Msk           (0x7FFU << SLIB_STS1_SLIB_DAT_SS_Pos)   /*!< 0x003FF800 */
+#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start sector */
 #define SLIB_STS1_SLIB_ES_Pos               (22U)
 #define SLIB_STS1_SLIB_ES_Msk               (0x3FFU << SLIB_STS1_SLIB_ES_Pos)       /*!< 0xFFC00000 */
-#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end page */
+#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end sector */
 
-/*****************  Bit definition for SLIB_PWD_CLR register ******************/
+/*****************  Bit definition for SLIB_PWD_CLR register  *****************/
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk      (0xFFFFFFFFU << SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos)
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL          SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk          /*!< Security library password clear value */
 
-/*****************  Bit definition for SLIB_MISC_STS register *****************/
+/****************  Bit definition for SLIB_MISC_STS register  *****************/
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Pos      (0U)                                    /*!< 0x00000001 */
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Msk      (0x1U << SLIB_MISC_STS_SLIB_PWD_ERR_Pos)
 #define SLIB_MISC_STS_SLIB_PWD_ERR          SLIB_MISC_STS_SLIB_PWD_ERR_Msk          /*!< Security library password error */
@@ -2143,54 +2142,54 @@ typedef struct
 #define SLIB_MISC_STS_SLIB_ULKF_Msk         (0x1U << SLIB_MISC_STS_SLIB_ULKF_Pos)   /*!< 0x00000004 */
 #define SLIB_MISC_STS_SLIB_ULKF             SLIB_MISC_STS_SLIB_ULKF_Msk             /*!< Security library unlock flag */
 
-/****************  Bit definition for FLASH_CRC_ADDR register *****************/
+/****************  Bit definition for FLASH_CRC_ADDR register  ****************/
 #define FLASH_CRC_ADDR_CRC_ADDR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_ADDR_CRC_ADDR_Msk         (0xFFFFFFFFU << FLASH_CRC_ADDR_CRC_ADDR_Pos)
 #define FLASH_CRC_ADDR_CRC_ADDR             FLASH_CRC_ADDR_CRC_ADDR_Msk             /*!< CRC address */
 
-/****************  Bit definition for FLASH_CRC_CTRL register *****************/
+/****************  Bit definition for FLASH_CRC_CTRL register  ****************/
 #define FLASH_CRC_CTRL_CRC_SN_Pos           (0U)
 #define FLASH_CRC_CTRL_CRC_SN_Msk           (0xFFFFU << FLASH_CRC_CTRL_CRC_SN_Pos)  /*!< 0x0000FFFF */
-#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC page number */
+#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC sector number */
 #define FLASH_CRC_CTRL_CRC_STRT_Pos         (16U)
 #define FLASH_CRC_CTRL_CRC_STRT_Msk         (0x1U << FLASH_CRC_CTRL_CRC_STRT_Pos)   /*!< 0x00010000 */
 #define FLASH_CRC_CTRL_CRC_STRT             FLASH_CRC_CTRL_CRC_STRT_Msk             /*!< CRC start */
 
-/****************  Bit definition for FLASH_CRC_CHKR register *****************/
+/****************  Bit definition for FLASH_CRC_CHKR register  ****************/
 #define FLASH_CRC_CHKR_CRC_CHKR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_CHKR_CRC_CHKR_Msk         (0xFFFFFFFFU << FLASH_CRC_CHKR_CRC_CHKR_Pos)
 #define FLASH_CRC_CHKR_CRC_CHKR             FLASH_CRC_CHKR_CRC_CHKR_Msk             /*!< CRC check result */
 
-/*****************  Bit definition for SLIB_SET_PWD register ******************/
+/*****************  Bit definition for SLIB_SET_PWD register  *****************/
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Msk      (0xFFFFFFFFU << SLIB_SET_PWD_SLIB_PSET_VAL_Pos)
 #define SLIB_SET_PWD_SLIB_PSET_VAL          SLIB_SET_PWD_SLIB_PSET_VAL_Msk          /*!< Security library password setting value */
 
-/****************  Bit definition for SLIB_SET_RANGE register *****************/
+/****************  Bit definition for SLIB_SET_RANGE register  ****************/
 #define SLIB_SET_RANGE_SLIB_SS_SET_Pos      (0U)                                    /*!< 0x000007FF */
 #define SLIB_SET_RANGE_SLIB_SS_SET_Msk      (0x7FFU << SLIB_SET_RANGE_SLIB_SS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start page setting */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_ISS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ISS_SET         SLIB_SET_RANGE_SLIB_ISS_SET_Msk         /*!< Security library instruction start page setting */
+#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start sector setting */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_DSS_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_DSS_SET         SLIB_SET_RANGE_SLIB_DSS_SET_Msk         /*!< Security library data start sector setting */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Pos      (22U)                                   /*!< 0xFFC00000 */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0x3FFU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end page setting */
+#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end sector setting */
 
-/******************  Bit definition for EM_SLIB_SET register ******************/
+/*****************  Bit definition for EM_SLIB_SET register  ******************/
 #define EM_SLIB_SET_EM_SLIB_SET_Pos         (0U)                                    /*!< 0x0000FFFF */
 #define EM_SLIB_SET_EM_SLIB_SET_Msk         (0xFFFFU << EM_SLIB_SET_EM_SLIB_SET_Pos)
 #define EM_SLIB_SET_EM_SLIB_SET             EM_SLIB_SET_EM_SLIB_SET_Msk             /*!< Extension memory sLib setting */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_ISS_SET_Pos)
-#define EM_SLIB_SET_EM_SLIB_ISS_SET         EM_SLIB_SET_EM_SLIB_ISS_SET_Msk         /*!< Extension memory sLib instruction start page setting */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_DSS_SET_Pos)
+#define EM_SLIB_SET_EM_SLIB_DSS_SET         EM_SLIB_SET_EM_SLIB_DSS_SET_Msk         /*!< Extension memory sLib data start sector setting */
 
-/*****************  Bit definition for BTM_MODE_SET register ******************/
+/*****************  Bit definition for BTM_MODE_SET register  *****************/
 #define BTM_MODE_SET_BTM_MODE_SET_Pos       (0U)                                    /*!< 0x000000FF */
 #define BTM_MODE_SET_BTM_MODE_SET_Msk       (0xFFU << BTM_MODE_SET_BTM_MODE_SET_Pos)
 #define BTM_MODE_SET_BTM_MODE_SET           BTM_MODE_SET_BTM_MODE_SET_Msk           /*!< Boot memory mode setting */
 
-/*****************  Bit definition for SLIB_UNLOCK register ******************/
+/*****************  Bit definition for SLIB_UNLOCK register  ******************/
 #define SLIB_UNLOCK_SLIB_UKVAL_Pos          (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_UNLOCK_SLIB_UKVAL_Msk          (0xFFFFFFFFU << SLIB_UNLOCK_SLIB_UKVAL_Pos)
 #define SLIB_UNLOCK_SLIB_UKVAL              SLIB_UNLOCK_SLIB_UKVAL_Msk              /*!< Security library unlock key value */
@@ -2520,7 +2519,7 @@ typedef struct
 #define GPIO_OMODE_OM15_Msk                 (0x1U << GPIO_OMODE_OM15_Pos)           /*!< 0x00008000 */
 #define GPIO_OMODE_OM15                     GPIO_OMODE_OM15_Msk                     /*!< GPIO x output mode configuration, pin 15 */
 
-/*!<***************  Bit definition for GPIO_ODRVR register  ******************/
+/******************  Bit definition for GPIO_ODRVR register  ******************/
 #define GPIO_ODRVR_ODRV_Pos                 (0U)
 #define GPIO_ODRVR_ODRV_Msk                 (0xFFFFFFFFU << GPIO_ODRVR_ODRV_Pos)    /*!< 0xFFFFFFFF */
 #define GPIO_ODRVR_ODRV                     GPIO_ODRVR_ODRV_Msk                     /*!< GPIO x drive capability */
@@ -2637,7 +2636,7 @@ typedef struct
 #define GPIO_ODRVR_ODRV15_0                 (0x1U << GPIO_ODRVR_ODRV15_Pos)         /*!< 0x40000000 */
 #define GPIO_ODRVR_ODRV15_1                 (0x2U << GPIO_ODRVR_ODRV15_Pos)         /*!< 0x80000000 */
 
-/*!<***************  Bit definition for GPIO_PULL register  *******************/
+/******************  Bit definition for GPIO_PULL register  *******************/
 #define GPIO_PULL_PULL_Pos                  (0U)
 #define GPIO_PULL_PULL_Msk                  (0xFFFFFFFFU << GPIO_PULL_PULL_Pos)     /*!< 0xFFFFFFFF */
 #define GPIO_PULL_PULL                      GPIO_PULL_PULL_Msk                      /*!< GPIO x pull-up/pull-down configuration */
@@ -2754,7 +2753,7 @@ typedef struct
 #define GPIO_PULL_PULL15_0                  (0x1U << GPIO_PULL_PULL15_Pos)          /*!< 0x40000000 */
 #define GPIO_PULL_PULL15_1                  (0x2U << GPIO_PULL_PULL15_Pos)          /*!< 0x80000000 */
 
-/*!<****************  Bit definition for GPIO_IDT register  *******************/
+/*******************  Bit definition for GPIO_IDT register  *******************/
 #define GPIO_IDT_IDT0_Pos                   (0U)
 #define GPIO_IDT_IDT0_Msk                   (0x1U << GPIO_IDT_IDT0_Pos)             /*!< 0x00000001 */
 #define GPIO_IDT_IDT0                       GPIO_IDT_IDT0_Msk                       /*!< GPIO x input data, pin 0 */
@@ -3309,56 +3308,6 @@ typedef struct
 #define GPIO_HDRV_HDRV15_Msk                (0x1U << GPIO_HDRV_HDRV15_Pos)          /*!< 0x00008000 */
 #define GPIO_HDRV_HDRV15                    GPIO_HDRV_HDRV15_Msk                    /*!< GPIO x huge sourcing/sinking strength control, pin 15 */
 
-/******************  Bit definition for GPIO_SRCTR register  ******************/
-#define GPIO_SRCTR_SRCTR0_Pos               (0U)
-#define GPIO_SRCTR_SRCTR0_Msk               (0x1U << GPIO_SRCTR_SRCTR0_Pos)           /*!< 0x00000001 */
-#define GPIO_SRCTR_SRCTR0                   GPIO_SRCTR_SRCTR0_Msk                     /*!< GPIO x SRCTR, pin 0 */
-#define GPIO_SRCTR_SRCTR1_Pos               (1U)
-#define GPIO_SRCTR_SRCTR1_Msk               (0x1U << GPIO_SRCTR_SRCTR1_Pos)           /*!< 0x00000002 */
-#define GPIO_SRCTR_SRCTR1                   GPIO_SRCTR_SRCTR1_Msk                     /*!< GPIO x SRCTR, pin 1 */
-#define GPIO_SRCTR_SRCTR2_Pos               (2U)
-#define GPIO_SRCTR_SRCTR2_Msk               (0x1U << GPIO_SRCTR_SRCTR2_Pos)           /*!< 0x00000004 */
-#define GPIO_SRCTR_SRCTR2                   GPIO_SRCTR_SRCTR2_Msk                     /*!< GPIO x SRCTR, pin 2 */
-#define GPIO_SRCTR_SRCTR3_Pos               (3U)
-#define GPIO_SRCTR_SRCTR3_Msk               (0x1U << GPIO_SRCTR_SRCTR3_Pos)           /*!< 0x00000008 */
-#define GPIO_SRCTR_SRCTR3                   GPIO_SRCTR_SRCTR3_Msk                     /*!< GPIO x SRCTR, pin 3 */
-#define GPIO_SRCTR_SRCTR4_Pos               (4U)
-#define GPIO_SRCTR_SRCTR4_Msk               (0x1U << GPIO_SRCTR_SRCTR4_Pos)           /*!< 0x00000010 */
-#define GPIO_SRCTR_SRCTR4                   GPIO_SRCTR_SRCTR4_Msk                     /*!< GPIO x SRCTR, pin 4 */
-#define GPIO_SRCTR_SRCTR5_Pos               (5U)
-#define GPIO_SRCTR_SRCTR5_Msk               (0x1U << GPIO_SRCTR_SRCTR5_Pos)           /*!< 0x00000020 */
-#define GPIO_SRCTR_SRCTR5                   GPIO_SRCTR_SRCTR5_Msk                     /*!< GPIO x SRCTR, pin 5 */
-#define GPIO_SRCTR_SRCTR6_Pos               (6U)
-#define GPIO_SRCTR_SRCTR6_Msk               (0x1U << GPIO_SRCTR_SRCTR6_Pos)           /*!< 0x00000040 */
-#define GPIO_SRCTR_SRCTR6                   GPIO_SRCTR_SRCTR6_Msk                     /*!< GPIO x SRCTR, pin 6 */
-#define GPIO_SRCTR_SRCTR7_Pos               (7U)
-#define GPIO_SRCTR_SRCTR7_Msk               (0x1U << GPIO_SRCTR_SRCTR7_Pos)           /*!< 0x00000080 */
-#define GPIO_SRCTR_SRCTR7                   GPIO_SRCTR_SRCTR7_Msk                     /*!< GPIO x SRCTR, pin 7 */
-#define GPIO_SRCTR_SRCTR8_Pos               (8U)
-#define GPIO_SRCTR_SRCTR8_Msk               (0x1U << GPIO_SRCTR_SRCTR8_Pos)           /*!< 0x00000100 */
-#define GPIO_SRCTR_SRCTR8                   GPIO_SRCTR_SRCTR8_Msk                     /*!< GPIO x SRCTR, pin 8 */
-#define GPIO_SRCTR_SRCTR9_Pos               (9U)
-#define GPIO_SRCTR_SRCTR9_Msk               (0x1U << GPIO_SRCTR_SRCTR9_Pos)           /*!< 0x00000200 */
-#define GPIO_SRCTR_SRCTR9                   GPIO_SRCTR_SRCTR9_Msk                     /*!< GPIO x SRCTR, pin 9 */
-#define GPIO_SRCTR_SRCTR10_Pos              (10U)
-#define GPIO_SRCTR_SRCTR10_Msk              (0x1U << GPIO_SRCTR_SRCTR10_Pos)          /*!< 0x00000400 */
-#define GPIO_SRCTR_SRCTR10                  GPIO_SRCTR_SRCTR10_Msk                    /*!< GPIO x SRCTR, pin 10 */
-#define GPIO_SRCTR_SRCTR11_Pos              (11U)
-#define GPIO_SRCTR_SRCTR11_Msk              (0x1U << GPIO_SRCTR_SRCTR11_Pos)          /*!< 0x00000800 */
-#define GPIO_SRCTR_SRCTR11                  GPIO_SRCTR_SRCTR11_Msk                    /*!< GPIO x SRCTR, pin 11 */
-#define GPIO_SRCTR_SRCTR12_Pos              (12U)
-#define GPIO_SRCTR_SRCTR12_Msk              (0x1U << GPIO_SRCTR_SRCTR12_Pos)          /*!< 0x00001000 */
-#define GPIO_SRCTR_SRCTR12                  GPIO_SRCTR_SRCTR12_Msk                    /*!< GPIO x SRCTR, pin 12 */
-#define GPIO_SRCTR_SRCTR13_Pos              (13U)
-#define GPIO_SRCTR_SRCTR13_Msk              (0x1U << GPIO_SRCTR_SRCTR13_Pos)          /*!< 0x00002000 */
-#define GPIO_SRCTR_SRCTR13                  GPIO_SRCTR_SRCTR13_Msk                    /*!< GPIO x SRCTR, pin 13 */
-#define GPIO_SRCTR_SRCTR14_Pos              (14U)
-#define GPIO_SRCTR_SRCTR14_Msk              (0x1U << GPIO_SRCTR_SRCTR14_Pos)          /*!< 0x00004000 */
-#define GPIO_SRCTR_SRCTR14                  GPIO_SRCTR_SRCTR14_Msk                    /*!< GPIO x SRCTR, pin 14 */
-#define GPIO_SRCTR_SRCTR15_Pos              (15U)
-#define GPIO_SRCTR_SRCTR15_Msk              (0x1U << GPIO_SRCTR_SRCTR15_Pos)          /*!< 0x00008000 */
-#define GPIO_SRCTR_SRCTR15                  GPIO_SRCTR_SRCTR15_Msk                    /*!< GPIO x SRCTR, pin 15 */
-
 /******************************************************************************/
 /*                                                                            */
 /*                   System configuration controller (SCFG)                   */
@@ -3515,7 +3464,7 @@ typedef struct
 #define SCFG_EXINTC2_EXINT4_GPF_Msk         (0x1U << SCFG_EXINTC2_EXINT4_GPF_Pos)   /*!< 0x00000004 */
 #define SCFG_EXINTC2_EXINT4_GPF             SCFG_EXINTC2_EXINT4_GPF_Msk             /*!< GPIOF pin 4 */
 
-/* EXINT5 configuration */
+/*!< EXINT5 configuration */
 #define SCFG_EXINTC2_EXINT5_Pos             (4U)
 #define SCFG_EXINTC2_EXINT5_Msk             (0xFU << SCFG_EXINTC2_EXINT5_Pos)       /*!< 0x000000F0 */
 #define SCFG_EXINTC2_EXINT5                 SCFG_EXINTC2_EXINT5_Msk                 /*!< EXINT5[3:0] bits (EXINT5 input source configuration) */
@@ -3650,7 +3599,7 @@ typedef struct
 #define SCFG_EXINTC3_EXINT11_GPF            SCFG_EXINTC3_EXINT11_GPF_Msk            /*!< GPIOF pin 11 */
 
 /*****************  Bit definition for SCFG_EXINTC4 register  *****************/
-/* EXINT12 configuration */
+/*!< EXINT12 configuration */
 #define SCFG_EXINTC4_EXINT12_Pos            (0U)
 #define SCFG_EXINTC4_EXINT12_Msk            (0xFU << SCFG_EXINTC4_EXINT12_Pos)      /*!< 0x0000000F */
 #define SCFG_EXINTC4_EXINT12                SCFG_EXINTC4_EXINT12_Msk                /*!< EXINT12[3:0] bits (EXINT12 input source configuration) */
@@ -3669,7 +3618,7 @@ typedef struct
 #define SCFG_EXINTC4_EXINT12_GPF_Msk        (0x1U << SCFG_EXINTC4_EXINT12_GPF_Pos)  /*!< 0x00000004 */
 #define SCFG_EXINTC4_EXINT12_GPF            SCFG_EXINTC4_EXINT12_GPF_Msk            /*!< GPIOF pin 12 */
 
-/* EXINT13 configuration */
+/*!< EXINT13 configuration */
 #define SCFG_EXINTC4_EXINT13_Pos            (4U)
 #define SCFG_EXINTC4_EXINT13_Msk            (0xFU << SCFG_EXINTC4_EXINT13_Pos)      /*!< 0x000000F0 */
 #define SCFG_EXINTC4_EXINT13                SCFG_EXINTC4_EXINT13_Msk                /*!< EXINT13[3:0] bits (EXINT13 input source configuration) */
@@ -3811,7 +3760,7 @@ typedef struct
 #define EXINT_INTEN_INTEN22_Msk             (0x1U << EXINT_INTEN_INTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTEN_INTEN22                 EXINT_INTEN_INTEN22_Msk                 /*!< Interrupt enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTEN_INT0                    EXINT_INTEN_INTEN0
 #define EXINT_INTEN_INT1                    EXINT_INTEN_INTEN1
 #define EXINT_INTEN_INT2                    EXINT_INTEN_INTEN2
@@ -3904,7 +3853,7 @@ typedef struct
 #define EXINT_EVTEN_EVTEN22_Msk             (0x1U << EXINT_EVTEN_EVTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_EVTEN_EVTEN22                 EXINT_EVTEN_EVTEN22_Msk                 /*!< Event enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_EVTEN_EVT0                    EXINT_EVTEN_EVTEN0
 #define EXINT_EVTEN_EVT1                    EXINT_EVTEN_EVTEN1
 #define EXINT_EVTEN_EVT2                    EXINT_EVTEN_EVTEN2
@@ -3996,7 +3945,7 @@ typedef struct
 #define EXINT_POLCFG1_RP22_Msk              (0x1U << EXINT_POLCFG1_RP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG1_RP22                  EXINT_POLCFG1_RP22_Msk                  /*!< Rising edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG1_POL0                  EXINT_POLCFG1_RP0
 #define EXINT_POLCFG1_POL1                  EXINT_POLCFG1_RP1
 #define EXINT_POLCFG1_POL2                  EXINT_POLCFG1_RP2
@@ -4088,7 +4037,7 @@ typedef struct
 #define EXINT_POLCFG2_FP22_Msk              (0x1U << EXINT_POLCFG2_FP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG2_FP22                  EXINT_POLCFG2_FP22_Msk                  /*!< Falling edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG2_POL0                  EXINT_POLCFG2_FP0
 #define EXINT_POLCFG2_POL1                  EXINT_POLCFG2_FP1
 #define EXINT_POLCFG2_POL2                  EXINT_POLCFG2_FP2
@@ -4180,7 +4129,7 @@ typedef struct
 #define EXINT_SWTRG_SWT22_Msk               (0x1U << EXINT_SWTRG_SWT22_Pos)         /*!< 0x00400000 */
 #define EXINT_SWTRG_SWT22                   EXINT_SWTRG_SWT22_Msk                   /*!< Software trigger on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_SWTRG_SW0                     EXINT_SWTRG_SWT0
 #define EXINT_SWTRG_SW1                     EXINT_SWTRG_SWT1
 #define EXINT_SWTRG_SW2                     EXINT_SWTRG_SWT2
@@ -4272,7 +4221,7 @@ typedef struct
 #define EXINT_INTSTS_LINE22_Msk             (0x1U << EXINT_INTSTS_LINE22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTSTS_LINE22                 EXINT_INTSTS_LINE22_Msk                 /*!< Status bit for line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTSTS_INT0                   EXINT_INTSTS_LINE0
 #define EXINT_INTSTS_INT1                   EXINT_INTSTS_LINE1
 #define EXINT_INTSTS_INT2                   EXINT_INTSTS_LINE2
@@ -4827,8 +4776,8 @@ typedef struct
 
 /******************  Bit definition for I2C_OADDR1 register  ******************/
 /*!< ADDR1 configuration */
-#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface Address */
-#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface Address */
+#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface address */
+#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface address */
 
 #define I2C_OADDR1_ADDR1_0_Pos              (0U)
 #define I2C_OADDR1_ADDR1_0_Msk              (0x1U << I2C_OADDR1_ADDR1_0_Pos)        /*!< 0x00000001 */
@@ -5310,7 +5259,7 @@ typedef struct
 #define SPI_CTRL1_NTC                       SPI_CTRL1_NTC_Msk                       /*!< Transmit CRC next */
 #define SPI_CTRL1_CCEN_Pos                  (13U)
 #define SPI_CTRL1_CCEN_Msk                  (0x1U << SPI_CTRL1_CCEN_Pos)            /*!< 0x00002000 */
-#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< RC calculation enable */
+#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< CRC calculation enable */
 #define SPI_CTRL1_SLBTD_Pos                 (14U)
 #define SPI_CTRL1_SLBTD_Msk                 (0x1U << SPI_CTRL1_SLBTD_Pos)           /*!< 0x00004000 */
 #define SPI_CTRL1_SLBTD                     SPI_CTRL1_SLBTD_Msk                     /*!< Single line bidirectional half-duplex transmission direction */
@@ -5381,7 +5330,7 @@ typedef struct
 #define SPI_DT_DT_Msk                       (0xFFFFU << SPI_DT_DT_Pos)              /*!< 0x0000FFFF */
 #define SPI_DT_DT                           SPI_DT_DT_Msk                           /*!< Data value */
 
-/*******************  Bit definition for SPI_CPOLY register  ******************/
+/******************  Bit definition for SPI_CPOLY register  *******************/
 #define SPI_CPOLY_CPOLY_Pos                 (0U)
 #define SPI_CPOLY_CPOLY_Msk                 (0xFFFFU << SPI_CPOLY_CPOLY_Pos)        /*!< 0x0000FFFF */
 #define SPI_CPOLY_CPOLY                     SPI_CPOLY_CPOLY_Msk                     /*!< CRC polynomial */
@@ -6617,12 +6566,12 @@ typedef struct
 #define ADC_PCDTO4_PCDTO4_Msk               (0xFFFU << ADC_PCDTO4_PCDTO4_Pos)       /*!< 0x00000FFF */
 #define ADC_PCDTO4_PCDTO4                   ADC_PCDTO4_PCDTO4_Msk                   /*!< Data offset for Preempted channel 4 */
 
-/*******************  Bit definition for ADC_VMHB register  ********************/
+/*******************  Bit definition for ADC_VMHB register  *******************/
 #define ADC_VMHB_VMHB_Pos                   (0U)
 #define ADC_VMHB_VMHB_Msk                   (0xFFFFU << ADC_VMHB_VMHB_Pos)          /*!< 0x0000FFFF */
 #define ADC_VMHB_VMHB                       ADC_VMHB_VMHB_Msk                       /*!< Voltage monitoring high boundary */
 
-/*******************  Bit definition for ADC_VMLB register  ********************/
+/*******************  Bit definition for ADC_VMLB register  *******************/
 #define ADC_VMLB_VMLB_Pos                   (0U)
 #define ADC_VMLB_VMLB_Msk                   (0xFFFFU << ADC_VMLB_VMLB_Pos)          /*!< 0x0000FFFF */
 #define ADC_VMLB_VMLB                       ADC_VMLB_VMLB_Msk                       /*!< Voltage monitoring low boundary */
@@ -7068,7 +7017,7 @@ typedef struct
 #define CAN_TSTS_TMNR_Msk                   (0x3U << CAN_TSTS_TMNR_Pos)             /*!< 0x03000000 */
 #define CAN_TSTS_TMNR                       CAN_TSTS_TMNR_Msk                       /*!< TMNR[1:0] bits (Transmit mailbox number record) */
 
-/*!< TMEF congiguration */
+/*!< TMEF configuration */
 #define CAN_TSTS_TMEF_Pos                   (26U)
 #define CAN_TSTS_TMEF_Msk                   (0x7U << CAN_TSTS_TMEF_Pos)             /*!< 0x1C000000 */
 #define CAN_TSTS_TMEF                       CAN_TSTS_TMEF_Msk                       /*!< TMEF[2:0] bits (Transmit mailbox empty flag) */
@@ -7082,7 +7031,7 @@ typedef struct
 #define CAN_TSTS_TM2EF_Msk                  (0x1U << CAN_TSTS_TM2EF_Pos)            /*!< 0x10000000 */
 #define CAN_TSTS_TM2EF                      CAN_TSTS_TM2EF_Msk                      /*!< Transmit mailbox 2 empty flag */
 
-/*!< TMLPF congiguration */
+/*!< TMLPF configuration */
 #define CAN_TSTS_TMLPF_Pos                  (29U)
 #define CAN_TSTS_TMLPF_Msk                  (0x7U << CAN_TSTS_TMLPF_Pos)            /*!< 0xE0000000 */
 #define CAN_TSTS_TMLPF                      CAN_TSTS_TMLPF_Msk                      /*!< TMLPF[2:0] bits (Transmit mailbox lowest priority flag) */
@@ -7179,7 +7128,7 @@ typedef struct
 #define CAN_ESTS_BOF_Msk                    (0x1U << CAN_ESTS_BOF_Pos)              /*!< 0x00000004 */
 #define CAN_ESTS_BOF                        CAN_ESTS_BOF_Msk                        /*!< Bus-off flag */
 
-/*!< ETR congiguration */
+/*!< ETR configuration */
 #define CAN_ESTS_ETR_Pos                    (4U)
 #define CAN_ESTS_ETR_Msk                    (0x7U << CAN_ESTS_ETR_Pos)              /*!< 0x00000070 */
 #define CAN_ESTS_ETR                        CAN_ESTS_ETR_Msk                        /*!< ETR[2:0] bits (Error type record) */
@@ -7199,7 +7148,7 @@ typedef struct
 #define CAN_BTMG_BRDIV_Msk                  (0xFFFU << CAN_BTMG_BRDIV_Pos)          /*!< 0x00000FFF */
 #define CAN_BTMG_BRDIV                      CAN_BTMG_BRDIV_Msk                      /*!< Baud rate division */
 
-/*!< BTS1 congiguration */
+/*!< BTS1 configuration */
 #define CAN_BTMG_BTS1_Pos                   (16U)
 #define CAN_BTMG_BTS1_Msk                   (0xFU << CAN_BTMG_BTS1_Pos)             /*!< 0x000F0000 */
 #define CAN_BTMG_BTS1                       CAN_BTMG_BTS1_Msk                       /*!< BTS1[3:0] bits (Bit time segment 1) */
@@ -7208,7 +7157,7 @@ typedef struct
 #define CAN_BTMG_BTS1_2                     (0x4U << CAN_BTMG_BTS1_Pos)             /*!< 0x00040000 */
 #define CAN_BTMG_BTS1_3                     (0x8U << CAN_BTMG_BTS1_Pos)             /*!< 0x00080000 */
 
-/*!< BTS2 congiguration */
+/*!< BTS2 configuration */
 #define CAN_BTMG_BTS2_Pos                   (20U)
 #define CAN_BTMG_BTS2_Msk                   (0x7U << CAN_BTMG_BTS2_Pos)             /*!< 0x00700000 */
 #define CAN_BTMG_BTS2                       CAN_BTMG_BTS2_Msk                       /*!< BTS2[2:0] bits (Bit time segment 2) */
@@ -7216,7 +7165,7 @@ typedef struct
 #define CAN_BTMG_BTS2_1                     (0x2U << CAN_BTMG_BTS2_Pos)             /*!< 0x00200000 */
 #define CAN_BTMG_BTS2_2                     (0x4U << CAN_BTMG_BTS2_Pos)             /*!< 0x00400000 */
 
-/*!< RSAW congiguration */
+/*!< RSAW configuration */
 #define CAN_BTMG_RSAW_Pos                   (24U)
 #define CAN_BTMG_RSAW_Msk                   (0x3U << CAN_BTMG_RSAW_Pos)             /*!< 0x03000000 */
 #define CAN_BTMG_RSAW                       CAN_BTMG_RSAW_Msk                       /*!< RSAW[1:0] bits (Resynchronization width) */
@@ -10677,7 +10626,7 @@ typedef struct
 #define QSPI_CMD_W0_SPIADR                  QSPI_CMD_W0_SPIADR_Msk                  /*!< SPI Flash address */
 
 /*****************  Bit definition for QSPI_CMD_W1 register  ******************/
-/*!< ADRLEN congiguration */
+/*!< ADRLEN configuration */
 #define QSPI_CMD_W1_ADRLEN_Pos              (0U)
 #define QSPI_CMD_W1_ADRLEN_Msk              (0x7U << QSPI_CMD_W1_ADRLEN_Pos)        /*!< 0x00000007 */
 #define QSPI_CMD_W1_ADRLEN                  QSPI_CMD_W1_ADRLEN_Msk                  /*!< ADRLEN[2:0] bits (SPI address length) */
@@ -10691,7 +10640,7 @@ typedef struct
 #define QSPI_CMD_W1_ADRLEN_3BYTE            0x00000003U                             /*!< 3-byte address */
 #define QSPI_CMD_W1_ADRLEN_4BYTE            0x00000004U                             /*!< 4-byte address */
 
-/*!< DUM2 congiguration */
+/*!< DUM2 configuration */
 #define QSPI_CMD_W1_DUM2_Pos                (16U)
 #define QSPI_CMD_W1_DUM2_Msk                (0xFFU << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00FF0000 */
 #define QSPI_CMD_W1_DUM2                    QSPI_CMD_W1_DUM2_Msk                    /*!< DUM2[7:0] bits (Second dummy state cycle) */
@@ -10704,7 +10653,7 @@ typedef struct
 #define QSPI_CMD_W1_DUM2_6                  (0x40U << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00400000 */
 #define QSPI_CMD_W1_DUM2_7                  (0x80U << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00800000 */
 
-/*!< INSLEN congiguration */
+/*!< INSLEN configuration */
 #define QSPI_CMD_W1_INSLEN_Pos              (24U)
 #define QSPI_CMD_W1_INSLEN_Msk              (0x3U << QSPI_CMD_W1_INSLEN_Pos)        /*!< 0x03000000 */
 #define QSPI_CMD_W1_INSLEN                  QSPI_CMD_W1_INSLEN_Msk                  /*!< INSLEN[1:0] bits (Instruction code length) */
@@ -10735,7 +10684,7 @@ typedef struct
 #define QSPI_CMD_W3_RSTSC_Msk               (0x1U << QSPI_CMD_W3_RSTSC_Pos)         /*!< 0x00000008 */
 #define QSPI_CMD_W3_RSTSC                   QSPI_CMD_W3_RSTSC_Msk                   /*!< Read SPI status configuration */
 
-/*!< OPMODE congiguration */
+/*!< OPMODE configuration */
 #define QSPI_CMD_W3_OPMODE_Pos              (5U)
 #define QSPI_CMD_W3_OPMODE_Msk              (0x7U << QSPI_CMD_W3_OPMODE_Pos)        /*!< 0x000000E0 */
 #define QSPI_CMD_W3_OPMODE                  QSPI_CMD_W3_OPMODE_Msk                  /*!< OPMODE[2:0] bits (SPI Operation mode) */
@@ -10759,7 +10708,7 @@ typedef struct
 #define QSPI_CMD_W3_INSC                    QSPI_CMD_W3_INSC_Msk                    /*!< Instruction code */
 
 /******************  Bit definition for QSPI_CTRL register  *******************/
-/*!< CLKDIV congiguration */
+/*!< CLKDIV configuration */
 #define QSPI_CTRL_CLKDIV_Pos                (0U)
 #define QSPI_CTRL_CLKDIV_Msk                (0x7U << QSPI_CTRL_CLKDIV_Pos)          /*!< 0x00000007 */
 #define QSPI_CTRL_CLKDIV                    QSPI_CTRL_CLKDIV_Msk                    /*!< CLKDIV[2:0] bits (Clock divider) */
@@ -10786,7 +10735,7 @@ typedef struct
 #define QSPI_CTRL_ABORT_Msk                 (0x1U << QSPI_CTRL_ABORT_Pos)           /*!< 0x00000100 */
 #define QSPI_CTRL_ABORT                     QSPI_CTRL_ABORT_Msk                     /*!< Refresh all commands/FIFOs and reset state machine */
 
-/*!< BUSY congiguration */
+/*!< BUSY configuration */
 #define QSPI_CTRL_BUSY_Pos                  (16U)
 #define QSPI_CTRL_BUSY_Msk                  (0x7U << QSPI_CTRL_BUSY_Pos)            /*!< 0x00070000 */
 #define QSPI_CTRL_BUSY                      QSPI_CTRL_BUSY_Msk                      /*!< BUSY[2:0] bits (Busy bit of SPI status) */
@@ -10829,7 +10778,7 @@ typedef struct
 #define QSPI_CTRL2_CMDIE_Msk                (0x1U << QSPI_CTRL2_CMDIE_Pos)          /*!< 0x00000002 */
 #define QSPI_CTRL2_CMDIE                    QSPI_CTRL2_CMDIE_Msk                    /*!< Command complete Interrupt enable */
 
-/*!< TXFIFO_THOD congiguration */
+/*!< TXFIFO_THOD configuration */
 #define QSPI_CTRL2_TXFIFO_THOD_Pos          (8U)
 #define QSPI_CTRL2_TXFIFO_THOD_Msk          (0x3U << QSPI_CTRL2_TXFIFO_THOD_Pos)    /*!< 0x00000300 */
 #define QSPI_CTRL2_TXFIFO_THOD              QSPI_CTRL2_TXFIFO_THOD_Msk              /*!< TXFIFO_THOD[1:0] bits (Program the level value to trigger TX FIFO threshold IRQ) */
@@ -10840,7 +10789,7 @@ typedef struct
 #define QSPI_CTRL2_TXFIFO_THOD_16WORD       0x00000100U                             /*!< 16 WORD */
 #define QSPI_CTRL2_TXFIFO_THOD_24WORD       0x00000200U                             /*!< 24 WORD */
 
-/*!< RXFIFO_THOD congiguration */
+/*!< RXFIFO_THOD configuration */
 #define QSPI_CTRL2_RXFIFO_THOD_Pos          (12U)
 #define QSPI_CTRL2_RXFIFO_THOD_Msk          (0x3U << QSPI_CTRL2_RXFIFO_THOD_Pos)    /*!< 0x00003000 */
 #define QSPI_CTRL2_RXFIFO_THOD              QSPI_CTRL2_RXFIFO_THOD_Msk              /*!< RXFIFO_THOD[1:0] bits (Program the level value to trigger RX FIFO threshold IRQ) */
@@ -10867,7 +10816,7 @@ typedef struct
 #define QSPI_FSIZE_SPIFSIZE                 QSPI_FSIZE_SPIFSIZE_Msk                 /*!< SPI flash size */
 
 /***************  Bit definition for QSPI_XIP_CMD_W0 register  ****************/
-/*!< XIPR_DUM2 congiguration */
+/*!< XIPR_DUM2 configuration */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_Pos       (0U)
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_Msk       (0xFFU << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x000000FF */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2           QSPI_XIP_CMD_W0_XIPR_DUM2_Msk            /*!< XIPR_DUM2[7:0] bits (XIP read second dummy cycle) */
@@ -10880,7 +10829,7 @@ typedef struct
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_6         (0x40U << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x00000040 */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_7         (0x80U << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x00000080 */
 
-/*!< XIPR_OPMODE congiguration */
+/*!< XIPR_OPMODE configuration */
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE_Pos     (8U)                                      /*!< 0x00000700 */
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE_Msk     (0x7U << QSPI_XIP_CMD_W0_XIPR_OPMODE_Pos)
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE         QSPI_XIP_CMD_W0_XIPR_OPMODE_Msk           /*!< XIPR_OPMODE[2:0] bits (XIP read operation mode) */
@@ -10904,7 +10853,7 @@ typedef struct
 #define QSPI_XIP_CMD_W0_XIPR_INSC           QSPI_XIP_CMD_W0_XIPR_INSC_Msk           /*!< XIP read instruction code */
 
 /***************  Bit definition for QSPI_XIP_CMD_W1 register  ****************/
-/*!< XIPW_DUM2 congiguration */
+/*!< XIPW_DUM2 configuration */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_Pos       (0U)
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_Msk       (0xFFU << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x000000FF */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2           QSPI_XIP_CMD_W1_XIPW_DUM2_Msk            /*!< XIPW_DUM2[7:0] bits (XIP write second dummy cycle) */
@@ -10917,7 +10866,7 @@ typedef struct
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_6         (0x40U << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x00000040 */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_7         (0x80U << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x00000080 */
 
-/*!< XIPW_OPMODE congiguration */
+/*!< XIPW_OPMODE configuration */
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE_Pos     (8U)                                      /*!< 0x00000700 */
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE_Msk     (0x7U << QSPI_XIP_CMD_W1_XIPW_OPMODE_Pos)
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE         QSPI_XIP_CMD_W1_XIPW_OPMODE_Msk           /*!< XIPW_OPMODE[2:0] bits (XIP write operation mode) */
@@ -10990,7 +10939,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for DEBUG_IDCODE register  *****************/
-/*!< PID congiguration */
+/*!< PID configuration */
 #define DEBUG_IDCODE_PID_Pos                (0U)
 #define DEBUG_IDCODE_PID_Msk                (0xFFFFFFFFU << DEBUG_IDCODE_PID_Pos)   /*!< 0xFFFFFFFF */
 #define DEBUG_IDCODE_PID                    DEBUG_IDCODE_PID_Msk                    /*!< PID[31:0] bits (PID information) */
@@ -11097,7 +11046,7 @@ typedef struct
 #define DEBUG_APB2_PAUSE_TMR11_PAUSE        DEBUG_APB2_PAUSE_TMR11_PAUSE_Msk        /*!< TMR11 pause control bit */
 
 /*****************  Bit definition for DEBUG_SER_ID register  *****************/
-/*!< REV_ID congiguration */
+/*!< REV_ID configuration */
 #define DEBUG_SER_ID_REV_ID_Pos             (0U)
 #define DEBUG_SER_ID_REV_ID_Msk             (0x7U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000007 */
 #define DEBUG_SER_ID_REV_ID                 DEBUG_SER_ID_REV_ID_Msk                 /*!< REV_ID[2:0] bits (Revision ID) */
@@ -11105,7 +11054,7 @@ typedef struct
 #define DEBUG_SER_ID_REV_ID_1               (0x2U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000002 */
 #define DEBUG_SER_ID_REV_ID_2               (0x4U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000004 */
 
-/*!< SER_ID congiguration */
+/*!< SER_ID configuration */
 #define DEBUG_SER_ID_SER_ID_Pos             (8U)
 #define DEBUG_SER_ID_SER_ID_Msk             (0xFFU << DEBUG_SER_ID_SER_ID_Pos)      /*!< 0x0000FF00 */
 #define DEBUG_SER_ID_SER_ID                 DEBUG_SER_ID_SER_ID_Msk                 /*!< SER_ID[7:0] bits (Serial ID) */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F402_405/at32f402_405kx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F402_405/at32f402_405kx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f402_405kx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian & Maxjta
-  * @version v2.1.2
-  * @date    20-Jan-2025
+  * @version v2.1.4
+  * @date    24-Nov-2025
   * @brief   AT32F402_405Kx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.2
+  * @brief CMSIS Device version number V2.1.4
   */
 #define __AT32F402_405_LIBRARY_VERSION_MAJOR  (0x02) /*!< [31:24] major version */
 #define __AT32F402_405_LIBRARY_VERSION_MIDDLE (0x01) /*!< [23:16] middle version */
-#define __AT32F402_405_LIBRARY_VERSION_MINOR  (0x02) /*!< [15:8]  minor version */
+#define __AT32F402_405_LIBRARY_VERSION_MINOR  (0x04) /*!< [15:8]  minor version */
 #define __AT32F402_405_LIBRARY_VERSION_RC     (0x00) /*!< [7:0]   release candidate */
 #define __AT32F402_405_LIBRARY_VERSION        ((__AT32F402_405_LIBRARY_VERSION_MAJOR  << 24)\
                                               |(__AT32F402_405_LIBRARY_VERSION_MIDDLE << 16)\
@@ -99,7 +99,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                   */
 
 /******  AT32 specific Interrupt Numbers **********************************************************/
-  WWDT_IRQn                   = 0,      /*!< Window WatchDog Timer Interrupt                      */
+  WWDT_IRQn                   = 0,      /*!< Window WATCHDOG Timer Interrupt                      */
   PVM_IRQn                    = 1,      /*!< PVM Interrupt linked to EXINT16                      */
   TAMPER_IRQn                 = 2,      /*!< Tamper Interrupt linked to EXINT21                   */
   ERTC_WKUP_IRQn              = 3,      /*!< ERTC Wake Up Interrupt linked to EXINT22             */
@@ -189,12 +189,12 @@ typedef enum
 
 typedef struct
 {
-  __IO uint32_t STS;      /*!< ACC Status register,                         Address offset: 0x00 */
-  __IO uint32_t CTRL1;    /*!< ACC Control register 1,                      Address offset: 0x04 */
-  __IO uint32_t CTRL2;    /*!< ACC Control register 2,                      Address offset: 0x08 */
-  __IO uint32_t CP1;      /*!< ACC Compare value 1,                         Address offset: 0x0C */
-  __IO uint32_t CP2;      /*!< ACC Compare value 2,                         Address offset: 0x10 */
-  __IO uint32_t CP3;      /*!< ACC Compare value 3,                         Address offset: 0x14 */
+  __IO uint32_t STS;      /*!< ACC status register,                         Address offset: 0x00 */
+  __IO uint32_t CTRL1;    /*!< ACC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CTRL2;    /*!< ACC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t CP1;      /*!< ACC compare value 1,                         Address offset: 0x0C */
+  __IO uint32_t CP2;      /*!< ACC compare value 2,                         Address offset: 0x10 */
+  __IO uint32_t CP3;      /*!< ACC compare value 3,                         Address offset: 0x14 */
 } ACC_TypeDef;
 
 /**
@@ -281,8 +281,8 @@ typedef struct
   __IO uint32_t ESTS;                                /*!< CAN error status register,                   Address offset: 0x018         */
   __IO uint32_t BTMG;                                /*!< CAN bit timing register,                     Address offset: 0x01C         */
   uint32_t      RESERVED0[88];                       /*!< Reserved,                                    Address offset: 0x020 ~ 0x17C */
-  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX Mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
-  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO Mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
+  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
+  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
   uint32_t      RESERVED1[12];                       /*!< Reserved,                                    Address offset: 0x1D0 ~ 0x1FC */
   __IO uint32_t FCTRL;                               /*!< CAN filter control register,                 Address offset: 0x200         */
   __IO uint32_t FMCFG;                               /*!< CAN filter mode configuration register,      Address offset: 0x204         */
@@ -302,12 +302,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t DT;          /*!< CRC Data register,                           Address offset: 0x00 */
-  __IO uint32_t CDT;         /*!< CRC Common data register,                    Address offset: 0x04 */
-  __IO uint32_t CTRL;        /*!< CRC Control register,                        Address offset: 0x08 */
+  __IO uint32_t DT;          /*!< CRC data register,                           Address offset: 0x00 */
+  __IO uint32_t CDT;         /*!< CRC common data register,                    Address offset: 0x04 */
+  __IO uint32_t CTRL;        /*!< CRC control register,                        Address offset: 0x08 */
   uint32_t      RESERVED;    /*!< Reserved,                                    Address offset: 0x0C */
-  __IO uint32_t IDT;         /*!< CRC Initialization register,                 Address offset: 0x10 */
-  __IO uint32_t POLY;        /*!< CRC Polynomial register,                     Address offset: 0x14 */
+  __IO uint32_t IDT;         /*!< CRC initialization register,                 Address offset: 0x10 */
+  __IO uint32_t POLY;        /*!< CRC polynomial register,                     Address offset: 0x14 */
 } CRC_TypeDef;
 
 /**
@@ -316,10 +316,10 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;            /*!< CRM Clock control register,                  Address offset: 0x00        */
+  __IO uint32_t CTRL;            /*!< CRM clock control register,                  Address offset: 0x00        */
   __IO uint32_t PLLCFG;          /*!< CRM PLL clock configuration register,        Address offset: 0x04        */
-  __IO uint32_t CFG;             /*!< CRM Clock configuration register,            Address offset: 0x08        */
-  __IO uint32_t CLKINT;          /*!< CRM Clock interrupt register,                Address offset: 0x0C        */
+  __IO uint32_t CFG;             /*!< CRM clock configuration register,            Address offset: 0x08        */
+  __IO uint32_t CLKINT;          /*!< CRM clock interrupt register,                Address offset: 0x0C        */
   __IO uint32_t AHBRST1;         /*!< CRM AHB peripheral reset register 1,         Address offset: 0x10        */
   __IO uint32_t AHBRST2;         /*!< CRM AHB peripheral reset register 2,         Address offset: 0x14        */
   __IO uint32_t AHBRST3;         /*!< CRM AHB peripheral reset register 3,         Address offset: 0x18        */
@@ -341,12 +341,12 @@ typedef struct
   __IO uint32_t APB1LPEN;        /*!< CRM APB1 periph clk enable in LP mode reg,   Address offset: 0x60        */
   __IO uint32_t APB2LPEN;        /*!< CRM APB2 periph clk enable in LP mode reg,   Address offset: 0x64        */
   uint32_t      RESERVED5[2];    /*!< Reserved,                                    Address offset: 0x68 ~ 0x6C */
-  __IO uint32_t BPDC;            /*!< CRM Battery powered domain control register, Address offset: 0x70        */
-  __IO uint32_t CTRLSTS;         /*!< CRM Control/status register,                 Address offset: 0x74        */
+  __IO uint32_t BPDC;            /*!< CRM battery powered domain control register, Address offset: 0x70        */
+  __IO uint32_t CTRLSTS;         /*!< CRM control/status register,                 Address offset: 0x74        */
   __IO uint32_t OTGHS;           /*!< CRM OTGHS control register (F405 only),      Address offset: 0x78        */
   uint32_t      RESERVED6[9];    /*!< Reserved,                                    Address offset: 0x7C ~ 0x9C */
-  __IO uint32_t MISC1;           /*!< CRM Additional register 1,                   Address offset: 0xA0        */
-  __IO uint32_t MISC2;           /*!< CRM Additional register 2,                   Address offset: 0xA4        */
+  __IO uint32_t MISC1;           /*!< CRM additional register 1,                   Address offset: 0xA0        */
+  __IO uint32_t MISC2;           /*!< CRM additional register 2,                   Address offset: 0xA4        */
 } CRM_TypeDef;
 
 /**
@@ -459,12 +459,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t INTEN;      /*!< EXINT Interrupt enable register,             Address offset: 0x00 */
-  __IO uint32_t EVTEN;      /*!< EXINT Event enable register,                 Address offset: 0x04 */
-  __IO uint32_t POLCFG1;    /*!< EXINT Polarity configuration register 1,     Address offset: 0x08 */
-  __IO uint32_t POLCFG2;    /*!< EXINT Polarity configuration register 2,     Address offset: 0x0C */
-  __IO uint32_t SWTRG;      /*!< EXINT Software trigger register,             Address offset: 0x10 */
-  __IO uint32_t INTSTS;     /*!< EXINT Interrupt status register,             Address offset: 0x14 */
+  __IO uint32_t INTEN;      /*!< EXINT interrupt enable register,             Address offset: 0x00 */
+  __IO uint32_t EVTEN;      /*!< EXINT event enable register,                 Address offset: 0x04 */
+  __IO uint32_t POLCFG1;    /*!< EXINT polarity configuration register 1,     Address offset: 0x08 */
+  __IO uint32_t POLCFG2;    /*!< EXINT polarity configuration register 2,     Address offset: 0x0C */
+  __IO uint32_t SWTRG;      /*!< EXINT software trigger register,             Address offset: 0x10 */
+  __IO uint32_t INTSTS;     /*!< EXINT interrupt status register,             Address offset: 0x14 */
 } EXINT_TypeDef;
 
 /**
@@ -480,7 +480,7 @@ typedef struct
   __IO uint32_t CTRL;              /*!< FLASH control register,                      Address offset: 0x10         */
   __IO uint32_t ADDR;              /*!< FLASH address register,                      Address offset: 0x14         */
   uint32_t      RESERVED0;         /*!< Reserved,                                    Address offset: 0x18         */
-  __IO uint32_t USD;               /*!< FLASH user system data register,             Address offset: 0x1C         */
+  __IO uint32_t FUSD;              /*!< FLASH user system data register,             Address offset: 0x1C         */
   __IO uint32_t EPPS;              /*!< FLASH erase/program protection status reg,   Address offset: 0x20         */
   uint32_t      RESERVED1[20];     /*!< Reserved,                                    Address offset: 0x24 ~ 0x70  */
   __IO uint32_t SLIB_STS0;         /*!< FLASH security library status register 0,    Address offset: 0x74         */
@@ -504,25 +504,25 @@ typedef struct
 
 typedef struct
 {
-  __IO uint16_t FAP;               /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
-  __IO uint16_t SSB;               /*!< USD System configuration byte,               Address offset: 0x1FFF_F802               */
-  __IO uint16_t DATA0;             /*!< USD User data 0,                             Address offset: 0x1FFF_F804               */
-  __IO uint16_t DATA1;             /*!< USD User data 1,                             Address offset: 0x1FFF_F806               */
-  __IO uint16_t EPP0;              /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
-  __IO uint16_t EPP1;              /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
-  __IO uint16_t EPP2;              /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
-  __IO uint16_t EPP3;              /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
-  uint32_t      RESERVED0[9];      /*!< Reserved,                                    Address offset: 0x1FFF_F810 ~ 0x1FFF_F830 */
-  __IO uint16_t QSPIKEY0;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 0,                       Address offset: 0x1FFF_F834               */
-  __IO uint16_t QSPIKEY1;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 1,                       Address offset: 0x1FFF_F836               */
-  __IO uint16_t QSPIKEY2;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 2,                       Address offset: 0x1FFF_F838               */
-  __IO uint16_t QSPIKEY3;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 3,                       Address offset: 0x1FFF_F83A               */
-  uint32_t      RESERVED1[4];      /*!< Reserved,                                    Address offset: 0x1FFF_F83C ~ 0x1FFF_F848 */
-  __IO uint16_t DATA[218];         /*!< USD User data 2 ~ 219,                       Address offset: 0x1FFF_F84C ~ 0x1FFF_F9FC */
+  __IO uint16_t FAP;             /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
+  __IO uint16_t SSB;             /*!< USD system configuration byte,               Address offset: 0x1FFF_F802               */
+  __IO uint16_t DATA0;           /*!< USD user data 0,                             Address offset: 0x1FFF_F804               */
+  __IO uint16_t DATA1;           /*!< USD user data 1,                             Address offset: 0x1FFF_F806               */
+  __IO uint16_t EPP0;            /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
+  __IO uint16_t EPP1;            /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
+  __IO uint16_t EPP2;            /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
+  __IO uint16_t EPP3;            /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
+  uint32_t      RESERVED0[9];    /*!< Reserved,                                    Address offset: 0x1FFF_F810 ~ 0x1FFF_F830 */
+  __IO uint16_t QSPIKEY0;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 0,                       Address offset: 0x1FFF_F834               */
+  __IO uint16_t QSPIKEY1;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 1,                       Address offset: 0x1FFF_F836               */
+  __IO uint16_t QSPIKEY2;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 2,                       Address offset: 0x1FFF_F838               */
+  __IO uint16_t QSPIKEY3;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 3,                       Address offset: 0x1FFF_F83A               */
+  uint32_t      RESERVED1[4];    /*!< Reserved,                                    Address offset: 0x1FFF_F83C ~ 0x1FFF_F848 */
+  __IO uint16_t DATA[218];       /*!< USD user data 2 ~ 219,                       Address offset: 0x1FFF_F84C ~ 0x1FFF_F9FC */
 } USD_TypeDef;
 
 /**
@@ -545,7 +545,6 @@ typedef struct
   __IO uint32_t TOGR;           /*!< GPIO port bit toggle register,               Address offset: 0x2C        */
   uint32_t      RESERVED[3];    /*!< Reserved,                                    Address offset: 0x30 ~ 0x38 */
   __IO uint32_t HDRV;           /*!< GPIO huge current control register,          Address offset: 0x3C        */
-  __IO uint32_t SRCTR;          /*!< GPIO SRCTR register,                         Address offset: 0x40        */
 } GPIO_TypeDef;
 
 /**
@@ -554,17 +553,17 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL1;      /*!< I2C Control register 1,                      Address offset: 0x00 */
-  __IO uint32_t CTRL2;      /*!< I2C Control register 2,                      Address offset: 0x04 */
-  __IO uint32_t OADDR1;     /*!< I2C Own address register 1,                  Address offset: 0x08 */
-  __IO uint32_t OADDR2;     /*!< I2C Own address register 2,                  Address offset: 0x0C */
-  __IO uint32_t CLKCTRL;    /*!< I2C Clock control register,                  Address offset: 0x10 */
-  __IO uint32_t TIMEOUT;    /*!< I2C Timeout register,                        Address offset: 0x14 */
-  __IO uint32_t STS;        /*!< I2C Status register,                         Address offset: 0x18 */
-  __IO uint32_t CLR;        /*!< I2C Status clear flag register,              Address offset: 0x1C */
+  __IO uint32_t CTRL1;      /*!< I2C control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CTRL2;      /*!< I2C control register 2,                      Address offset: 0x04 */
+  __IO uint32_t OADDR1;     /*!< I2C own address register 1,                  Address offset: 0x08 */
+  __IO uint32_t OADDR2;     /*!< I2C own address register 2,                  Address offset: 0x0C */
+  __IO uint32_t CLKCTRL;    /*!< I2C clock control register,                  Address offset: 0x10 */
+  __IO uint32_t TIMEOUT;    /*!< I2C timeout register,                        Address offset: 0x14 */
+  __IO uint32_t STS;        /*!< I2C status register,                         Address offset: 0x18 */
+  __IO uint32_t CLR;        /*!< I2C status clear flag register,              Address offset: 0x1C */
   __IO uint32_t PEC;        /*!< I2C PEC register,                            Address offset: 0x20 */
-  __IO uint32_t RXDT;       /*!< I2C Receive data register,                   Address offset: 0x24 */
-  __IO uint32_t TXDT;       /*!< I2C Transmit data register,                  Address offset: 0x28 */
+  __IO uint32_t RXDT;       /*!< I2C receive data register,                   Address offset: 0x24 */
+  __IO uint32_t TXDT;       /*!< I2C transmit data register,                  Address offset: 0x28 */
 } I2C_TypeDef;
 
 /**
@@ -573,8 +572,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;           /*!< PWC Power control register,                  Address offset: 0x00        */
-  __IO uint32_t CTRLSTS;        /*!< PWC Power control/status register,           Address offset: 0x04        */
+  __IO uint32_t CTRL;           /*!< PWC power control register,                  Address offset: 0x00        */
+  __IO uint32_t CTRLSTS;        /*!< PWC power control/status register,           Address offset: 0x04        */
   uint32_t      RESERVED[2];    /*!< Reserved,                                    Address offset: 0x08 ~ 0x0C */
   __IO uint32_t LDOOV;          /*!< PWC LDO output voltage select register,      Address offset: 0x10        */
 } PWC_TypeDef;
@@ -585,29 +584,29 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD_W0;           /*!< QSPI Command word 0 register,                Address offset: 0x00        */
-  __IO uint32_t CMD_W1;           /*!< QSPI Command word 1 register,                Address offset: 0x04        */
-  __IO uint32_t CMD_W2;           /*!< QSPI Command word 2 register,                Address offset: 0x08        */
-  __IO uint32_t CMD_W3;           /*!< QSPI Command word 3 register,                Address offset: 0x0C        */
-  __IO uint32_t CTRL;             /*!< QSPI Control register,                       Address offset: 0x10        */
+  __IO uint32_t CMD_W0;           /*!< QSPI command word 0 register,                Address offset: 0x00        */
+  __IO uint32_t CMD_W1;           /*!< QSPI command word 1 register,                Address offset: 0x04        */
+  __IO uint32_t CMD_W2;           /*!< QSPI command word 2 register,                Address offset: 0x08        */
+  __IO uint32_t CMD_W3;           /*!< QSPI command word 3 register,                Address offset: 0x0C        */
+  __IO uint32_t CTRL;             /*!< QSPI control register,                       Address offset: 0x10        */
   uint32_t      RESERVED0;        /*!< Reserved,                                    Address offset: 0x14        */
   __IO uint32_t FIFOSTS;          /*!< QSPI FIFO status register,                   Address offset: 0x18        */
   uint32_t      RESERVED1;        /*!< Reserved,                                    Address offset: 0x1C        */
-  __IO uint32_t CTRL2;            /*!< QSPI Control register 2,                     Address offset: 0x20        */
-  __IO uint32_t CMDSTS;           /*!< QSPI Command status register,                Address offset: 0x24        */
-  __IO uint32_t RSTS;             /*!< QSPI Read status register,                   Address offset: 0x28        */
-  __IO uint32_t FSIZE;            /*!< QSPI Flash size register,                    Address offset: 0x2C        */
+  __IO uint32_t CTRL2;            /*!< QSPI control register 2,                     Address offset: 0x20        */
+  __IO uint32_t CMDSTS;           /*!< QSPI command status register,                Address offset: 0x24        */
+  __IO uint32_t RSTS;             /*!< QSPI read status register,                   Address offset: 0x28        */
+  __IO uint32_t FSIZE;            /*!< QSPI flash size register,                    Address offset: 0x2C        */
   __IO uint32_t XIP_CMD_W0;       /*!< QSPI XIP command word 0 register,            Address offset: 0x30        */
   __IO uint32_t XIP_CMD_W1;       /*!< QSPI XIP command word 1 register,            Address offset: 0x34        */
   __IO uint32_t XIP_CMD_W2;       /*!< QSPI XIP command word 2 register,            Address offset: 0x38        */
   __IO uint32_t XIP_CMD_W3;       /*!< QSPI XIP command word 3 register,            Address offset: 0x3C        */
-  __IO uint32_t CTRL3;            /*!< QSPI Control register 3,                     Address offset: 0x40        */
+  __IO uint32_t CTRL3;            /*!< QSPI control register 3,                     Address offset: 0x40        */
   uint32_t      RESERVED2[3];     /*!< Reserved,                                    Address offset: 0x44 ~ 0x4C */
-  __IO uint32_t REV;              /*!< QSPI Revision register,                      Address offset: 0x50        */
+  __IO uint32_t REV;              /*!< QSPI revision register,                      Address offset: 0x50        */
   uint32_t      RESERVED3[43];    /*!< Reserved,                                    Address offset: 0x54 ~ 0xFC */
-  __IO uint8_t  DT_U8;            /*!< QSPI Data port (8-bit) register,             Address offset: 0x100       */
-  __IO uint16_t DT_U16;           /*!< QSPI Data port (16-bit) register,            Address offset: 0x100       */
-  __IO uint32_t DT;               /*!< QSPI Data port register,                     Address offset: 0x100       */
+  __IO uint8_t  DT_U8;            /*!< QSPI data port (8-bit) register,             Address offset: 0x100       */
+  __IO uint16_t DT_U16;           /*!< QSPI data port (16-bit) register,            Address offset: 0x100       */
+  __IO uint32_t DT;               /*!< QSPI data port register,                     Address offset: 0x100       */
 } QSPI_TypeDef;
 
 /**
@@ -665,7 +664,7 @@ typedef struct
   __IO uint32_t C2DT;       /*!< TMR channel 2 data register,                 Address offset: 0x38 */
   __IO uint32_t C3DT;       /*!< TMR channel 3 data register,                 Address offset: 0x3C */
   __IO uint32_t C4DT;       /*!< TMR channel 4 data register,                 Address offset: 0x40 */
-  __IO uint32_t BRK;        /*!< TMR break register,                          Address offset: 0x44 */
+  __IO uint32_t BRK;        /*!< TMR brake register,                          Address offset: 0x44 */
   __IO uint32_t DMACTRL;    /*!< TMR DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMADT;      /*!< TMR DMA data register,                       Address offset: 0x4C */
   __IO uint32_t RMP;        /*!< TMR channel input remap register,            Address offset: 0x50 */
@@ -694,11 +693,11 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD;    /*!< WDT Command register,                        Address offset: 0x00 */
-  __IO uint32_t DIV;    /*!< WDT Divider register,                        Address offset: 0x04 */
-  __IO uint32_t RLD;    /*!< WDT Reload register,                         Address offset: 0x08 */
-  __IO uint32_t STS;    /*!< WDT Status register,                         Address offset: 0x0C */
-  __IO uint32_t WIN;    /*!< WDT Window register,                         Address offset: 0x10 */
+  __IO uint32_t CMD;    /*!< WDT command register,                        Address offset: 0x00 */
+  __IO uint32_t DIV;    /*!< WDT divider register,                        Address offset: 0x04 */
+  __IO uint32_t RLD;    /*!< WDT reload register,                         Address offset: 0x08 */
+  __IO uint32_t STS;    /*!< WDT status register,                         Address offset: 0x0C */
+  __IO uint32_t WIN;    /*!< WDT window register,                         Address offset: 0x10 */
 } WDT_TypeDef;
 
 /**
@@ -707,9 +706,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;    /*!< WWDT Control register,                       Address offset: 0x00 */
-  __IO uint32_t CFG;     /*!< WWDT Configuration register,                 Address offset: 0x04 */
-  __IO uint32_t STS;     /*!< WWDT Status register,                        Address offset: 0x08 */
+  __IO uint32_t CTRL;    /*!< WWDT control register,                       Address offset: 0x00 */
+  __IO uint32_t CFG;     /*!< WWDT configuration register,                 Address offset: 0x04 */
+  __IO uint32_t STS;     /*!< WWDT status register,                        Address offset: 0x08 */
 } WWDT_TypeDef;
 
 /**
@@ -969,7 +968,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Power Control (PWC)                            */
+/*                             Power control (PWC)                            */
 /*                                                                            */
 /******************************************************************************/
 
@@ -1040,7 +1039,7 @@ typedef struct
 #define PWC_CTRLSTS_SWPEN6                  PWC_CTRLSTS_SWPEN6_Msk                  /*!< Standby wake-up pin 6 enable */
 
 /******************  Bit definition for PWC_LDOOV register  *******************/
-/*!< LDOOVSEL congiguration */
+/*!< LDOOVSEL configuration */
 #define PWC_LDOOV_LDOOVSEL_Pos              (0U)
 #define PWC_LDOOV_LDOOVSEL_Msk              (0x3U << PWC_LDOOV_LDOOVSEL_Pos)        /*!< 0x00000003 */
 #define PWC_LDOOV_LDOOVSEL                  PWC_LDOOV_LDOOVSEL_Msk                  /*!< LDOOVSEL[1:0] bits (Voltage regulator output voltage select) */
@@ -1102,7 +1101,7 @@ typedef struct
 #define CRM_CTRL_PLLUSTBL                   CRM_CTRL_PLLUSTBL_Msk                   /*!< PLLU clock stable */
 
 /******************  Bit definition for CRM_PLLCFG register  ******************/
-/*!< PLL_MS congiguration */
+/*!< PLL_MS configuration */
 #define CRM_PLLCFG_PLL_MS_Pos               (0U)
 #define CRM_PLLCFG_PLL_MS_Msk               (0xFU << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x0000000F */
 #define CRM_PLLCFG_PLL_MS                   CRM_PLLCFG_PLL_MS_Msk                   /*!< PLL_MS[3:0] bits (PLL pre-division) */
@@ -1111,7 +1110,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_MS_2                 (0x4U << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x00000004 */
 #define CRM_PLLCFG_PLL_MS_3                 (0x8U << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x00000008 */
 
-/*!< PLL_NS congiguration */
+/*!< PLL_NS configuration */
 #define CRM_PLLCFG_PLL_NS_Pos               (6U)
 #define CRM_PLLCFG_PLL_NS_Msk               (0x1FFU << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00007FC0 */
 #define CRM_PLLCFG_PLL_NS                   CRM_PLLCFG_PLL_NS_Msk                   /*!< PLL_NS[8:0] bits (PLL multiplication factor) */
@@ -1125,7 +1124,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_NS_7                 (0x080U << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00002000 */
 #define CRM_PLLCFG_PLL_NS_8                 (0x100U << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00004000 */
 
-/*!< PLL_FP congiguration */
+/*!< PLL_FP configuration */
 #define CRM_PLLCFG_PLL_FP_Pos               (16U)
 #define CRM_PLLCFG_PLL_FP_Msk               (0xFU << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x000F0000 */
 #define CRM_PLLCFG_PLL_FP                   CRM_PLLCFG_PLL_FP_Msk                   /*!< PLL_FP[3:0] bits (PLLP post-division) */
@@ -1134,7 +1133,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_FP_2                 (0x4U << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x00040000 */
 #define CRM_PLLCFG_PLL_FP_3                 (0x8U << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x00080000 */
 
-/*!< PLL_FU congiguration */
+/*!< PLL_FU configuration */
 #define CRM_PLLCFG_PLL_FU_Pos               (20U)
 #define CRM_PLLCFG_PLL_FU_Msk               (0x7U << CRM_PLLCFG_PLL_FU_Pos)         /*!< 0x00700000 */
 #define CRM_PLLCFG_PLL_FU                   CRM_PLLCFG_PLL_FU_Msk                   /*!< PLL_FU[2:0] bits (PLLU post-division) */
@@ -1283,7 +1282,7 @@ typedef struct
 #define CRM_CFG_CLKOUTDIV1_1                (0x2U << CRM_CFG_CLKOUTDIV1_Pos)        /*!< 0x10000000 */
 #define CRM_CFG_CLKOUTDIV1_2                (0x4U << CRM_CFG_CLKOUTDIV1_Pos)        /*!< 0x20000000 */
 
-#define CRM_CFG_CLKOUTDIV1_DIV1             0x00000000U                             /*!< No clock output */
+#define CRM_CFG_CLKOUTDIV1_DIV1             0x00000000U                             /*!< No clock output division */
 #define CRM_CFG_CLKOUTDIV1_DIV2             0x20000000U                             /*!< Clock output divided by 2 */
 #define CRM_CFG_CLKOUTDIV1_DIV3             0x28000000U                             /*!< Clock output divided by 3 */
 #define CRM_CFG_CLKOUTDIV1_DIV4             0x30000000U                             /*!< Clock output divided by 4 */
@@ -1310,7 +1309,7 @@ typedef struct
 #define CRM_CFG_CLKSEL1_HEXT                CRM_CFG_CLKOUT_SEL1_HEXT
 #define CRM_CFG_CLKSEL1_PLL                 CRM_CFG_CLKOUT_SEL1_PLL
 
-/*!<***************  Bit definition for CRM_CLKINT register  ******************/
+/******************  Bit definition for CRM_CLKINT register  ******************/
 #define CRM_CLKINT_LICKSTBLF_Pos            (0U)
 #define CRM_CLKINT_LICKSTBLF_Msk            (0x1U << CRM_CLKINT_LICKSTBLF_Pos)      /*!< 0x00000001 */
 #define CRM_CLKINT_LICKSTBLF                CRM_CLKINT_LICKSTBLF_Msk                /*!< LICK stable interrupt flag */
@@ -1782,7 +1781,7 @@ typedef struct
 #define CRM_BPDC_LEXTBYPS_Msk               (0x1U << CRM_BPDC_LEXTBYPS_Pos)         /*!< 0x00000004 */
 #define CRM_BPDC_LEXTBYPS                   CRM_BPDC_LEXTBYPS_Msk                   /*!< External low-speed crystal bypass */
 
-/*!< ERTCSEL congiguration */
+/*!< ERTCSEL configuration */
 #define CRM_BPDC_ERTCSEL_Pos                (8U)
 #define CRM_BPDC_ERTCSEL_Msk                (0x3U << CRM_BPDC_ERTCSEL_Pos)          /*!< 0x00000300 */
 #define CRM_BPDC_ERTCSEL                    CRM_BPDC_ERTCSEL_Msk                    /*!< ERTCSEL[1:0] bits (ERTC clock selection) */
@@ -1849,7 +1848,7 @@ typedef struct
 #define CRM_MISC1_HICKRST_Msk               (0x1U << CRM_MISC1_HICKRST_Pos)         /*!< 0x00008000 */
 #define CRM_MISC1_HICKRST                   CRM_MISC1_HICKRST_Msk                   /*!< HICKRST */
 
-/*!< CLKOUT_SEL2 congiguration */
+/*!< CLKOUT_SEL2 configuration */
 #define CRM_MISC1_CLKOUT_SEL2_Pos           (16U)
 #define CRM_MISC1_CLKOUT_SEL2_Msk           (0xFU << CRM_MISC1_CLKOUT_SEL2_Pos)     /*!< 0x000F0000 */
 #define CRM_MISC1_CLKOUT_SEL2               CRM_MISC1_CLKOUT_SEL2_Msk               /*!< CLKOUT_SEL2[3:0] bits (Clock output selection 2) */
@@ -1876,7 +1875,7 @@ typedef struct
 #define CRM_MISC1_CLKSEL2_LICK              CRM_MISC1_CLKOUT_SEL2_LICK
 #define CRM_MISC1_CLKSEL2_LEXT              CRM_MISC1_CLKOUT_SEL2_LEXT
 
-/*!< CLKOUTDIV2 congiguration */
+/*!< CLKOUTDIV2 configuration */
 #define CRM_MISC1_CLKOUTDIV2_Pos            (28U)
 #define CRM_MISC1_CLKOUTDIV2_Msk            (0xFU << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0xF0000000 */
 #define CRM_MISC1_CLKOUTDIV2                CRM_MISC1_CLKOUTDIV2_Msk                /*!< CLKOUTDIV2[3:0] bits (Clock output division 2) */
@@ -1885,7 +1884,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV2_2              (0x4U << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0x40000000 */
 #define CRM_MISC1_CLKOUTDIV2_3              (0x8U << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0x80000000 */
 
-#define CRM_MISC1_CLKOUTDIV2_DIV1           0x00000000U                             /*!< No clock output */
+#define CRM_MISC1_CLKOUTDIV2_DIV1           0x00000000U                             /*!< No clock output division */
 #define CRM_MISC1_CLKOUTDIV2_DIV2           0x80000000U                             /*!< Clock output divided by 2 */
 #define CRM_MISC1_CLKOUTDIV2_DIV4           0x90000000U                             /*!< Clock output divided by 4 */
 #define CRM_MISC1_CLKOUTDIV2_DIV8           0xA0000000U                             /*!< Clock output divided by 8 */
@@ -1896,7 +1895,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV2_DIV512         0xF0000000U                             /*!< Clock output divided by 512 */
 
 /******************  Bit definition for CRM_MISC2 register  *******************/
-/*!< AUTO_STEP_EN congiguration */
+/*!< AUTO_STEP_EN configuration */
 #define CRM_MISC2_AUTO_STEP_EN_Pos          (4U)
 #define CRM_MISC2_AUTO_STEP_EN_Msk          (0x3U << CRM_MISC2_AUTO_STEP_EN_Pos)    /*!< 0x00000030 */
 #define CRM_MISC2_AUTO_STEP_EN              CRM_MISC2_AUTO_STEP_EN_Msk              /*!< AUTO_STEP_EN[1:0] bits (Auto step-by-step SCLK switch enable) */
@@ -1907,7 +1906,7 @@ typedef struct
 #define CRM_MISC2_PLLU_USB48_SEL_Msk        (0x1U << CRM_MISC2_PLLU_USB48_SEL_Pos)  /*!< 0x00000400 */
 #define CRM_MISC2_PLLU_USB48_SEL            CRM_MISC2_PLLU_USB48_SEL_Msk            /*!< USBFS 48M clock source selection */
 
-/*!< HICK_TO_SCLK_DIV congiguration */
+/*!< HICK_TO_SCLK_DIV configuration */
 #define CRM_MISC2_HICK_TO_SCLK_DIV_Pos      (16U)
 #define CRM_MISC2_HICK_TO_SCLK_DIV_Msk      (0x7U << CRM_MISC2_HICK_TO_SCLK_DIV_Pos) /*!< 0x00070000 */
 #define CRM_MISC2_HICK_TO_SCLK_DIV          CRM_MISC2_HICK_TO_SCLK_DIV_Msk           /*!< HICK_TO_SCLK_DIV[2:0] bits (HICK as SCLK frequency division) */
@@ -1921,7 +1920,7 @@ typedef struct
 #define CRM_MISC2_HICK_TO_SCLK_DIV_DIV8     0x00030000U                              /*!< HICK/8 */
 #define CRM_MISC2_HICK_TO_SCLK_DIV_DIV16    0x00040000U                              /*!< HICK/16 */
 
-/*!< HEXT_TO_SCLK_DIV congiguration */
+/*!< HEXT_TO_SCLK_DIV configuration */
 #define CRM_MISC2_HEXT_TO_SCLK_DIV_Pos      (19U)
 #define CRM_MISC2_HEXT_TO_SCLK_DIV_Msk      (0x7U << CRM_MISC2_HEXT_TO_SCLK_DIV_Pos) /*!< 0x00380000 */
 #define CRM_MISC2_HEXT_TO_SCLK_DIV          CRM_MISC2_HEXT_TO_SCLK_DIV_Msk           /*!< HEXT_TO_SCLK_DIV[2:0] bits (HEXT as SCLK frequency division) */
@@ -1938,12 +1937,12 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                Flash and User System Data Registers (FLASH)                */
+/*                Flash and User System Data registers (FLASH)                */
 /*                                                                            */
 /******************************************************************************/
 
-/*******************  Bit definition for FLASH_PSR register  ******************/
-/*!< WTCYC congiguration */
+/******************  Bit definition for FLASH_PSR register  *******************/
+/*!< WTCYC configuration */
 #define FLASH_PSR_WTCYC_Pos                 (0U)
 #define FLASH_PSR_WTCYC_Msk                 (0x7U << FLASH_PSR_WTCYC_Pos)           /*!< 0x00000007 */
 #define FLASH_PSR_WTCYC                     FLASH_PSR_WTCYC_Msk                     /*!< WTCYC[2:0] bits (Wait cycle) */
@@ -2010,7 +2009,7 @@ typedef struct
 #define FLASH_CTRL_FPRGM                    FLASH_CTRL_FPRGM_Msk                    /*!< Flash program */
 #define FLASH_CTRL_SECERS_Pos               (1U)
 #define FLASH_CTRL_SECERS_Msk               (0x1U << FLASH_CTRL_SECERS_Pos)         /*!< 0x00000002 */
-#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Page erase */
+#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Sector erase */
 #define FLASH_CTRL_BANKERS_Pos              (2U)
 #define FLASH_CTRL_BANKERS_Msk              (0x1U << FLASH_CTRL_BANKERS_Pos)        /*!< 0x00000004 */
 #define FLASH_CTRL_BANKERS                  FLASH_CTRL_BANKERS_Msk                  /*!< Bank erase */
@@ -2049,7 +2048,7 @@ typedef struct
 #define FLASH_USD_FAP_Msk                   (0x1U << FLASH_USD_FAP_Pos)             /*!< 0x00000002 */
 #define FLASH_USD_FAP                       FLASH_USD_FAP_Msk                       /*!< Flash access protection */
 
-/*!< SSB congiguration */
+/*!< SSB configuration */
 #define FLASH_USD_WDT_ATO_EN_Pos            (2U)
 #define FLASH_USD_WDT_ATO_EN_Msk            (0x1U << FLASH_USD_WDT_ATO_EN_Pos)      /*!< 0x00000004 */
 #define FLASH_USD_WDT_ATO_EN                FLASH_USD_WDT_ATO_EN_Msk                /*!< nWDT_ATO_EN */
@@ -2090,7 +2089,7 @@ typedef struct
 #define FLASH_EPPS_EPPS_Msk                 (0xFFFFFFFFU << FLASH_EPPS_EPPS_Pos)    /*!< 0xFFFFFFFF */
 #define FLASH_EPPS_EPPS                     FLASH_EPPS_EPPS_Msk                     /*!< Erase/Program protection status */
 
-/*******************  Bit definition for SLIB_STS0 register *******************/
+/******************  Bit definition for SLIB_STS0 register  *******************/
 #define SLIB_STS0_BTM_AP_ENF_Pos            (0U)
 #define SLIB_STS0_BTM_AP_ENF_Msk            (0x1U << SLIB_STS0_BTM_AP_ENF_Pos)      /*!< 0x00000001 */
 #define SLIB_STS0_BTM_AP_ENF                SLIB_STS0_BTM_AP_ENF_Msk                /*!< Boot memory store application code enabled flag */
@@ -2100,27 +2099,27 @@ typedef struct
 #define SLIB_STS0_SLIB_ENF_Pos              (3U)
 #define SLIB_STS0_SLIB_ENF_Msk              (0x1U << SLIB_STS0_SLIB_ENF_Pos)        /*!< 0x00000008 */
 #define SLIB_STS0_SLIB_ENF                  SLIB_STS0_SLIB_ENF_Msk                  /*!< Security library enable flag */
-#define SLIB_STS0_EM_SLIB_INST_SS_Pos       (16U)                                   /*!< 0x00FF0000 */
-#define SLIB_STS0_EM_SLIB_INST_SS_Msk       (0xFFU << SLIB_STS0_EM_SLIB_INST_SS_Pos)
-#define SLIB_STS0_EM_SLIB_INST_SS           SLIB_STS0_EM_SLIB_INST_SS_Msk           /*!< Extension memory sLib instruction start page */
+#define SLIB_STS0_EM_SLIB_DAT_SS_Pos        (16U)
+#define SLIB_STS0_EM_SLIB_DAT_SS_Msk        (0xFFU << SLIB_STS0_EM_SLIB_DAT_SS_Pos) /*!< 0x00FF0000 */
+#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start sector */
 
-/*******************  Bit definition for SLIB_STS1 register *******************/
+/******************  Bit definition for SLIB_STS1 register  *******************/
 #define SLIB_STS1_SLIB_SS_Pos               (0U)
 #define SLIB_STS1_SLIB_SS_Msk               (0x7FFU << SLIB_STS1_SLIB_SS_Pos)       /*!< 0x000007FF */
-#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start page */
-#define SLIB_STS1_SLIB_INST_SS_Pos          (11U)
-#define SLIB_STS1_SLIB_INST_SS_Msk          (0x7FFU << SLIB_STS1_SLIB_INST_SS_Pos)  /*!< 0x003FF800 */
-#define SLIB_STS1_SLIB_INST_SS              SLIB_STS1_SLIB_INST_SS_Msk              /*!< Security library instruction start page */
+#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start sector */
+#define SLIB_STS1_SLIB_DAT_SS_Pos           (11U)
+#define SLIB_STS1_SLIB_DAT_SS_Msk           (0x7FFU << SLIB_STS1_SLIB_DAT_SS_Pos)   /*!< 0x003FF800 */
+#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start sector */
 #define SLIB_STS1_SLIB_ES_Pos               (22U)
 #define SLIB_STS1_SLIB_ES_Msk               (0x3FFU << SLIB_STS1_SLIB_ES_Pos)       /*!< 0xFFC00000 */
-#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end page */
+#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end sector */
 
-/*****************  Bit definition for SLIB_PWD_CLR register ******************/
+/*****************  Bit definition for SLIB_PWD_CLR register  *****************/
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk      (0xFFFFFFFFU << SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos)
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL          SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk          /*!< Security library password clear value */
 
-/*****************  Bit definition for SLIB_MISC_STS register *****************/
+/****************  Bit definition for SLIB_MISC_STS register  *****************/
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Pos      (0U)                                    /*!< 0x00000001 */
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Msk      (0x1U << SLIB_MISC_STS_SLIB_PWD_ERR_Pos)
 #define SLIB_MISC_STS_SLIB_PWD_ERR          SLIB_MISC_STS_SLIB_PWD_ERR_Msk          /*!< Security library password error */
@@ -2131,54 +2130,54 @@ typedef struct
 #define SLIB_MISC_STS_SLIB_ULKF_Msk         (0x1U << SLIB_MISC_STS_SLIB_ULKF_Pos)   /*!< 0x00000004 */
 #define SLIB_MISC_STS_SLIB_ULKF             SLIB_MISC_STS_SLIB_ULKF_Msk             /*!< Security library unlock flag */
 
-/****************  Bit definition for FLASH_CRC_ADDR register *****************/
+/****************  Bit definition for FLASH_CRC_ADDR register  ****************/
 #define FLASH_CRC_ADDR_CRC_ADDR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_ADDR_CRC_ADDR_Msk         (0xFFFFFFFFU << FLASH_CRC_ADDR_CRC_ADDR_Pos)
 #define FLASH_CRC_ADDR_CRC_ADDR             FLASH_CRC_ADDR_CRC_ADDR_Msk             /*!< CRC address */
 
-/****************  Bit definition for FLASH_CRC_CTRL register *****************/
+/****************  Bit definition for FLASH_CRC_CTRL register  ****************/
 #define FLASH_CRC_CTRL_CRC_SN_Pos           (0U)
 #define FLASH_CRC_CTRL_CRC_SN_Msk           (0xFFFFU << FLASH_CRC_CTRL_CRC_SN_Pos)  /*!< 0x0000FFFF */
-#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC page number */
+#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC sector number */
 #define FLASH_CRC_CTRL_CRC_STRT_Pos         (16U)
 #define FLASH_CRC_CTRL_CRC_STRT_Msk         (0x1U << FLASH_CRC_CTRL_CRC_STRT_Pos)   /*!< 0x00010000 */
 #define FLASH_CRC_CTRL_CRC_STRT             FLASH_CRC_CTRL_CRC_STRT_Msk             /*!< CRC start */
 
-/****************  Bit definition for FLASH_CRC_CHKR register *****************/
+/****************  Bit definition for FLASH_CRC_CHKR register  ****************/
 #define FLASH_CRC_CHKR_CRC_CHKR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_CHKR_CRC_CHKR_Msk         (0xFFFFFFFFU << FLASH_CRC_CHKR_CRC_CHKR_Pos)
 #define FLASH_CRC_CHKR_CRC_CHKR             FLASH_CRC_CHKR_CRC_CHKR_Msk             /*!< CRC check result */
 
-/*****************  Bit definition for SLIB_SET_PWD register ******************/
+/*****************  Bit definition for SLIB_SET_PWD register  *****************/
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Msk      (0xFFFFFFFFU << SLIB_SET_PWD_SLIB_PSET_VAL_Pos)
 #define SLIB_SET_PWD_SLIB_PSET_VAL          SLIB_SET_PWD_SLIB_PSET_VAL_Msk          /*!< Security library password setting value */
 
-/****************  Bit definition for SLIB_SET_RANGE register *****************/
+/****************  Bit definition for SLIB_SET_RANGE register  ****************/
 #define SLIB_SET_RANGE_SLIB_SS_SET_Pos      (0U)                                    /*!< 0x000007FF */
 #define SLIB_SET_RANGE_SLIB_SS_SET_Msk      (0x7FFU << SLIB_SET_RANGE_SLIB_SS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start page setting */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_ISS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ISS_SET         SLIB_SET_RANGE_SLIB_ISS_SET_Msk         /*!< Security library instruction start page setting */
+#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start sector setting */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_DSS_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_DSS_SET         SLIB_SET_RANGE_SLIB_DSS_SET_Msk         /*!< Security library data start sector setting */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Pos      (22U)                                   /*!< 0xFFC00000 */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0x3FFU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end page setting */
+#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end sector setting */
 
-/******************  Bit definition for EM_SLIB_SET register ******************/
+/*****************  Bit definition for EM_SLIB_SET register  ******************/
 #define EM_SLIB_SET_EM_SLIB_SET_Pos         (0U)                                    /*!< 0x0000FFFF */
 #define EM_SLIB_SET_EM_SLIB_SET_Msk         (0xFFFFU << EM_SLIB_SET_EM_SLIB_SET_Pos)
 #define EM_SLIB_SET_EM_SLIB_SET             EM_SLIB_SET_EM_SLIB_SET_Msk             /*!< Extension memory sLib setting */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_ISS_SET_Pos)
-#define EM_SLIB_SET_EM_SLIB_ISS_SET         EM_SLIB_SET_EM_SLIB_ISS_SET_Msk         /*!< Extension memory sLib instruction start page setting */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_DSS_SET_Pos)
+#define EM_SLIB_SET_EM_SLIB_DSS_SET         EM_SLIB_SET_EM_SLIB_DSS_SET_Msk         /*!< Extension memory sLib data start sector setting */
 
-/*****************  Bit definition for BTM_MODE_SET register ******************/
+/*****************  Bit definition for BTM_MODE_SET register  *****************/
 #define BTM_MODE_SET_BTM_MODE_SET_Pos       (0U)                                    /*!< 0x000000FF */
 #define BTM_MODE_SET_BTM_MODE_SET_Msk       (0xFFU << BTM_MODE_SET_BTM_MODE_SET_Pos)
 #define BTM_MODE_SET_BTM_MODE_SET           BTM_MODE_SET_BTM_MODE_SET_Msk           /*!< Boot memory mode setting */
 
-/*****************  Bit definition for SLIB_UNLOCK register ******************/
+/*****************  Bit definition for SLIB_UNLOCK register  ******************/
 #define SLIB_UNLOCK_SLIB_UKVAL_Pos          (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_UNLOCK_SLIB_UKVAL_Msk          (0xFFFFFFFFU << SLIB_UNLOCK_SLIB_UKVAL_Pos)
 #define SLIB_UNLOCK_SLIB_UKVAL              SLIB_UNLOCK_SLIB_UKVAL_Msk              /*!< Security library unlock key value */
@@ -2508,7 +2507,7 @@ typedef struct
 #define GPIO_OMODE_OM15_Msk                 (0x1U << GPIO_OMODE_OM15_Pos)           /*!< 0x00008000 */
 #define GPIO_OMODE_OM15                     GPIO_OMODE_OM15_Msk                     /*!< GPIO x output mode configuration, pin 15 */
 
-/*!<***************  Bit definition for GPIO_ODRVR register  ******************/
+/******************  Bit definition for GPIO_ODRVR register  ******************/
 #define GPIO_ODRVR_ODRV_Pos                 (0U)
 #define GPIO_ODRVR_ODRV_Msk                 (0xFFFFFFFFU << GPIO_ODRVR_ODRV_Pos)    /*!< 0xFFFFFFFF */
 #define GPIO_ODRVR_ODRV                     GPIO_ODRVR_ODRV_Msk                     /*!< GPIO x drive capability */
@@ -2625,7 +2624,7 @@ typedef struct
 #define GPIO_ODRVR_ODRV15_0                 (0x1U << GPIO_ODRVR_ODRV15_Pos)         /*!< 0x40000000 */
 #define GPIO_ODRVR_ODRV15_1                 (0x2U << GPIO_ODRVR_ODRV15_Pos)         /*!< 0x80000000 */
 
-/*!<***************  Bit definition for GPIO_PULL register  *******************/
+/******************  Bit definition for GPIO_PULL register  *******************/
 #define GPIO_PULL_PULL_Pos                  (0U)
 #define GPIO_PULL_PULL_Msk                  (0xFFFFFFFFU << GPIO_PULL_PULL_Pos)     /*!< 0xFFFFFFFF */
 #define GPIO_PULL_PULL                      GPIO_PULL_PULL_Msk                      /*!< GPIO x pull-up/pull-down configuration */
@@ -2742,7 +2741,7 @@ typedef struct
 #define GPIO_PULL_PULL15_0                  (0x1U << GPIO_PULL_PULL15_Pos)          /*!< 0x40000000 */
 #define GPIO_PULL_PULL15_1                  (0x2U << GPIO_PULL_PULL15_Pos)          /*!< 0x80000000 */
 
-/*!<****************  Bit definition for GPIO_IDT register  *******************/
+/*******************  Bit definition for GPIO_IDT register  *******************/
 #define GPIO_IDT_IDT0_Pos                   (0U)
 #define GPIO_IDT_IDT0_Msk                   (0x1U << GPIO_IDT_IDT0_Pos)             /*!< 0x00000001 */
 #define GPIO_IDT_IDT0                       GPIO_IDT_IDT0_Msk                       /*!< GPIO x input data, pin 0 */
@@ -3297,56 +3296,6 @@ typedef struct
 #define GPIO_HDRV_HDRV15_Msk                (0x1U << GPIO_HDRV_HDRV15_Pos)          /*!< 0x00008000 */
 #define GPIO_HDRV_HDRV15                    GPIO_HDRV_HDRV15_Msk                    /*!< GPIO x huge sourcing/sinking strength control, pin 15 */
 
-/******************  Bit definition for GPIO_SRCTR register  ******************/
-#define GPIO_SRCTR_SRCTR0_Pos               (0U)
-#define GPIO_SRCTR_SRCTR0_Msk               (0x1U << GPIO_SRCTR_SRCTR0_Pos)           /*!< 0x00000001 */
-#define GPIO_SRCTR_SRCTR0                   GPIO_SRCTR_SRCTR0_Msk                     /*!< GPIO x SRCTR, pin 0 */
-#define GPIO_SRCTR_SRCTR1_Pos               (1U)
-#define GPIO_SRCTR_SRCTR1_Msk               (0x1U << GPIO_SRCTR_SRCTR1_Pos)           /*!< 0x00000002 */
-#define GPIO_SRCTR_SRCTR1                   GPIO_SRCTR_SRCTR1_Msk                     /*!< GPIO x SRCTR, pin 1 */
-#define GPIO_SRCTR_SRCTR2_Pos               (2U)
-#define GPIO_SRCTR_SRCTR2_Msk               (0x1U << GPIO_SRCTR_SRCTR2_Pos)           /*!< 0x00000004 */
-#define GPIO_SRCTR_SRCTR2                   GPIO_SRCTR_SRCTR2_Msk                     /*!< GPIO x SRCTR, pin 2 */
-#define GPIO_SRCTR_SRCTR3_Pos               (3U)
-#define GPIO_SRCTR_SRCTR3_Msk               (0x1U << GPIO_SRCTR_SRCTR3_Pos)           /*!< 0x00000008 */
-#define GPIO_SRCTR_SRCTR3                   GPIO_SRCTR_SRCTR3_Msk                     /*!< GPIO x SRCTR, pin 3 */
-#define GPIO_SRCTR_SRCTR4_Pos               (4U)
-#define GPIO_SRCTR_SRCTR4_Msk               (0x1U << GPIO_SRCTR_SRCTR4_Pos)           /*!< 0x00000010 */
-#define GPIO_SRCTR_SRCTR4                   GPIO_SRCTR_SRCTR4_Msk                     /*!< GPIO x SRCTR, pin 4 */
-#define GPIO_SRCTR_SRCTR5_Pos               (5U)
-#define GPIO_SRCTR_SRCTR5_Msk               (0x1U << GPIO_SRCTR_SRCTR5_Pos)           /*!< 0x00000020 */
-#define GPIO_SRCTR_SRCTR5                   GPIO_SRCTR_SRCTR5_Msk                     /*!< GPIO x SRCTR, pin 5 */
-#define GPIO_SRCTR_SRCTR6_Pos               (6U)
-#define GPIO_SRCTR_SRCTR6_Msk               (0x1U << GPIO_SRCTR_SRCTR6_Pos)           /*!< 0x00000040 */
-#define GPIO_SRCTR_SRCTR6                   GPIO_SRCTR_SRCTR6_Msk                     /*!< GPIO x SRCTR, pin 6 */
-#define GPIO_SRCTR_SRCTR7_Pos               (7U)
-#define GPIO_SRCTR_SRCTR7_Msk               (0x1U << GPIO_SRCTR_SRCTR7_Pos)           /*!< 0x00000080 */
-#define GPIO_SRCTR_SRCTR7                   GPIO_SRCTR_SRCTR7_Msk                     /*!< GPIO x SRCTR, pin 7 */
-#define GPIO_SRCTR_SRCTR8_Pos               (8U)
-#define GPIO_SRCTR_SRCTR8_Msk               (0x1U << GPIO_SRCTR_SRCTR8_Pos)           /*!< 0x00000100 */
-#define GPIO_SRCTR_SRCTR8                   GPIO_SRCTR_SRCTR8_Msk                     /*!< GPIO x SRCTR, pin 8 */
-#define GPIO_SRCTR_SRCTR9_Pos               (9U)
-#define GPIO_SRCTR_SRCTR9_Msk               (0x1U << GPIO_SRCTR_SRCTR9_Pos)           /*!< 0x00000200 */
-#define GPIO_SRCTR_SRCTR9                   GPIO_SRCTR_SRCTR9_Msk                     /*!< GPIO x SRCTR, pin 9 */
-#define GPIO_SRCTR_SRCTR10_Pos              (10U)
-#define GPIO_SRCTR_SRCTR10_Msk              (0x1U << GPIO_SRCTR_SRCTR10_Pos)          /*!< 0x00000400 */
-#define GPIO_SRCTR_SRCTR10                  GPIO_SRCTR_SRCTR10_Msk                    /*!< GPIO x SRCTR, pin 10 */
-#define GPIO_SRCTR_SRCTR11_Pos              (11U)
-#define GPIO_SRCTR_SRCTR11_Msk              (0x1U << GPIO_SRCTR_SRCTR11_Pos)          /*!< 0x00000800 */
-#define GPIO_SRCTR_SRCTR11                  GPIO_SRCTR_SRCTR11_Msk                    /*!< GPIO x SRCTR, pin 11 */
-#define GPIO_SRCTR_SRCTR12_Pos              (12U)
-#define GPIO_SRCTR_SRCTR12_Msk              (0x1U << GPIO_SRCTR_SRCTR12_Pos)          /*!< 0x00001000 */
-#define GPIO_SRCTR_SRCTR12                  GPIO_SRCTR_SRCTR12_Msk                    /*!< GPIO x SRCTR, pin 12 */
-#define GPIO_SRCTR_SRCTR13_Pos              (13U)
-#define GPIO_SRCTR_SRCTR13_Msk              (0x1U << GPIO_SRCTR_SRCTR13_Pos)          /*!< 0x00002000 */
-#define GPIO_SRCTR_SRCTR13                  GPIO_SRCTR_SRCTR13_Msk                    /*!< GPIO x SRCTR, pin 13 */
-#define GPIO_SRCTR_SRCTR14_Pos              (14U)
-#define GPIO_SRCTR_SRCTR14_Msk              (0x1U << GPIO_SRCTR_SRCTR14_Pos)          /*!< 0x00004000 */
-#define GPIO_SRCTR_SRCTR14                  GPIO_SRCTR_SRCTR14_Msk                    /*!< GPIO x SRCTR, pin 14 */
-#define GPIO_SRCTR_SRCTR15_Pos              (15U)
-#define GPIO_SRCTR_SRCTR15_Msk              (0x1U << GPIO_SRCTR_SRCTR15_Pos)          /*!< 0x00008000 */
-#define GPIO_SRCTR_SRCTR15                  GPIO_SRCTR_SRCTR15_Msk                    /*!< GPIO x SRCTR, pin 15 */
-
 /******************************************************************************/
 /*                                                                            */
 /*                   System configuration controller (SCFG)                   */
@@ -3503,7 +3452,7 @@ typedef struct
 #define SCFG_EXINTC2_EXINT4_GPF_Msk         (0x1U << SCFG_EXINTC2_EXINT4_GPF_Pos)   /*!< 0x00000004 */
 #define SCFG_EXINTC2_EXINT4_GPF             SCFG_EXINTC2_EXINT4_GPF_Msk             /*!< GPIOF pin 4 */
 
-/* EXINT5 configuration */
+/*!< EXINT5 configuration */
 #define SCFG_EXINTC2_EXINT5_Pos             (4U)
 #define SCFG_EXINTC2_EXINT5_Msk             (0xFU << SCFG_EXINTC2_EXINT5_Pos)       /*!< 0x000000F0 */
 #define SCFG_EXINTC2_EXINT5                 SCFG_EXINTC2_EXINT5_Msk                 /*!< EXINT5[3:0] bits (EXINT5 input source configuration) */
@@ -3638,7 +3587,7 @@ typedef struct
 #define SCFG_EXINTC3_EXINT11_GPF            SCFG_EXINTC3_EXINT11_GPF_Msk            /*!< GPIOF pin 11 */
 
 /*****************  Bit definition for SCFG_EXINTC4 register  *****************/
-/* EXINT12 configuration */
+/*!< EXINT12 configuration */
 #define SCFG_EXINTC4_EXINT12_Pos            (0U)
 #define SCFG_EXINTC4_EXINT12_Msk            (0xFU << SCFG_EXINTC4_EXINT12_Pos)      /*!< 0x0000000F */
 #define SCFG_EXINTC4_EXINT12                SCFG_EXINTC4_EXINT12_Msk                /*!< EXINT12[3:0] bits (EXINT12 input source configuration) */
@@ -3657,7 +3606,7 @@ typedef struct
 #define SCFG_EXINTC4_EXINT12_GPF_Msk        (0x1U << SCFG_EXINTC4_EXINT12_GPF_Pos)  /*!< 0x00000004 */
 #define SCFG_EXINTC4_EXINT12_GPF            SCFG_EXINTC4_EXINT12_GPF_Msk            /*!< GPIOF pin 12 */
 
-/* EXINT13 configuration */
+/*!< EXINT13 configuration */
 #define SCFG_EXINTC4_EXINT13_Pos            (4U)
 #define SCFG_EXINTC4_EXINT13_Msk            (0xFU << SCFG_EXINTC4_EXINT13_Pos)      /*!< 0x000000F0 */
 #define SCFG_EXINTC4_EXINT13                SCFG_EXINTC4_EXINT13_Msk                /*!< EXINT13[3:0] bits (EXINT13 input source configuration) */
@@ -3799,7 +3748,7 @@ typedef struct
 #define EXINT_INTEN_INTEN22_Msk             (0x1U << EXINT_INTEN_INTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTEN_INTEN22                 EXINT_INTEN_INTEN22_Msk                 /*!< Interrupt enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTEN_INT0                    EXINT_INTEN_INTEN0
 #define EXINT_INTEN_INT1                    EXINT_INTEN_INTEN1
 #define EXINT_INTEN_INT2                    EXINT_INTEN_INTEN2
@@ -3892,7 +3841,7 @@ typedef struct
 #define EXINT_EVTEN_EVTEN22_Msk             (0x1U << EXINT_EVTEN_EVTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_EVTEN_EVTEN22                 EXINT_EVTEN_EVTEN22_Msk                 /*!< Event enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_EVTEN_EVT0                    EXINT_EVTEN_EVTEN0
 #define EXINT_EVTEN_EVT1                    EXINT_EVTEN_EVTEN1
 #define EXINT_EVTEN_EVT2                    EXINT_EVTEN_EVTEN2
@@ -3984,7 +3933,7 @@ typedef struct
 #define EXINT_POLCFG1_RP22_Msk              (0x1U << EXINT_POLCFG1_RP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG1_RP22                  EXINT_POLCFG1_RP22_Msk                  /*!< Rising edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG1_POL0                  EXINT_POLCFG1_RP0
 #define EXINT_POLCFG1_POL1                  EXINT_POLCFG1_RP1
 #define EXINT_POLCFG1_POL2                  EXINT_POLCFG1_RP2
@@ -4076,7 +4025,7 @@ typedef struct
 #define EXINT_POLCFG2_FP22_Msk              (0x1U << EXINT_POLCFG2_FP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG2_FP22                  EXINT_POLCFG2_FP22_Msk                  /*!< Falling edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG2_POL0                  EXINT_POLCFG2_FP0
 #define EXINT_POLCFG2_POL1                  EXINT_POLCFG2_FP1
 #define EXINT_POLCFG2_POL2                  EXINT_POLCFG2_FP2
@@ -4168,7 +4117,7 @@ typedef struct
 #define EXINT_SWTRG_SWT22_Msk               (0x1U << EXINT_SWTRG_SWT22_Pos)         /*!< 0x00400000 */
 #define EXINT_SWTRG_SWT22                   EXINT_SWTRG_SWT22_Msk                   /*!< Software trigger on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_SWTRG_SW0                     EXINT_SWTRG_SWT0
 #define EXINT_SWTRG_SW1                     EXINT_SWTRG_SWT1
 #define EXINT_SWTRG_SW2                     EXINT_SWTRG_SWT2
@@ -4260,7 +4209,7 @@ typedef struct
 #define EXINT_INTSTS_LINE22_Msk             (0x1U << EXINT_INTSTS_LINE22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTSTS_LINE22                 EXINT_INTSTS_LINE22_Msk                 /*!< Status bit for line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTSTS_INT0                   EXINT_INTSTS_LINE0
 #define EXINT_INTSTS_INT1                   EXINT_INTSTS_LINE1
 #define EXINT_INTSTS_INT2                   EXINT_INTSTS_LINE2
@@ -4815,8 +4764,8 @@ typedef struct
 
 /******************  Bit definition for I2C_OADDR1 register  ******************/
 /*!< ADDR1 configuration */
-#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface Address */
-#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface Address */
+#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface address */
+#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface address */
 
 #define I2C_OADDR1_ADDR1_0_Pos              (0U)
 #define I2C_OADDR1_ADDR1_0_Msk              (0x1U << I2C_OADDR1_ADDR1_0_Pos)        /*!< 0x00000001 */
@@ -5298,7 +5247,7 @@ typedef struct
 #define SPI_CTRL1_NTC                       SPI_CTRL1_NTC_Msk                       /*!< Transmit CRC next */
 #define SPI_CTRL1_CCEN_Pos                  (13U)
 #define SPI_CTRL1_CCEN_Msk                  (0x1U << SPI_CTRL1_CCEN_Pos)            /*!< 0x00002000 */
-#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< RC calculation enable */
+#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< CRC calculation enable */
 #define SPI_CTRL1_SLBTD_Pos                 (14U)
 #define SPI_CTRL1_SLBTD_Msk                 (0x1U << SPI_CTRL1_SLBTD_Pos)           /*!< 0x00004000 */
 #define SPI_CTRL1_SLBTD                     SPI_CTRL1_SLBTD_Msk                     /*!< Single line bidirectional half-duplex transmission direction */
@@ -5369,7 +5318,7 @@ typedef struct
 #define SPI_DT_DT_Msk                       (0xFFFFU << SPI_DT_DT_Pos)              /*!< 0x0000FFFF */
 #define SPI_DT_DT                           SPI_DT_DT_Msk                           /*!< Data value */
 
-/*******************  Bit definition for SPI_CPOLY register  ******************/
+/******************  Bit definition for SPI_CPOLY register  *******************/
 #define SPI_CPOLY_CPOLY_Pos                 (0U)
 #define SPI_CPOLY_CPOLY_Msk                 (0xFFFFU << SPI_CPOLY_CPOLY_Pos)        /*!< 0x0000FFFF */
 #define SPI_CPOLY_CPOLY                     SPI_CPOLY_CPOLY_Msk                     /*!< CRC polynomial */
@@ -6605,12 +6554,12 @@ typedef struct
 #define ADC_PCDTO4_PCDTO4_Msk               (0xFFFU << ADC_PCDTO4_PCDTO4_Pos)       /*!< 0x00000FFF */
 #define ADC_PCDTO4_PCDTO4                   ADC_PCDTO4_PCDTO4_Msk                   /*!< Data offset for Preempted channel 4 */
 
-/*******************  Bit definition for ADC_VMHB register  ********************/
+/*******************  Bit definition for ADC_VMHB register  *******************/
 #define ADC_VMHB_VMHB_Pos                   (0U)
 #define ADC_VMHB_VMHB_Msk                   (0xFFFFU << ADC_VMHB_VMHB_Pos)          /*!< 0x0000FFFF */
 #define ADC_VMHB_VMHB                       ADC_VMHB_VMHB_Msk                       /*!< Voltage monitoring high boundary */
 
-/*******************  Bit definition for ADC_VMLB register  ********************/
+/*******************  Bit definition for ADC_VMLB register  *******************/
 #define ADC_VMLB_VMLB_Pos                   (0U)
 #define ADC_VMLB_VMLB_Msk                   (0xFFFFU << ADC_VMLB_VMLB_Pos)          /*!< 0x0000FFFF */
 #define ADC_VMLB_VMLB                       ADC_VMLB_VMLB_Msk                       /*!< Voltage monitoring low boundary */
@@ -7056,7 +7005,7 @@ typedef struct
 #define CAN_TSTS_TMNR_Msk                   (0x3U << CAN_TSTS_TMNR_Pos)             /*!< 0x03000000 */
 #define CAN_TSTS_TMNR                       CAN_TSTS_TMNR_Msk                       /*!< TMNR[1:0] bits (Transmit mailbox number record) */
 
-/*!< TMEF congiguration */
+/*!< TMEF configuration */
 #define CAN_TSTS_TMEF_Pos                   (26U)
 #define CAN_TSTS_TMEF_Msk                   (0x7U << CAN_TSTS_TMEF_Pos)             /*!< 0x1C000000 */
 #define CAN_TSTS_TMEF                       CAN_TSTS_TMEF_Msk                       /*!< TMEF[2:0] bits (Transmit mailbox empty flag) */
@@ -7070,7 +7019,7 @@ typedef struct
 #define CAN_TSTS_TM2EF_Msk                  (0x1U << CAN_TSTS_TM2EF_Pos)            /*!< 0x10000000 */
 #define CAN_TSTS_TM2EF                      CAN_TSTS_TM2EF_Msk                      /*!< Transmit mailbox 2 empty flag */
 
-/*!< TMLPF congiguration */
+/*!< TMLPF configuration */
 #define CAN_TSTS_TMLPF_Pos                  (29U)
 #define CAN_TSTS_TMLPF_Msk                  (0x7U << CAN_TSTS_TMLPF_Pos)            /*!< 0xE0000000 */
 #define CAN_TSTS_TMLPF                      CAN_TSTS_TMLPF_Msk                      /*!< TMLPF[2:0] bits (Transmit mailbox lowest priority flag) */
@@ -7167,7 +7116,7 @@ typedef struct
 #define CAN_ESTS_BOF_Msk                    (0x1U << CAN_ESTS_BOF_Pos)              /*!< 0x00000004 */
 #define CAN_ESTS_BOF                        CAN_ESTS_BOF_Msk                        /*!< Bus-off flag */
 
-/*!< ETR congiguration */
+/*!< ETR configuration */
 #define CAN_ESTS_ETR_Pos                    (4U)
 #define CAN_ESTS_ETR_Msk                    (0x7U << CAN_ESTS_ETR_Pos)              /*!< 0x00000070 */
 #define CAN_ESTS_ETR                        CAN_ESTS_ETR_Msk                        /*!< ETR[2:0] bits (Error type record) */
@@ -7187,7 +7136,7 @@ typedef struct
 #define CAN_BTMG_BRDIV_Msk                  (0xFFFU << CAN_BTMG_BRDIV_Pos)          /*!< 0x00000FFF */
 #define CAN_BTMG_BRDIV                      CAN_BTMG_BRDIV_Msk                      /*!< Baud rate division */
 
-/*!< BTS1 congiguration */
+/*!< BTS1 configuration */
 #define CAN_BTMG_BTS1_Pos                   (16U)
 #define CAN_BTMG_BTS1_Msk                   (0xFU << CAN_BTMG_BTS1_Pos)             /*!< 0x000F0000 */
 #define CAN_BTMG_BTS1                       CAN_BTMG_BTS1_Msk                       /*!< BTS1[3:0] bits (Bit time segment 1) */
@@ -7196,7 +7145,7 @@ typedef struct
 #define CAN_BTMG_BTS1_2                     (0x4U << CAN_BTMG_BTS1_Pos)             /*!< 0x00040000 */
 #define CAN_BTMG_BTS1_3                     (0x8U << CAN_BTMG_BTS1_Pos)             /*!< 0x00080000 */
 
-/*!< BTS2 congiguration */
+/*!< BTS2 configuration */
 #define CAN_BTMG_BTS2_Pos                   (20U)
 #define CAN_BTMG_BTS2_Msk                   (0x7U << CAN_BTMG_BTS2_Pos)             /*!< 0x00700000 */
 #define CAN_BTMG_BTS2                       CAN_BTMG_BTS2_Msk                       /*!< BTS2[2:0] bits (Bit time segment 2) */
@@ -7204,7 +7153,7 @@ typedef struct
 #define CAN_BTMG_BTS2_1                     (0x2U << CAN_BTMG_BTS2_Pos)             /*!< 0x00200000 */
 #define CAN_BTMG_BTS2_2                     (0x4U << CAN_BTMG_BTS2_Pos)             /*!< 0x00400000 */
 
-/*!< RSAW congiguration */
+/*!< RSAW configuration */
 #define CAN_BTMG_RSAW_Pos                   (24U)
 #define CAN_BTMG_RSAW_Msk                   (0x3U << CAN_BTMG_RSAW_Pos)             /*!< 0x03000000 */
 #define CAN_BTMG_RSAW                       CAN_BTMG_RSAW_Msk                       /*!< RSAW[1:0] bits (Resynchronization width) */
@@ -10665,7 +10614,7 @@ typedef struct
 #define QSPI_CMD_W0_SPIADR                  QSPI_CMD_W0_SPIADR_Msk                  /*!< SPI Flash address */
 
 /*****************  Bit definition for QSPI_CMD_W1 register  ******************/
-/*!< ADRLEN congiguration */
+/*!< ADRLEN configuration */
 #define QSPI_CMD_W1_ADRLEN_Pos              (0U)
 #define QSPI_CMD_W1_ADRLEN_Msk              (0x7U << QSPI_CMD_W1_ADRLEN_Pos)        /*!< 0x00000007 */
 #define QSPI_CMD_W1_ADRLEN                  QSPI_CMD_W1_ADRLEN_Msk                  /*!< ADRLEN[2:0] bits (SPI address length) */
@@ -10679,7 +10628,7 @@ typedef struct
 #define QSPI_CMD_W1_ADRLEN_3BYTE            0x00000003U                             /*!< 3-byte address */
 #define QSPI_CMD_W1_ADRLEN_4BYTE            0x00000004U                             /*!< 4-byte address */
 
-/*!< DUM2 congiguration */
+/*!< DUM2 configuration */
 #define QSPI_CMD_W1_DUM2_Pos                (16U)
 #define QSPI_CMD_W1_DUM2_Msk                (0xFFU << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00FF0000 */
 #define QSPI_CMD_W1_DUM2                    QSPI_CMD_W1_DUM2_Msk                    /*!< DUM2[7:0] bits (Second dummy state cycle) */
@@ -10692,7 +10641,7 @@ typedef struct
 #define QSPI_CMD_W1_DUM2_6                  (0x40U << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00400000 */
 #define QSPI_CMD_W1_DUM2_7                  (0x80U << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00800000 */
 
-/*!< INSLEN congiguration */
+/*!< INSLEN configuration */
 #define QSPI_CMD_W1_INSLEN_Pos              (24U)
 #define QSPI_CMD_W1_INSLEN_Msk              (0x3U << QSPI_CMD_W1_INSLEN_Pos)        /*!< 0x03000000 */
 #define QSPI_CMD_W1_INSLEN                  QSPI_CMD_W1_INSLEN_Msk                  /*!< INSLEN[1:0] bits (Instruction code length) */
@@ -10723,7 +10672,7 @@ typedef struct
 #define QSPI_CMD_W3_RSTSC_Msk               (0x1U << QSPI_CMD_W3_RSTSC_Pos)         /*!< 0x00000008 */
 #define QSPI_CMD_W3_RSTSC                   QSPI_CMD_W3_RSTSC_Msk                   /*!< Read SPI status configuration */
 
-/*!< OPMODE congiguration */
+/*!< OPMODE configuration */
 #define QSPI_CMD_W3_OPMODE_Pos              (5U)
 #define QSPI_CMD_W3_OPMODE_Msk              (0x7U << QSPI_CMD_W3_OPMODE_Pos)        /*!< 0x000000E0 */
 #define QSPI_CMD_W3_OPMODE                  QSPI_CMD_W3_OPMODE_Msk                  /*!< OPMODE[2:0] bits (SPI Operation mode) */
@@ -10747,7 +10696,7 @@ typedef struct
 #define QSPI_CMD_W3_INSC                    QSPI_CMD_W3_INSC_Msk                    /*!< Instruction code */
 
 /******************  Bit definition for QSPI_CTRL register  *******************/
-/*!< CLKDIV congiguration */
+/*!< CLKDIV configuration */
 #define QSPI_CTRL_CLKDIV_Pos                (0U)
 #define QSPI_CTRL_CLKDIV_Msk                (0x7U << QSPI_CTRL_CLKDIV_Pos)          /*!< 0x00000007 */
 #define QSPI_CTRL_CLKDIV                    QSPI_CTRL_CLKDIV_Msk                    /*!< CLKDIV[2:0] bits (Clock divider) */
@@ -10774,7 +10723,7 @@ typedef struct
 #define QSPI_CTRL_ABORT_Msk                 (0x1U << QSPI_CTRL_ABORT_Pos)           /*!< 0x00000100 */
 #define QSPI_CTRL_ABORT                     QSPI_CTRL_ABORT_Msk                     /*!< Refresh all commands/FIFOs and reset state machine */
 
-/*!< BUSY congiguration */
+/*!< BUSY configuration */
 #define QSPI_CTRL_BUSY_Pos                  (16U)
 #define QSPI_CTRL_BUSY_Msk                  (0x7U << QSPI_CTRL_BUSY_Pos)            /*!< 0x00070000 */
 #define QSPI_CTRL_BUSY                      QSPI_CTRL_BUSY_Msk                      /*!< BUSY[2:0] bits (Busy bit of SPI status) */
@@ -10817,7 +10766,7 @@ typedef struct
 #define QSPI_CTRL2_CMDIE_Msk                (0x1U << QSPI_CTRL2_CMDIE_Pos)          /*!< 0x00000002 */
 #define QSPI_CTRL2_CMDIE                    QSPI_CTRL2_CMDIE_Msk                    /*!< Command complete Interrupt enable */
 
-/*!< TXFIFO_THOD congiguration */
+/*!< TXFIFO_THOD configuration */
 #define QSPI_CTRL2_TXFIFO_THOD_Pos          (8U)
 #define QSPI_CTRL2_TXFIFO_THOD_Msk          (0x3U << QSPI_CTRL2_TXFIFO_THOD_Pos)    /*!< 0x00000300 */
 #define QSPI_CTRL2_TXFIFO_THOD              QSPI_CTRL2_TXFIFO_THOD_Msk              /*!< TXFIFO_THOD[1:0] bits (Program the level value to trigger TX FIFO threshold IRQ) */
@@ -10828,7 +10777,7 @@ typedef struct
 #define QSPI_CTRL2_TXFIFO_THOD_16WORD       0x00000100U                             /*!< 16 WORD */
 #define QSPI_CTRL2_TXFIFO_THOD_24WORD       0x00000200U                             /*!< 24 WORD */
 
-/*!< RXFIFO_THOD congiguration */
+/*!< RXFIFO_THOD configuration */
 #define QSPI_CTRL2_RXFIFO_THOD_Pos          (12U)
 #define QSPI_CTRL2_RXFIFO_THOD_Msk          (0x3U << QSPI_CTRL2_RXFIFO_THOD_Pos)    /*!< 0x00003000 */
 #define QSPI_CTRL2_RXFIFO_THOD              QSPI_CTRL2_RXFIFO_THOD_Msk              /*!< RXFIFO_THOD[1:0] bits (Program the level value to trigger RX FIFO threshold IRQ) */
@@ -10855,7 +10804,7 @@ typedef struct
 #define QSPI_FSIZE_SPIFSIZE                 QSPI_FSIZE_SPIFSIZE_Msk                 /*!< SPI flash size */
 
 /***************  Bit definition for QSPI_XIP_CMD_W0 register  ****************/
-/*!< XIPR_DUM2 congiguration */
+/*!< XIPR_DUM2 configuration */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_Pos       (0U)
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_Msk       (0xFFU << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x000000FF */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2           QSPI_XIP_CMD_W0_XIPR_DUM2_Msk            /*!< XIPR_DUM2[7:0] bits (XIP read second dummy cycle) */
@@ -10868,7 +10817,7 @@ typedef struct
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_6         (0x40U << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x00000040 */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_7         (0x80U << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x00000080 */
 
-/*!< XIPR_OPMODE congiguration */
+/*!< XIPR_OPMODE configuration */
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE_Pos     (8U)                                      /*!< 0x00000700 */
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE_Msk     (0x7U << QSPI_XIP_CMD_W0_XIPR_OPMODE_Pos)
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE         QSPI_XIP_CMD_W0_XIPR_OPMODE_Msk           /*!< XIPR_OPMODE[2:0] bits (XIP read operation mode) */
@@ -10892,7 +10841,7 @@ typedef struct
 #define QSPI_XIP_CMD_W0_XIPR_INSC           QSPI_XIP_CMD_W0_XIPR_INSC_Msk           /*!< XIP read instruction code */
 
 /***************  Bit definition for QSPI_XIP_CMD_W1 register  ****************/
-/*!< XIPW_DUM2 congiguration */
+/*!< XIPW_DUM2 configuration */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_Pos       (0U)
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_Msk       (0xFFU << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x000000FF */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2           QSPI_XIP_CMD_W1_XIPW_DUM2_Msk            /*!< XIPW_DUM2[7:0] bits (XIP write second dummy cycle) */
@@ -10905,7 +10854,7 @@ typedef struct
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_6         (0x40U << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x00000040 */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_7         (0x80U << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x00000080 */
 
-/*!< XIPW_OPMODE congiguration */
+/*!< XIPW_OPMODE configuration */
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE_Pos     (8U)                                      /*!< 0x00000700 */
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE_Msk     (0x7U << QSPI_XIP_CMD_W1_XIPW_OPMODE_Pos)
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE         QSPI_XIP_CMD_W1_XIPW_OPMODE_Msk           /*!< XIPW_OPMODE[2:0] bits (XIP write operation mode) */
@@ -10978,7 +10927,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for DEBUG_IDCODE register  *****************/
-/*!< PID congiguration */
+/*!< PID configuration */
 #define DEBUG_IDCODE_PID_Pos                (0U)
 #define DEBUG_IDCODE_PID_Msk                (0xFFFFFFFFU << DEBUG_IDCODE_PID_Pos)   /*!< 0xFFFFFFFF */
 #define DEBUG_IDCODE_PID                    DEBUG_IDCODE_PID_Msk                    /*!< PID[31:0] bits (PID information) */
@@ -11085,7 +11034,7 @@ typedef struct
 #define DEBUG_APB2_PAUSE_TMR11_PAUSE        DEBUG_APB2_PAUSE_TMR11_PAUSE_Msk        /*!< TMR11 pause control bit */
 
 /*****************  Bit definition for DEBUG_SER_ID register  *****************/
-/*!< REV_ID congiguration */
+/*!< REV_ID configuration */
 #define DEBUG_SER_ID_REV_ID_Pos             (0U)
 #define DEBUG_SER_ID_REV_ID_Msk             (0x7U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000007 */
 #define DEBUG_SER_ID_REV_ID                 DEBUG_SER_ID_REV_ID_Msk                 /*!< REV_ID[2:0] bits (Revision ID) */
@@ -11093,7 +11042,7 @@ typedef struct
 #define DEBUG_SER_ID_REV_ID_1               (0x2U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000002 */
 #define DEBUG_SER_ID_REV_ID_2               (0x4U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000004 */
 
-/*!< SER_ID congiguration */
+/*!< SER_ID configuration */
 #define DEBUG_SER_ID_SER_ID_Pos             (8U)
 #define DEBUG_SER_ID_SER_ID_Msk             (0xFFU << DEBUG_SER_ID_SER_ID_Pos)      /*!< 0x0000FF00 */
 #define DEBUG_SER_ID_SER_ID                 DEBUG_SER_ID_SER_ID_Msk                 /*!< SER_ID[7:0] bits (Serial ID) */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F402_405/at32f402_405rx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F402_405/at32f402_405rx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f402_405rx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian & Maxjta
-  * @version v2.1.2
-  * @date    20-Jan-2025
+  * @version v2.1.4
+  * @date    24-Nov-2025
   * @brief   AT32F402_405Rx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.2
+  * @brief CMSIS Device version number V2.1.4
   */
 #define __AT32F402_405_LIBRARY_VERSION_MAJOR  (0x02) /*!< [31:24] major version */
 #define __AT32F402_405_LIBRARY_VERSION_MIDDLE (0x01) /*!< [23:16] middle version */
-#define __AT32F402_405_LIBRARY_VERSION_MINOR  (0x02) /*!< [15:8]  minor version */
+#define __AT32F402_405_LIBRARY_VERSION_MINOR  (0x04) /*!< [15:8]  minor version */
 #define __AT32F402_405_LIBRARY_VERSION_RC     (0x00) /*!< [7:0]   release candidate */
 #define __AT32F402_405_LIBRARY_VERSION        ((__AT32F402_405_LIBRARY_VERSION_MAJOR  << 24)\
                                               |(__AT32F402_405_LIBRARY_VERSION_MIDDLE << 16)\
@@ -99,7 +99,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                   */
 
 /******  AT32 specific Interrupt Numbers **********************************************************/
-  WWDT_IRQn                   = 0,      /*!< Window WatchDog Timer Interrupt                      */
+  WWDT_IRQn                   = 0,      /*!< Window WATCHDOG Timer Interrupt                      */
   PVM_IRQn                    = 1,      /*!< PVM Interrupt linked to EXINT16                      */
   TAMPER_IRQn                 = 2,      /*!< Tamper Interrupt linked to EXINT21                   */
   ERTC_WKUP_IRQn              = 3,      /*!< ERTC Wake Up Interrupt linked to EXINT22             */
@@ -191,12 +191,12 @@ typedef enum
 
 typedef struct
 {
-  __IO uint32_t STS;      /*!< ACC Status register,                         Address offset: 0x00 */
-  __IO uint32_t CTRL1;    /*!< ACC Control register 1,                      Address offset: 0x04 */
-  __IO uint32_t CTRL2;    /*!< ACC Control register 2,                      Address offset: 0x08 */
-  __IO uint32_t CP1;      /*!< ACC Compare value 1,                         Address offset: 0x0C */
-  __IO uint32_t CP2;      /*!< ACC Compare value 2,                         Address offset: 0x10 */
-  __IO uint32_t CP3;      /*!< ACC Compare value 3,                         Address offset: 0x14 */
+  __IO uint32_t STS;      /*!< ACC status register,                         Address offset: 0x00 */
+  __IO uint32_t CTRL1;    /*!< ACC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CTRL2;    /*!< ACC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t CP1;      /*!< ACC compare value 1,                         Address offset: 0x0C */
+  __IO uint32_t CP2;      /*!< ACC compare value 2,                         Address offset: 0x10 */
+  __IO uint32_t CP3;      /*!< ACC compare value 3,                         Address offset: 0x14 */
 } ACC_TypeDef;
 
 /**
@@ -283,8 +283,8 @@ typedef struct
   __IO uint32_t ESTS;                                /*!< CAN error status register,                   Address offset: 0x018         */
   __IO uint32_t BTMG;                                /*!< CAN bit timing register,                     Address offset: 0x01C         */
   uint32_t      RESERVED0[88];                       /*!< Reserved,                                    Address offset: 0x020 ~ 0x17C */
-  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX Mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
-  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO Mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
+  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
+  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
   uint32_t      RESERVED1[12];                       /*!< Reserved,                                    Address offset: 0x1D0 ~ 0x1FC */
   __IO uint32_t FCTRL;                               /*!< CAN filter control register,                 Address offset: 0x200         */
   __IO uint32_t FMCFG;                               /*!< CAN filter mode configuration register,      Address offset: 0x204         */
@@ -304,12 +304,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t DT;          /*!< CRC Data register,                           Address offset: 0x00 */
-  __IO uint32_t CDT;         /*!< CRC Common data register,                    Address offset: 0x04 */
-  __IO uint32_t CTRL;        /*!< CRC Control register,                        Address offset: 0x08 */
+  __IO uint32_t DT;          /*!< CRC data register,                           Address offset: 0x00 */
+  __IO uint32_t CDT;         /*!< CRC common data register,                    Address offset: 0x04 */
+  __IO uint32_t CTRL;        /*!< CRC control register,                        Address offset: 0x08 */
   uint32_t      RESERVED;    /*!< Reserved,                                    Address offset: 0x0C */
-  __IO uint32_t IDT;         /*!< CRC Initialization register,                 Address offset: 0x10 */
-  __IO uint32_t POLY;        /*!< CRC Polynomial register,                     Address offset: 0x14 */
+  __IO uint32_t IDT;         /*!< CRC initialization register,                 Address offset: 0x10 */
+  __IO uint32_t POLY;        /*!< CRC polynomial register,                     Address offset: 0x14 */
 } CRC_TypeDef;
 
 /**
@@ -318,10 +318,10 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;            /*!< CRM Clock control register,                  Address offset: 0x00        */
+  __IO uint32_t CTRL;            /*!< CRM clock control register,                  Address offset: 0x00        */
   __IO uint32_t PLLCFG;          /*!< CRM PLL clock configuration register,        Address offset: 0x04        */
-  __IO uint32_t CFG;             /*!< CRM Clock configuration register,            Address offset: 0x08        */
-  __IO uint32_t CLKINT;          /*!< CRM Clock interrupt register,                Address offset: 0x0C        */
+  __IO uint32_t CFG;             /*!< CRM clock configuration register,            Address offset: 0x08        */
+  __IO uint32_t CLKINT;          /*!< CRM clock interrupt register,                Address offset: 0x0C        */
   __IO uint32_t AHBRST1;         /*!< CRM AHB peripheral reset register 1,         Address offset: 0x10        */
   __IO uint32_t AHBRST2;         /*!< CRM AHB peripheral reset register 2,         Address offset: 0x14        */
   __IO uint32_t AHBRST3;         /*!< CRM AHB peripheral reset register 3,         Address offset: 0x18        */
@@ -343,12 +343,12 @@ typedef struct
   __IO uint32_t APB1LPEN;        /*!< CRM APB1 periph clk enable in LP mode reg,   Address offset: 0x60        */
   __IO uint32_t APB2LPEN;        /*!< CRM APB2 periph clk enable in LP mode reg,   Address offset: 0x64        */
   uint32_t      RESERVED5[2];    /*!< Reserved,                                    Address offset: 0x68 ~ 0x6C */
-  __IO uint32_t BPDC;            /*!< CRM Battery powered domain control register, Address offset: 0x70        */
-  __IO uint32_t CTRLSTS;         /*!< CRM Control/status register,                 Address offset: 0x74        */
+  __IO uint32_t BPDC;            /*!< CRM battery powered domain control register, Address offset: 0x70        */
+  __IO uint32_t CTRLSTS;         /*!< CRM control/status register,                 Address offset: 0x74        */
   __IO uint32_t OTGHS;           /*!< CRM OTGHS control register (F405 only),      Address offset: 0x78        */
   uint32_t      RESERVED6[9];    /*!< Reserved,                                    Address offset: 0x7C ~ 0x9C */
-  __IO uint32_t MISC1;           /*!< CRM Additional register 1,                   Address offset: 0xA0        */
-  __IO uint32_t MISC2;           /*!< CRM Additional register 2,                   Address offset: 0xA4        */
+  __IO uint32_t MISC1;           /*!< CRM additional register 1,                   Address offset: 0xA0        */
+  __IO uint32_t MISC2;           /*!< CRM additional register 2,                   Address offset: 0xA4        */
 } CRM_TypeDef;
 
 /**
@@ -461,12 +461,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t INTEN;      /*!< EXINT Interrupt enable register,             Address offset: 0x00 */
-  __IO uint32_t EVTEN;      /*!< EXINT Event enable register,                 Address offset: 0x04 */
-  __IO uint32_t POLCFG1;    /*!< EXINT Polarity configuration register 1,     Address offset: 0x08 */
-  __IO uint32_t POLCFG2;    /*!< EXINT Polarity configuration register 2,     Address offset: 0x0C */
-  __IO uint32_t SWTRG;      /*!< EXINT Software trigger register,             Address offset: 0x10 */
-  __IO uint32_t INTSTS;     /*!< EXINT Interrupt status register,             Address offset: 0x14 */
+  __IO uint32_t INTEN;      /*!< EXINT interrupt enable register,             Address offset: 0x00 */
+  __IO uint32_t EVTEN;      /*!< EXINT event enable register,                 Address offset: 0x04 */
+  __IO uint32_t POLCFG1;    /*!< EXINT polarity configuration register 1,     Address offset: 0x08 */
+  __IO uint32_t POLCFG2;    /*!< EXINT polarity configuration register 2,     Address offset: 0x0C */
+  __IO uint32_t SWTRG;      /*!< EXINT software trigger register,             Address offset: 0x10 */
+  __IO uint32_t INTSTS;     /*!< EXINT interrupt status register,             Address offset: 0x14 */
 } EXINT_TypeDef;
 
 /**
@@ -482,7 +482,7 @@ typedef struct
   __IO uint32_t CTRL;              /*!< FLASH control register,                      Address offset: 0x10         */
   __IO uint32_t ADDR;              /*!< FLASH address register,                      Address offset: 0x14         */
   uint32_t      RESERVED0;         /*!< Reserved,                                    Address offset: 0x18         */
-  __IO uint32_t USD;               /*!< FLASH user system data register,             Address offset: 0x1C         */
+  __IO uint32_t FUSD;              /*!< FLASH user system data register,             Address offset: 0x1C         */
   __IO uint32_t EPPS;              /*!< FLASH erase/program protection status reg,   Address offset: 0x20         */
   uint32_t      RESERVED1[20];     /*!< Reserved,                                    Address offset: 0x24 ~ 0x70  */
   __IO uint32_t SLIB_STS0;         /*!< FLASH security library status register 0,    Address offset: 0x74         */
@@ -506,25 +506,25 @@ typedef struct
 
 typedef struct
 {
-  __IO uint16_t FAP;               /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
-  __IO uint16_t SSB;               /*!< USD System configuration byte,               Address offset: 0x1FFF_F802               */
-  __IO uint16_t DATA0;             /*!< USD User data 0,                             Address offset: 0x1FFF_F804               */
-  __IO uint16_t DATA1;             /*!< USD User data 1,                             Address offset: 0x1FFF_F806               */
-  __IO uint16_t EPP0;              /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
-  __IO uint16_t EPP1;              /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
-  __IO uint16_t EPP2;              /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
-  __IO uint16_t EPP3;              /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
-  uint32_t      RESERVED0[9];      /*!< Reserved,                                    Address offset: 0x1FFF_F810 ~ 0x1FFF_F830 */
-  __IO uint16_t QSPIKEY0;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 0,                       Address offset: 0x1FFF_F834               */
-  __IO uint16_t QSPIKEY1;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 1,                       Address offset: 0x1FFF_F836               */
-  __IO uint16_t QSPIKEY2;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 2,                       Address offset: 0x1FFF_F838               */
-  __IO uint16_t QSPIKEY3;          /*!< USD QSPI ciphertext access area
-                                        encryption key byte 3,                       Address offset: 0x1FFF_F83A               */
-  uint32_t      RESERVED1[4];      /*!< Reserved,                                    Address offset: 0x1FFF_F83C ~ 0x1FFF_F848 */
-  __IO uint16_t DATA[218];         /*!< USD User data 2 ~ 219,                       Address offset: 0x1FFF_F84C ~ 0x1FFF_F9FC */
+  __IO uint16_t FAP;             /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
+  __IO uint16_t SSB;             /*!< USD system configuration byte,               Address offset: 0x1FFF_F802               */
+  __IO uint16_t DATA0;           /*!< USD user data 0,                             Address offset: 0x1FFF_F804               */
+  __IO uint16_t DATA1;           /*!< USD user data 1,                             Address offset: 0x1FFF_F806               */
+  __IO uint16_t EPP0;            /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
+  __IO uint16_t EPP1;            /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
+  __IO uint16_t EPP2;            /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
+  __IO uint16_t EPP3;            /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
+  uint32_t      RESERVED0[9];    /*!< Reserved,                                    Address offset: 0x1FFF_F810 ~ 0x1FFF_F830 */
+  __IO uint16_t QSPIKEY0;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 0,                       Address offset: 0x1FFF_F834               */
+  __IO uint16_t QSPIKEY1;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 1,                       Address offset: 0x1FFF_F836               */
+  __IO uint16_t QSPIKEY2;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 2,                       Address offset: 0x1FFF_F838               */
+  __IO uint16_t QSPIKEY3;        /*!< USD QSPI ciphertext access area
+                                      encryption key byte 3,                       Address offset: 0x1FFF_F83A               */
+  uint32_t      RESERVED1[4];    /*!< Reserved,                                    Address offset: 0x1FFF_F83C ~ 0x1FFF_F848 */
+  __IO uint16_t DATA[218];       /*!< USD user data 2 ~ 219,                       Address offset: 0x1FFF_F84C ~ 0x1FFF_F9FC */
 } USD_TypeDef;
 
 /**
@@ -547,7 +547,6 @@ typedef struct
   __IO uint32_t TOGR;           /*!< GPIO port bit toggle register,               Address offset: 0x2C        */
   uint32_t      RESERVED[3];    /*!< Reserved,                                    Address offset: 0x30 ~ 0x38 */
   __IO uint32_t HDRV;           /*!< GPIO huge current control register,          Address offset: 0x3C        */
-  __IO uint32_t SRCTR;          /*!< GPIO SRCTR register,                         Address offset: 0x40        */
 } GPIO_TypeDef;
 
 /**
@@ -556,17 +555,17 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL1;      /*!< I2C Control register 1,                      Address offset: 0x00 */
-  __IO uint32_t CTRL2;      /*!< I2C Control register 2,                      Address offset: 0x04 */
-  __IO uint32_t OADDR1;     /*!< I2C Own address register 1,                  Address offset: 0x08 */
-  __IO uint32_t OADDR2;     /*!< I2C Own address register 2,                  Address offset: 0x0C */
-  __IO uint32_t CLKCTRL;    /*!< I2C Clock control register,                  Address offset: 0x10 */
-  __IO uint32_t TIMEOUT;    /*!< I2C Timeout register,                        Address offset: 0x14 */
-  __IO uint32_t STS;        /*!< I2C Status register,                         Address offset: 0x18 */
-  __IO uint32_t CLR;        /*!< I2C Status clear flag register,              Address offset: 0x1C */
+  __IO uint32_t CTRL1;      /*!< I2C control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CTRL2;      /*!< I2C control register 2,                      Address offset: 0x04 */
+  __IO uint32_t OADDR1;     /*!< I2C own address register 1,                  Address offset: 0x08 */
+  __IO uint32_t OADDR2;     /*!< I2C own address register 2,                  Address offset: 0x0C */
+  __IO uint32_t CLKCTRL;    /*!< I2C clock control register,                  Address offset: 0x10 */
+  __IO uint32_t TIMEOUT;    /*!< I2C timeout register,                        Address offset: 0x14 */
+  __IO uint32_t STS;        /*!< I2C status register,                         Address offset: 0x18 */
+  __IO uint32_t CLR;        /*!< I2C status clear flag register,              Address offset: 0x1C */
   __IO uint32_t PEC;        /*!< I2C PEC register,                            Address offset: 0x20 */
-  __IO uint32_t RXDT;       /*!< I2C Receive data register,                   Address offset: 0x24 */
-  __IO uint32_t TXDT;       /*!< I2C Transmit data register,                  Address offset: 0x28 */
+  __IO uint32_t RXDT;       /*!< I2C receive data register,                   Address offset: 0x24 */
+  __IO uint32_t TXDT;       /*!< I2C transmit data register,                  Address offset: 0x28 */
 } I2C_TypeDef;
 
 /**
@@ -575,8 +574,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;           /*!< PWC Power control register,                  Address offset: 0x00        */
-  __IO uint32_t CTRLSTS;        /*!< PWC Power control/status register,           Address offset: 0x04        */
+  __IO uint32_t CTRL;           /*!< PWC power control register,                  Address offset: 0x00        */
+  __IO uint32_t CTRLSTS;        /*!< PWC power control/status register,           Address offset: 0x04        */
   uint32_t      RESERVED[2];    /*!< Reserved,                                    Address offset: 0x08 ~ 0x0C */
   __IO uint32_t LDOOV;          /*!< PWC LDO output voltage select register,      Address offset: 0x10        */
 } PWC_TypeDef;
@@ -587,29 +586,29 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD_W0;           /*!< QSPI Command word 0 register,                Address offset: 0x00        */
-  __IO uint32_t CMD_W1;           /*!< QSPI Command word 1 register,                Address offset: 0x04        */
-  __IO uint32_t CMD_W2;           /*!< QSPI Command word 2 register,                Address offset: 0x08        */
-  __IO uint32_t CMD_W3;           /*!< QSPI Command word 3 register,                Address offset: 0x0C        */
-  __IO uint32_t CTRL;             /*!< QSPI Control register,                       Address offset: 0x10        */
+  __IO uint32_t CMD_W0;           /*!< QSPI command word 0 register,                Address offset: 0x00        */
+  __IO uint32_t CMD_W1;           /*!< QSPI command word 1 register,                Address offset: 0x04        */
+  __IO uint32_t CMD_W2;           /*!< QSPI command word 2 register,                Address offset: 0x08        */
+  __IO uint32_t CMD_W3;           /*!< QSPI command word 3 register,                Address offset: 0x0C        */
+  __IO uint32_t CTRL;             /*!< QSPI control register,                       Address offset: 0x10        */
   uint32_t      RESERVED0;        /*!< Reserved,                                    Address offset: 0x14        */
   __IO uint32_t FIFOSTS;          /*!< QSPI FIFO status register,                   Address offset: 0x18        */
   uint32_t      RESERVED1;        /*!< Reserved,                                    Address offset: 0x1C        */
-  __IO uint32_t CTRL2;            /*!< QSPI Control register 2,                     Address offset: 0x20        */
-  __IO uint32_t CMDSTS;           /*!< QSPI Command status register,                Address offset: 0x24        */
-  __IO uint32_t RSTS;             /*!< QSPI Read status register,                   Address offset: 0x28        */
-  __IO uint32_t FSIZE;            /*!< QSPI Flash size register,                    Address offset: 0x2C        */
+  __IO uint32_t CTRL2;            /*!< QSPI control register 2,                     Address offset: 0x20        */
+  __IO uint32_t CMDSTS;           /*!< QSPI command status register,                Address offset: 0x24        */
+  __IO uint32_t RSTS;             /*!< QSPI read status register,                   Address offset: 0x28        */
+  __IO uint32_t FSIZE;            /*!< QSPI flash size register,                    Address offset: 0x2C        */
   __IO uint32_t XIP_CMD_W0;       /*!< QSPI XIP command word 0 register,            Address offset: 0x30        */
   __IO uint32_t XIP_CMD_W1;       /*!< QSPI XIP command word 1 register,            Address offset: 0x34        */
   __IO uint32_t XIP_CMD_W2;       /*!< QSPI XIP command word 2 register,            Address offset: 0x38        */
   __IO uint32_t XIP_CMD_W3;       /*!< QSPI XIP command word 3 register,            Address offset: 0x3C        */
-  __IO uint32_t CTRL3;            /*!< QSPI Control register 3,                     Address offset: 0x40        */
+  __IO uint32_t CTRL3;            /*!< QSPI control register 3,                     Address offset: 0x40        */
   uint32_t      RESERVED2[3];     /*!< Reserved,                                    Address offset: 0x44 ~ 0x4C */
-  __IO uint32_t REV;              /*!< QSPI Revision register,                      Address offset: 0x50        */
+  __IO uint32_t REV;              /*!< QSPI revision register,                      Address offset: 0x50        */
   uint32_t      RESERVED3[43];    /*!< Reserved,                                    Address offset: 0x54 ~ 0xFC */
-  __IO uint8_t  DT_U8;            /*!< QSPI Data port (8-bit) register,             Address offset: 0x100       */
-  __IO uint16_t DT_U16;           /*!< QSPI Data port (16-bit) register,            Address offset: 0x100       */
-  __IO uint32_t DT;               /*!< QSPI Data port register,                     Address offset: 0x100       */
+  __IO uint8_t  DT_U8;            /*!< QSPI data port (8-bit) register,             Address offset: 0x100       */
+  __IO uint16_t DT_U16;           /*!< QSPI data port (16-bit) register,            Address offset: 0x100       */
+  __IO uint32_t DT;               /*!< QSPI data port register,                     Address offset: 0x100       */
 } QSPI_TypeDef;
 
 /**
@@ -667,7 +666,7 @@ typedef struct
   __IO uint32_t C2DT;       /*!< TMR channel 2 data register,                 Address offset: 0x38 */
   __IO uint32_t C3DT;       /*!< TMR channel 3 data register,                 Address offset: 0x3C */
   __IO uint32_t C4DT;       /*!< TMR channel 4 data register,                 Address offset: 0x40 */
-  __IO uint32_t BRK;        /*!< TMR break register,                          Address offset: 0x44 */
+  __IO uint32_t BRK;        /*!< TMR brake register,                          Address offset: 0x44 */
   __IO uint32_t DMACTRL;    /*!< TMR DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMADT;      /*!< TMR DMA data register,                       Address offset: 0x4C */
   __IO uint32_t RMP;        /*!< TMR channel input remap register,            Address offset: 0x50 */
@@ -696,11 +695,11 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD;    /*!< WDT Command register,                        Address offset: 0x00 */
-  __IO uint32_t DIV;    /*!< WDT Divider register,                        Address offset: 0x04 */
-  __IO uint32_t RLD;    /*!< WDT Reload register,                         Address offset: 0x08 */
-  __IO uint32_t STS;    /*!< WDT Status register,                         Address offset: 0x0C */
-  __IO uint32_t WIN;    /*!< WDT Window register,                         Address offset: 0x10 */
+  __IO uint32_t CMD;    /*!< WDT command register,                        Address offset: 0x00 */
+  __IO uint32_t DIV;    /*!< WDT divider register,                        Address offset: 0x04 */
+  __IO uint32_t RLD;    /*!< WDT reload register,                         Address offset: 0x08 */
+  __IO uint32_t STS;    /*!< WDT status register,                         Address offset: 0x0C */
+  __IO uint32_t WIN;    /*!< WDT window register,                         Address offset: 0x10 */
 } WDT_TypeDef;
 
 /**
@@ -709,9 +708,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;    /*!< WWDT Control register,                       Address offset: 0x00 */
-  __IO uint32_t CFG;     /*!< WWDT Configuration register,                 Address offset: 0x04 */
-  __IO uint32_t STS;     /*!< WWDT Status register,                        Address offset: 0x08 */
+  __IO uint32_t CTRL;    /*!< WWDT control register,                       Address offset: 0x00 */
+  __IO uint32_t CFG;     /*!< WWDT configuration register,                 Address offset: 0x04 */
+  __IO uint32_t STS;     /*!< WWDT status register,                        Address offset: 0x08 */
 } WWDT_TypeDef;
 
 /**
@@ -975,7 +974,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Power Control (PWC)                            */
+/*                             Power control (PWC)                            */
 /*                                                                            */
 /******************************************************************************/
 
@@ -1046,7 +1045,7 @@ typedef struct
 #define PWC_CTRLSTS_SWPEN6                  PWC_CTRLSTS_SWPEN6_Msk                  /*!< Standby wake-up pin 6 enable */
 
 /******************  Bit definition for PWC_LDOOV register  *******************/
-/*!< LDOOVSEL congiguration */
+/*!< LDOOVSEL configuration */
 #define PWC_LDOOV_LDOOVSEL_Pos              (0U)
 #define PWC_LDOOV_LDOOVSEL_Msk              (0x3U << PWC_LDOOV_LDOOVSEL_Pos)        /*!< 0x00000003 */
 #define PWC_LDOOV_LDOOVSEL                  PWC_LDOOV_LDOOVSEL_Msk                  /*!< LDOOVSEL[1:0] bits (Voltage regulator output voltage select) */
@@ -1108,7 +1107,7 @@ typedef struct
 #define CRM_CTRL_PLLUSTBL                   CRM_CTRL_PLLUSTBL_Msk                   /*!< PLLU clock stable */
 
 /******************  Bit definition for CRM_PLLCFG register  ******************/
-/*!< PLL_MS congiguration */
+/*!< PLL_MS configuration */
 #define CRM_PLLCFG_PLL_MS_Pos               (0U)
 #define CRM_PLLCFG_PLL_MS_Msk               (0xFU << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x0000000F */
 #define CRM_PLLCFG_PLL_MS                   CRM_PLLCFG_PLL_MS_Msk                   /*!< PLL_MS[3:0] bits (PLL pre-division) */
@@ -1117,7 +1116,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_MS_2                 (0x4U << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x00000004 */
 #define CRM_PLLCFG_PLL_MS_3                 (0x8U << CRM_PLLCFG_PLL_MS_Pos)         /*!< 0x00000008 */
 
-/*!< PLL_NS congiguration */
+/*!< PLL_NS configuration */
 #define CRM_PLLCFG_PLL_NS_Pos               (6U)
 #define CRM_PLLCFG_PLL_NS_Msk               (0x1FFU << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00007FC0 */
 #define CRM_PLLCFG_PLL_NS                   CRM_PLLCFG_PLL_NS_Msk                   /*!< PLL_NS[8:0] bits (PLL multiplication factor) */
@@ -1131,7 +1130,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_NS_7                 (0x080U << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00002000 */
 #define CRM_PLLCFG_PLL_NS_8                 (0x100U << CRM_PLLCFG_PLL_NS_Pos)       /*!< 0x00004000 */
 
-/*!< PLL_FP congiguration */
+/*!< PLL_FP configuration */
 #define CRM_PLLCFG_PLL_FP_Pos               (16U)
 #define CRM_PLLCFG_PLL_FP_Msk               (0xFU << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x000F0000 */
 #define CRM_PLLCFG_PLL_FP                   CRM_PLLCFG_PLL_FP_Msk                   /*!< PLL_FP[3:0] bits (PLLP post-division) */
@@ -1140,7 +1139,7 @@ typedef struct
 #define CRM_PLLCFG_PLL_FP_2                 (0x4U << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x00040000 */
 #define CRM_PLLCFG_PLL_FP_3                 (0x8U << CRM_PLLCFG_PLL_FP_Pos)         /*!< 0x00080000 */
 
-/*!< PLL_FU congiguration */
+/*!< PLL_FU configuration */
 #define CRM_PLLCFG_PLL_FU_Pos               (20U)
 #define CRM_PLLCFG_PLL_FU_Msk               (0x7U << CRM_PLLCFG_PLL_FU_Pos)         /*!< 0x00700000 */
 #define CRM_PLLCFG_PLL_FU                   CRM_PLLCFG_PLL_FU_Msk                   /*!< PLL_FU[2:0] bits (PLLU post-division) */
@@ -1289,7 +1288,7 @@ typedef struct
 #define CRM_CFG_CLKOUTDIV1_1                (0x2U << CRM_CFG_CLKOUTDIV1_Pos)        /*!< 0x10000000 */
 #define CRM_CFG_CLKOUTDIV1_2                (0x4U << CRM_CFG_CLKOUTDIV1_Pos)        /*!< 0x20000000 */
 
-#define CRM_CFG_CLKOUTDIV1_DIV1             0x00000000U                             /*!< No clock output */
+#define CRM_CFG_CLKOUTDIV1_DIV1             0x00000000U                             /*!< No clock output division */
 #define CRM_CFG_CLKOUTDIV1_DIV2             0x20000000U                             /*!< Clock output divided by 2 */
 #define CRM_CFG_CLKOUTDIV1_DIV3             0x28000000U                             /*!< Clock output divided by 3 */
 #define CRM_CFG_CLKOUTDIV1_DIV4             0x30000000U                             /*!< Clock output divided by 4 */
@@ -1316,7 +1315,7 @@ typedef struct
 #define CRM_CFG_CLKSEL1_HEXT                CRM_CFG_CLKOUT_SEL1_HEXT
 #define CRM_CFG_CLKSEL1_PLL                 CRM_CFG_CLKOUT_SEL1_PLL
 
-/*!<***************  Bit definition for CRM_CLKINT register  ******************/
+/******************  Bit definition for CRM_CLKINT register  ******************/
 #define CRM_CLKINT_LICKSTBLF_Pos            (0U)
 #define CRM_CLKINT_LICKSTBLF_Msk            (0x1U << CRM_CLKINT_LICKSTBLF_Pos)      /*!< 0x00000001 */
 #define CRM_CLKINT_LICKSTBLF                CRM_CLKINT_LICKSTBLF_Msk                /*!< LICK stable interrupt flag */
@@ -1806,7 +1805,7 @@ typedef struct
 #define CRM_BPDC_LEXTBYPS_Msk               (0x1U << CRM_BPDC_LEXTBYPS_Pos)         /*!< 0x00000004 */
 #define CRM_BPDC_LEXTBYPS                   CRM_BPDC_LEXTBYPS_Msk                   /*!< External low-speed crystal bypass */
 
-/*!< ERTCSEL congiguration */
+/*!< ERTCSEL configuration */
 #define CRM_BPDC_ERTCSEL_Pos                (8U)
 #define CRM_BPDC_ERTCSEL_Msk                (0x3U << CRM_BPDC_ERTCSEL_Pos)          /*!< 0x00000300 */
 #define CRM_BPDC_ERTCSEL                    CRM_BPDC_ERTCSEL_Msk                    /*!< ERTCSEL[1:0] bits (ERTC clock selection) */
@@ -1873,7 +1872,7 @@ typedef struct
 #define CRM_MISC1_HICKRST_Msk               (0x1U << CRM_MISC1_HICKRST_Pos)         /*!< 0x00008000 */
 #define CRM_MISC1_HICKRST                   CRM_MISC1_HICKRST_Msk                   /*!< HICKRST */
 
-/*!< CLKOUT_SEL2 congiguration */
+/*!< CLKOUT_SEL2 configuration */
 #define CRM_MISC1_CLKOUT_SEL2_Pos           (16U)
 #define CRM_MISC1_CLKOUT_SEL2_Msk           (0xFU << CRM_MISC1_CLKOUT_SEL2_Pos)     /*!< 0x000F0000 */
 #define CRM_MISC1_CLKOUT_SEL2               CRM_MISC1_CLKOUT_SEL2_Msk               /*!< CLKOUT_SEL2[3:0] bits (Clock output selection 2) */
@@ -1900,7 +1899,7 @@ typedef struct
 #define CRM_MISC1_CLKSEL2_LICK              CRM_MISC1_CLKOUT_SEL2_LICK
 #define CRM_MISC1_CLKSEL2_LEXT              CRM_MISC1_CLKOUT_SEL2_LEXT
 
-/*!< CLKOUTDIV2 congiguration */
+/*!< CLKOUTDIV2 configuration */
 #define CRM_MISC1_CLKOUTDIV2_Pos            (28U)
 #define CRM_MISC1_CLKOUTDIV2_Msk            (0xFU << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0xF0000000 */
 #define CRM_MISC1_CLKOUTDIV2                CRM_MISC1_CLKOUTDIV2_Msk                /*!< CLKOUTDIV2[3:0] bits (Clock output division 2) */
@@ -1909,7 +1908,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV2_2              (0x4U << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0x40000000 */
 #define CRM_MISC1_CLKOUTDIV2_3              (0x8U << CRM_MISC1_CLKOUTDIV2_Pos)      /*!< 0x80000000 */
 
-#define CRM_MISC1_CLKOUTDIV2_DIV1           0x00000000U                             /*!< No clock output */
+#define CRM_MISC1_CLKOUTDIV2_DIV1           0x00000000U                             /*!< No clock output division */
 #define CRM_MISC1_CLKOUTDIV2_DIV2           0x80000000U                             /*!< Clock output divided by 2 */
 #define CRM_MISC1_CLKOUTDIV2_DIV4           0x90000000U                             /*!< Clock output divided by 4 */
 #define CRM_MISC1_CLKOUTDIV2_DIV8           0xA0000000U                             /*!< Clock output divided by 8 */
@@ -1920,7 +1919,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV2_DIV512         0xF0000000U                             /*!< Clock output divided by 512 */
 
 /******************  Bit definition for CRM_MISC2 register  *******************/
-/*!< AUTO_STEP_EN congiguration */
+/*!< AUTO_STEP_EN configuration */
 #define CRM_MISC2_AUTO_STEP_EN_Pos          (4U)
 #define CRM_MISC2_AUTO_STEP_EN_Msk          (0x3U << CRM_MISC2_AUTO_STEP_EN_Pos)    /*!< 0x00000030 */
 #define CRM_MISC2_AUTO_STEP_EN              CRM_MISC2_AUTO_STEP_EN_Msk              /*!< AUTO_STEP_EN[1:0] bits (Auto step-by-step SCLK switch enable) */
@@ -1931,7 +1930,7 @@ typedef struct
 #define CRM_MISC2_PLLU_USB48_SEL_Msk        (0x1U << CRM_MISC2_PLLU_USB48_SEL_Pos)  /*!< 0x00000400 */
 #define CRM_MISC2_PLLU_USB48_SEL            CRM_MISC2_PLLU_USB48_SEL_Msk            /*!< USBFS 48M clock source selection */
 
-/*!< HICK_TO_SCLK_DIV congiguration */
+/*!< HICK_TO_SCLK_DIV configuration */
 #define CRM_MISC2_HICK_TO_SCLK_DIV_Pos      (16U)
 #define CRM_MISC2_HICK_TO_SCLK_DIV_Msk      (0x7U << CRM_MISC2_HICK_TO_SCLK_DIV_Pos) /*!< 0x00070000 */
 #define CRM_MISC2_HICK_TO_SCLK_DIV          CRM_MISC2_HICK_TO_SCLK_DIV_Msk           /*!< HICK_TO_SCLK_DIV[2:0] bits (HICK as SCLK frequency division) */
@@ -1945,7 +1944,7 @@ typedef struct
 #define CRM_MISC2_HICK_TO_SCLK_DIV_DIV8     0x00030000U                              /*!< HICK/8 */
 #define CRM_MISC2_HICK_TO_SCLK_DIV_DIV16    0x00040000U                              /*!< HICK/16 */
 
-/*!< HEXT_TO_SCLK_DIV congiguration */
+/*!< HEXT_TO_SCLK_DIV configuration */
 #define CRM_MISC2_HEXT_TO_SCLK_DIV_Pos      (19U)
 #define CRM_MISC2_HEXT_TO_SCLK_DIV_Msk      (0x7U << CRM_MISC2_HEXT_TO_SCLK_DIV_Pos) /*!< 0x00380000 */
 #define CRM_MISC2_HEXT_TO_SCLK_DIV          CRM_MISC2_HEXT_TO_SCLK_DIV_Msk           /*!< HEXT_TO_SCLK_DIV[2:0] bits (HEXT as SCLK frequency division) */
@@ -1962,12 +1961,12 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                Flash and User System Data Registers (FLASH)                */
+/*                Flash and User System Data registers (FLASH)                */
 /*                                                                            */
 /******************************************************************************/
 
-/*******************  Bit definition for FLASH_PSR register  ******************/
-/*!< WTCYC congiguration */
+/******************  Bit definition for FLASH_PSR register  *******************/
+/*!< WTCYC configuration */
 #define FLASH_PSR_WTCYC_Pos                 (0U)
 #define FLASH_PSR_WTCYC_Msk                 (0x7U << FLASH_PSR_WTCYC_Pos)           /*!< 0x00000007 */
 #define FLASH_PSR_WTCYC                     FLASH_PSR_WTCYC_Msk                     /*!< WTCYC[2:0] bits (Wait cycle) */
@@ -2034,7 +2033,7 @@ typedef struct
 #define FLASH_CTRL_FPRGM                    FLASH_CTRL_FPRGM_Msk                    /*!< Flash program */
 #define FLASH_CTRL_SECERS_Pos               (1U)
 #define FLASH_CTRL_SECERS_Msk               (0x1U << FLASH_CTRL_SECERS_Pos)         /*!< 0x00000002 */
-#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Page erase */
+#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Sector erase */
 #define FLASH_CTRL_BANKERS_Pos              (2U)
 #define FLASH_CTRL_BANKERS_Msk              (0x1U << FLASH_CTRL_BANKERS_Pos)        /*!< 0x00000004 */
 #define FLASH_CTRL_BANKERS                  FLASH_CTRL_BANKERS_Msk                  /*!< Bank erase */
@@ -2073,7 +2072,7 @@ typedef struct
 #define FLASH_USD_FAP_Msk                   (0x1U << FLASH_USD_FAP_Pos)             /*!< 0x00000002 */
 #define FLASH_USD_FAP                       FLASH_USD_FAP_Msk                       /*!< Flash access protection */
 
-/*!< SSB congiguration */
+/*!< SSB configuration */
 #define FLASH_USD_WDT_ATO_EN_Pos            (2U)
 #define FLASH_USD_WDT_ATO_EN_Msk            (0x1U << FLASH_USD_WDT_ATO_EN_Pos)      /*!< 0x00000004 */
 #define FLASH_USD_WDT_ATO_EN                FLASH_USD_WDT_ATO_EN_Msk                /*!< nWDT_ATO_EN */
@@ -2114,7 +2113,7 @@ typedef struct
 #define FLASH_EPPS_EPPS_Msk                 (0xFFFFFFFFU << FLASH_EPPS_EPPS_Pos)    /*!< 0xFFFFFFFF */
 #define FLASH_EPPS_EPPS                     FLASH_EPPS_EPPS_Msk                     /*!< Erase/Program protection status */
 
-/*******************  Bit definition for SLIB_STS0 register *******************/
+/******************  Bit definition for SLIB_STS0 register  *******************/
 #define SLIB_STS0_BTM_AP_ENF_Pos            (0U)
 #define SLIB_STS0_BTM_AP_ENF_Msk            (0x1U << SLIB_STS0_BTM_AP_ENF_Pos)      /*!< 0x00000001 */
 #define SLIB_STS0_BTM_AP_ENF                SLIB_STS0_BTM_AP_ENF_Msk                /*!< Boot memory store application code enabled flag */
@@ -2124,27 +2123,27 @@ typedef struct
 #define SLIB_STS0_SLIB_ENF_Pos              (3U)
 #define SLIB_STS0_SLIB_ENF_Msk              (0x1U << SLIB_STS0_SLIB_ENF_Pos)        /*!< 0x00000008 */
 #define SLIB_STS0_SLIB_ENF                  SLIB_STS0_SLIB_ENF_Msk                  /*!< Security library enable flag */
-#define SLIB_STS0_EM_SLIB_INST_SS_Pos       (16U)                                   /*!< 0x00FF0000 */
-#define SLIB_STS0_EM_SLIB_INST_SS_Msk       (0xFFU << SLIB_STS0_EM_SLIB_INST_SS_Pos)
-#define SLIB_STS0_EM_SLIB_INST_SS           SLIB_STS0_EM_SLIB_INST_SS_Msk           /*!< Extension memory sLib instruction start page */
+#define SLIB_STS0_EM_SLIB_DAT_SS_Pos        (16U)
+#define SLIB_STS0_EM_SLIB_DAT_SS_Msk        (0xFFU << SLIB_STS0_EM_SLIB_DAT_SS_Pos) /*!< 0x00FF0000 */
+#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start sector */
 
-/*******************  Bit definition for SLIB_STS1 register *******************/
+/******************  Bit definition for SLIB_STS1 register  *******************/
 #define SLIB_STS1_SLIB_SS_Pos               (0U)
 #define SLIB_STS1_SLIB_SS_Msk               (0x7FFU << SLIB_STS1_SLIB_SS_Pos)       /*!< 0x000007FF */
-#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start page */
-#define SLIB_STS1_SLIB_INST_SS_Pos          (11U)
-#define SLIB_STS1_SLIB_INST_SS_Msk          (0x7FFU << SLIB_STS1_SLIB_INST_SS_Pos)  /*!< 0x003FF800 */
-#define SLIB_STS1_SLIB_INST_SS              SLIB_STS1_SLIB_INST_SS_Msk              /*!< Security library instruction start page */
+#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start sector */
+#define SLIB_STS1_SLIB_DAT_SS_Pos           (11U)
+#define SLIB_STS1_SLIB_DAT_SS_Msk           (0x7FFU << SLIB_STS1_SLIB_DAT_SS_Pos)   /*!< 0x003FF800 */
+#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start sector */
 #define SLIB_STS1_SLIB_ES_Pos               (22U)
 #define SLIB_STS1_SLIB_ES_Msk               (0x3FFU << SLIB_STS1_SLIB_ES_Pos)       /*!< 0xFFC00000 */
-#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end page */
+#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end sector */
 
-/*****************  Bit definition for SLIB_PWD_CLR register ******************/
+/*****************  Bit definition for SLIB_PWD_CLR register  *****************/
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk      (0xFFFFFFFFU << SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos)
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL          SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk          /*!< Security library password clear value */
 
-/*****************  Bit definition for SLIB_MISC_STS register *****************/
+/****************  Bit definition for SLIB_MISC_STS register  *****************/
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Pos      (0U)                                    /*!< 0x00000001 */
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Msk      (0x1U << SLIB_MISC_STS_SLIB_PWD_ERR_Pos)
 #define SLIB_MISC_STS_SLIB_PWD_ERR          SLIB_MISC_STS_SLIB_PWD_ERR_Msk          /*!< Security library password error */
@@ -2155,54 +2154,54 @@ typedef struct
 #define SLIB_MISC_STS_SLIB_ULKF_Msk         (0x1U << SLIB_MISC_STS_SLIB_ULKF_Pos)   /*!< 0x00000004 */
 #define SLIB_MISC_STS_SLIB_ULKF             SLIB_MISC_STS_SLIB_ULKF_Msk             /*!< Security library unlock flag */
 
-/****************  Bit definition for FLASH_CRC_ADDR register *****************/
+/****************  Bit definition for FLASH_CRC_ADDR register  ****************/
 #define FLASH_CRC_ADDR_CRC_ADDR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_ADDR_CRC_ADDR_Msk         (0xFFFFFFFFU << FLASH_CRC_ADDR_CRC_ADDR_Pos)
 #define FLASH_CRC_ADDR_CRC_ADDR             FLASH_CRC_ADDR_CRC_ADDR_Msk             /*!< CRC address */
 
-/****************  Bit definition for FLASH_CRC_CTRL register *****************/
+/****************  Bit definition for FLASH_CRC_CTRL register  ****************/
 #define FLASH_CRC_CTRL_CRC_SN_Pos           (0U)
 #define FLASH_CRC_CTRL_CRC_SN_Msk           (0xFFFFU << FLASH_CRC_CTRL_CRC_SN_Pos)  /*!< 0x0000FFFF */
-#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC page number */
+#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC sector number */
 #define FLASH_CRC_CTRL_CRC_STRT_Pos         (16U)
 #define FLASH_CRC_CTRL_CRC_STRT_Msk         (0x1U << FLASH_CRC_CTRL_CRC_STRT_Pos)   /*!< 0x00010000 */
 #define FLASH_CRC_CTRL_CRC_STRT             FLASH_CRC_CTRL_CRC_STRT_Msk             /*!< CRC start */
 
-/****************  Bit definition for FLASH_CRC_CHKR register *****************/
+/****************  Bit definition for FLASH_CRC_CHKR register  ****************/
 #define FLASH_CRC_CHKR_CRC_CHKR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_CHKR_CRC_CHKR_Msk         (0xFFFFFFFFU << FLASH_CRC_CHKR_CRC_CHKR_Pos)
 #define FLASH_CRC_CHKR_CRC_CHKR             FLASH_CRC_CHKR_CRC_CHKR_Msk             /*!< CRC check result */
 
-/*****************  Bit definition for SLIB_SET_PWD register ******************/
+/*****************  Bit definition for SLIB_SET_PWD register  *****************/
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Msk      (0xFFFFFFFFU << SLIB_SET_PWD_SLIB_PSET_VAL_Pos)
 #define SLIB_SET_PWD_SLIB_PSET_VAL          SLIB_SET_PWD_SLIB_PSET_VAL_Msk          /*!< Security library password setting value */
 
-/****************  Bit definition for SLIB_SET_RANGE register *****************/
+/****************  Bit definition for SLIB_SET_RANGE register  ****************/
 #define SLIB_SET_RANGE_SLIB_SS_SET_Pos      (0U)                                    /*!< 0x000007FF */
 #define SLIB_SET_RANGE_SLIB_SS_SET_Msk      (0x7FFU << SLIB_SET_RANGE_SLIB_SS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start page setting */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_ISS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ISS_SET         SLIB_SET_RANGE_SLIB_ISS_SET_Msk         /*!< Security library instruction start page setting */
+#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start sector setting */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_DSS_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_DSS_SET         SLIB_SET_RANGE_SLIB_DSS_SET_Msk         /*!< Security library data start sector setting */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Pos      (22U)                                   /*!< 0xFFC00000 */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0x3FFU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end page setting */
+#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end sector setting */
 
-/******************  Bit definition for EM_SLIB_SET register ******************/
+/*****************  Bit definition for EM_SLIB_SET register  ******************/
 #define EM_SLIB_SET_EM_SLIB_SET_Pos         (0U)                                    /*!< 0x0000FFFF */
 #define EM_SLIB_SET_EM_SLIB_SET_Msk         (0xFFFFU << EM_SLIB_SET_EM_SLIB_SET_Pos)
 #define EM_SLIB_SET_EM_SLIB_SET             EM_SLIB_SET_EM_SLIB_SET_Msk             /*!< Extension memory sLib setting */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_ISS_SET_Pos)
-#define EM_SLIB_SET_EM_SLIB_ISS_SET         EM_SLIB_SET_EM_SLIB_ISS_SET_Msk         /*!< Extension memory sLib instruction start page setting */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_DSS_SET_Pos)
+#define EM_SLIB_SET_EM_SLIB_DSS_SET         EM_SLIB_SET_EM_SLIB_DSS_SET_Msk         /*!< Extension memory sLib data start sector setting */
 
-/*****************  Bit definition for BTM_MODE_SET register ******************/
+/*****************  Bit definition for BTM_MODE_SET register  *****************/
 #define BTM_MODE_SET_BTM_MODE_SET_Pos       (0U)                                    /*!< 0x000000FF */
 #define BTM_MODE_SET_BTM_MODE_SET_Msk       (0xFFU << BTM_MODE_SET_BTM_MODE_SET_Pos)
 #define BTM_MODE_SET_BTM_MODE_SET           BTM_MODE_SET_BTM_MODE_SET_Msk           /*!< Boot memory mode setting */
 
-/*****************  Bit definition for SLIB_UNLOCK register ******************/
+/*****************  Bit definition for SLIB_UNLOCK register  ******************/
 #define SLIB_UNLOCK_SLIB_UKVAL_Pos          (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_UNLOCK_SLIB_UKVAL_Msk          (0xFFFFFFFFU << SLIB_UNLOCK_SLIB_UKVAL_Pos)
 #define SLIB_UNLOCK_SLIB_UKVAL              SLIB_UNLOCK_SLIB_UKVAL_Msk              /*!< Security library unlock key value */
@@ -2532,7 +2531,7 @@ typedef struct
 #define GPIO_OMODE_OM15_Msk                 (0x1U << GPIO_OMODE_OM15_Pos)           /*!< 0x00008000 */
 #define GPIO_OMODE_OM15                     GPIO_OMODE_OM15_Msk                     /*!< GPIO x output mode configuration, pin 15 */
 
-/*!<***************  Bit definition for GPIO_ODRVR register  ******************/
+/******************  Bit definition for GPIO_ODRVR register  ******************/
 #define GPIO_ODRVR_ODRV_Pos                 (0U)
 #define GPIO_ODRVR_ODRV_Msk                 (0xFFFFFFFFU << GPIO_ODRVR_ODRV_Pos)    /*!< 0xFFFFFFFF */
 #define GPIO_ODRVR_ODRV                     GPIO_ODRVR_ODRV_Msk                     /*!< GPIO x drive capability */
@@ -2649,7 +2648,7 @@ typedef struct
 #define GPIO_ODRVR_ODRV15_0                 (0x1U << GPIO_ODRVR_ODRV15_Pos)         /*!< 0x40000000 */
 #define GPIO_ODRVR_ODRV15_1                 (0x2U << GPIO_ODRVR_ODRV15_Pos)         /*!< 0x80000000 */
 
-/*!<***************  Bit definition for GPIO_PULL register  *******************/
+/******************  Bit definition for GPIO_PULL register  *******************/
 #define GPIO_PULL_PULL_Pos                  (0U)
 #define GPIO_PULL_PULL_Msk                  (0xFFFFFFFFU << GPIO_PULL_PULL_Pos)     /*!< 0xFFFFFFFF */
 #define GPIO_PULL_PULL                      GPIO_PULL_PULL_Msk                      /*!< GPIO x pull-up/pull-down configuration */
@@ -2766,7 +2765,7 @@ typedef struct
 #define GPIO_PULL_PULL15_0                  (0x1U << GPIO_PULL_PULL15_Pos)          /*!< 0x40000000 */
 #define GPIO_PULL_PULL15_1                  (0x2U << GPIO_PULL_PULL15_Pos)          /*!< 0x80000000 */
 
-/*!<****************  Bit definition for GPIO_IDT register  *******************/
+/*******************  Bit definition for GPIO_IDT register  *******************/
 #define GPIO_IDT_IDT0_Pos                   (0U)
 #define GPIO_IDT_IDT0_Msk                   (0x1U << GPIO_IDT_IDT0_Pos)             /*!< 0x00000001 */
 #define GPIO_IDT_IDT0                       GPIO_IDT_IDT0_Msk                       /*!< GPIO x input data, pin 0 */
@@ -3321,56 +3320,6 @@ typedef struct
 #define GPIO_HDRV_HDRV15_Msk                (0x1U << GPIO_HDRV_HDRV15_Pos)          /*!< 0x00008000 */
 #define GPIO_HDRV_HDRV15                    GPIO_HDRV_HDRV15_Msk                    /*!< GPIO x huge sourcing/sinking strength control, pin 15 */
 
-/******************  Bit definition for GPIO_SRCTR register  ******************/
-#define GPIO_SRCTR_SRCTR0_Pos               (0U)
-#define GPIO_SRCTR_SRCTR0_Msk               (0x1U << GPIO_SRCTR_SRCTR0_Pos)           /*!< 0x00000001 */
-#define GPIO_SRCTR_SRCTR0                   GPIO_SRCTR_SRCTR0_Msk                     /*!< GPIO x SRCTR, pin 0 */
-#define GPIO_SRCTR_SRCTR1_Pos               (1U)
-#define GPIO_SRCTR_SRCTR1_Msk               (0x1U << GPIO_SRCTR_SRCTR1_Pos)           /*!< 0x00000002 */
-#define GPIO_SRCTR_SRCTR1                   GPIO_SRCTR_SRCTR1_Msk                     /*!< GPIO x SRCTR, pin 1 */
-#define GPIO_SRCTR_SRCTR2_Pos               (2U)
-#define GPIO_SRCTR_SRCTR2_Msk               (0x1U << GPIO_SRCTR_SRCTR2_Pos)           /*!< 0x00000004 */
-#define GPIO_SRCTR_SRCTR2                   GPIO_SRCTR_SRCTR2_Msk                     /*!< GPIO x SRCTR, pin 2 */
-#define GPIO_SRCTR_SRCTR3_Pos               (3U)
-#define GPIO_SRCTR_SRCTR3_Msk               (0x1U << GPIO_SRCTR_SRCTR3_Pos)           /*!< 0x00000008 */
-#define GPIO_SRCTR_SRCTR3                   GPIO_SRCTR_SRCTR3_Msk                     /*!< GPIO x SRCTR, pin 3 */
-#define GPIO_SRCTR_SRCTR4_Pos               (4U)
-#define GPIO_SRCTR_SRCTR4_Msk               (0x1U << GPIO_SRCTR_SRCTR4_Pos)           /*!< 0x00000010 */
-#define GPIO_SRCTR_SRCTR4                   GPIO_SRCTR_SRCTR4_Msk                     /*!< GPIO x SRCTR, pin 4 */
-#define GPIO_SRCTR_SRCTR5_Pos               (5U)
-#define GPIO_SRCTR_SRCTR5_Msk               (0x1U << GPIO_SRCTR_SRCTR5_Pos)           /*!< 0x00000020 */
-#define GPIO_SRCTR_SRCTR5                   GPIO_SRCTR_SRCTR5_Msk                     /*!< GPIO x SRCTR, pin 5 */
-#define GPIO_SRCTR_SRCTR6_Pos               (6U)
-#define GPIO_SRCTR_SRCTR6_Msk               (0x1U << GPIO_SRCTR_SRCTR6_Pos)           /*!< 0x00000040 */
-#define GPIO_SRCTR_SRCTR6                   GPIO_SRCTR_SRCTR6_Msk                     /*!< GPIO x SRCTR, pin 6 */
-#define GPIO_SRCTR_SRCTR7_Pos               (7U)
-#define GPIO_SRCTR_SRCTR7_Msk               (0x1U << GPIO_SRCTR_SRCTR7_Pos)           /*!< 0x00000080 */
-#define GPIO_SRCTR_SRCTR7                   GPIO_SRCTR_SRCTR7_Msk                     /*!< GPIO x SRCTR, pin 7 */
-#define GPIO_SRCTR_SRCTR8_Pos               (8U)
-#define GPIO_SRCTR_SRCTR8_Msk               (0x1U << GPIO_SRCTR_SRCTR8_Pos)           /*!< 0x00000100 */
-#define GPIO_SRCTR_SRCTR8                   GPIO_SRCTR_SRCTR8_Msk                     /*!< GPIO x SRCTR, pin 8 */
-#define GPIO_SRCTR_SRCTR9_Pos               (9U)
-#define GPIO_SRCTR_SRCTR9_Msk               (0x1U << GPIO_SRCTR_SRCTR9_Pos)           /*!< 0x00000200 */
-#define GPIO_SRCTR_SRCTR9                   GPIO_SRCTR_SRCTR9_Msk                     /*!< GPIO x SRCTR, pin 9 */
-#define GPIO_SRCTR_SRCTR10_Pos              (10U)
-#define GPIO_SRCTR_SRCTR10_Msk              (0x1U << GPIO_SRCTR_SRCTR10_Pos)          /*!< 0x00000400 */
-#define GPIO_SRCTR_SRCTR10                  GPIO_SRCTR_SRCTR10_Msk                    /*!< GPIO x SRCTR, pin 10 */
-#define GPIO_SRCTR_SRCTR11_Pos              (11U)
-#define GPIO_SRCTR_SRCTR11_Msk              (0x1U << GPIO_SRCTR_SRCTR11_Pos)          /*!< 0x00000800 */
-#define GPIO_SRCTR_SRCTR11                  GPIO_SRCTR_SRCTR11_Msk                    /*!< GPIO x SRCTR, pin 11 */
-#define GPIO_SRCTR_SRCTR12_Pos              (12U)
-#define GPIO_SRCTR_SRCTR12_Msk              (0x1U << GPIO_SRCTR_SRCTR12_Pos)          /*!< 0x00001000 */
-#define GPIO_SRCTR_SRCTR12                  GPIO_SRCTR_SRCTR12_Msk                    /*!< GPIO x SRCTR, pin 12 */
-#define GPIO_SRCTR_SRCTR13_Pos              (13U)
-#define GPIO_SRCTR_SRCTR13_Msk              (0x1U << GPIO_SRCTR_SRCTR13_Pos)          /*!< 0x00002000 */
-#define GPIO_SRCTR_SRCTR13                  GPIO_SRCTR_SRCTR13_Msk                    /*!< GPIO x SRCTR, pin 13 */
-#define GPIO_SRCTR_SRCTR14_Pos              (14U)
-#define GPIO_SRCTR_SRCTR14_Msk              (0x1U << GPIO_SRCTR_SRCTR14_Pos)          /*!< 0x00004000 */
-#define GPIO_SRCTR_SRCTR14                  GPIO_SRCTR_SRCTR14_Msk                    /*!< GPIO x SRCTR, pin 14 */
-#define GPIO_SRCTR_SRCTR15_Pos              (15U)
-#define GPIO_SRCTR_SRCTR15_Msk              (0x1U << GPIO_SRCTR_SRCTR15_Pos)          /*!< 0x00008000 */
-#define GPIO_SRCTR_SRCTR15                  GPIO_SRCTR_SRCTR15_Msk                    /*!< GPIO x SRCTR, pin 15 */
-
 /******************************************************************************/
 /*                                                                            */
 /*                   System configuration controller (SCFG)                   */
@@ -3527,7 +3476,7 @@ typedef struct
 #define SCFG_EXINTC2_EXINT4_GPF_Msk         (0x1U << SCFG_EXINTC2_EXINT4_GPF_Pos)   /*!< 0x00000004 */
 #define SCFG_EXINTC2_EXINT4_GPF             SCFG_EXINTC2_EXINT4_GPF_Msk             /*!< GPIOF pin 4 */
 
-/* EXINT5 configuration */
+/*!< EXINT5 configuration */
 #define SCFG_EXINTC2_EXINT5_Pos             (4U)
 #define SCFG_EXINTC2_EXINT5_Msk             (0xFU << SCFG_EXINTC2_EXINT5_Pos)       /*!< 0x000000F0 */
 #define SCFG_EXINTC2_EXINT5                 SCFG_EXINTC2_EXINT5_Msk                 /*!< EXINT5[3:0] bits (EXINT5 input source configuration) */
@@ -3662,7 +3611,7 @@ typedef struct
 #define SCFG_EXINTC3_EXINT11_GPF            SCFG_EXINTC3_EXINT11_GPF_Msk            /*!< GPIOF pin 11 */
 
 /*****************  Bit definition for SCFG_EXINTC4 register  *****************/
-/* EXINT12 configuration */
+/*!< EXINT12 configuration */
 #define SCFG_EXINTC4_EXINT12_Pos            (0U)
 #define SCFG_EXINTC4_EXINT12_Msk            (0xFU << SCFG_EXINTC4_EXINT12_Pos)      /*!< 0x0000000F */
 #define SCFG_EXINTC4_EXINT12                SCFG_EXINTC4_EXINT12_Msk                /*!< EXINT12[3:0] bits (EXINT12 input source configuration) */
@@ -3681,7 +3630,7 @@ typedef struct
 #define SCFG_EXINTC4_EXINT12_GPF_Msk        (0x1U << SCFG_EXINTC4_EXINT12_GPF_Pos)  /*!< 0x00000004 */
 #define SCFG_EXINTC4_EXINT12_GPF            SCFG_EXINTC4_EXINT12_GPF_Msk            /*!< GPIOF pin 12 */
 
-/* EXINT13 configuration */
+/*!< EXINT13 configuration */
 #define SCFG_EXINTC4_EXINT13_Pos            (4U)
 #define SCFG_EXINTC4_EXINT13_Msk            (0xFU << SCFG_EXINTC4_EXINT13_Pos)      /*!< 0x000000F0 */
 #define SCFG_EXINTC4_EXINT13                SCFG_EXINTC4_EXINT13_Msk                /*!< EXINT13[3:0] bits (EXINT13 input source configuration) */
@@ -3823,7 +3772,7 @@ typedef struct
 #define EXINT_INTEN_INTEN22_Msk             (0x1U << EXINT_INTEN_INTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTEN_INTEN22                 EXINT_INTEN_INTEN22_Msk                 /*!< Interrupt enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTEN_INT0                    EXINT_INTEN_INTEN0
 #define EXINT_INTEN_INT1                    EXINT_INTEN_INTEN1
 #define EXINT_INTEN_INT2                    EXINT_INTEN_INTEN2
@@ -3916,7 +3865,7 @@ typedef struct
 #define EXINT_EVTEN_EVTEN22_Msk             (0x1U << EXINT_EVTEN_EVTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_EVTEN_EVTEN22                 EXINT_EVTEN_EVTEN22_Msk                 /*!< Event enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_EVTEN_EVT0                    EXINT_EVTEN_EVTEN0
 #define EXINT_EVTEN_EVT1                    EXINT_EVTEN_EVTEN1
 #define EXINT_EVTEN_EVT2                    EXINT_EVTEN_EVTEN2
@@ -4008,7 +3957,7 @@ typedef struct
 #define EXINT_POLCFG1_RP22_Msk              (0x1U << EXINT_POLCFG1_RP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG1_RP22                  EXINT_POLCFG1_RP22_Msk                  /*!< Rising edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG1_POL0                  EXINT_POLCFG1_RP0
 #define EXINT_POLCFG1_POL1                  EXINT_POLCFG1_RP1
 #define EXINT_POLCFG1_POL2                  EXINT_POLCFG1_RP2
@@ -4100,7 +4049,7 @@ typedef struct
 #define EXINT_POLCFG2_FP22_Msk              (0x1U << EXINT_POLCFG2_FP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG2_FP22                  EXINT_POLCFG2_FP22_Msk                  /*!< Falling edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG2_POL0                  EXINT_POLCFG2_FP0
 #define EXINT_POLCFG2_POL1                  EXINT_POLCFG2_FP1
 #define EXINT_POLCFG2_POL2                  EXINT_POLCFG2_FP2
@@ -4192,7 +4141,7 @@ typedef struct
 #define EXINT_SWTRG_SWT22_Msk               (0x1U << EXINT_SWTRG_SWT22_Pos)         /*!< 0x00400000 */
 #define EXINT_SWTRG_SWT22                   EXINT_SWTRG_SWT22_Msk                   /*!< Software trigger on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_SWTRG_SW0                     EXINT_SWTRG_SWT0
 #define EXINT_SWTRG_SW1                     EXINT_SWTRG_SWT1
 #define EXINT_SWTRG_SW2                     EXINT_SWTRG_SWT2
@@ -4284,7 +4233,7 @@ typedef struct
 #define EXINT_INTSTS_LINE22_Msk             (0x1U << EXINT_INTSTS_LINE22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTSTS_LINE22                 EXINT_INTSTS_LINE22_Msk                 /*!< Status bit for line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTSTS_INT0                   EXINT_INTSTS_LINE0
 #define EXINT_INTSTS_INT1                   EXINT_INTSTS_LINE1
 #define EXINT_INTSTS_INT2                   EXINT_INTSTS_LINE2
@@ -4839,8 +4788,8 @@ typedef struct
 
 /******************  Bit definition for I2C_OADDR1 register  ******************/
 /*!< ADDR1 configuration */
-#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface Address */
-#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface Address */
+#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface address */
+#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface address */
 
 #define I2C_OADDR1_ADDR1_0_Pos              (0U)
 #define I2C_OADDR1_ADDR1_0_Msk              (0x1U << I2C_OADDR1_ADDR1_0_Pos)        /*!< 0x00000001 */
@@ -5322,7 +5271,7 @@ typedef struct
 #define SPI_CTRL1_NTC                       SPI_CTRL1_NTC_Msk                       /*!< Transmit CRC next */
 #define SPI_CTRL1_CCEN_Pos                  (13U)
 #define SPI_CTRL1_CCEN_Msk                  (0x1U << SPI_CTRL1_CCEN_Pos)            /*!< 0x00002000 */
-#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< RC calculation enable */
+#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< CRC calculation enable */
 #define SPI_CTRL1_SLBTD_Pos                 (14U)
 #define SPI_CTRL1_SLBTD_Msk                 (0x1U << SPI_CTRL1_SLBTD_Pos)           /*!< 0x00004000 */
 #define SPI_CTRL1_SLBTD                     SPI_CTRL1_SLBTD_Msk                     /*!< Single line bidirectional half-duplex transmission direction */
@@ -5393,7 +5342,7 @@ typedef struct
 #define SPI_DT_DT_Msk                       (0xFFFFU << SPI_DT_DT_Pos)              /*!< 0x0000FFFF */
 #define SPI_DT_DT                           SPI_DT_DT_Msk                           /*!< Data value */
 
-/*******************  Bit definition for SPI_CPOLY register  ******************/
+/******************  Bit definition for SPI_CPOLY register  *******************/
 #define SPI_CPOLY_CPOLY_Pos                 (0U)
 #define SPI_CPOLY_CPOLY_Msk                 (0xFFFFU << SPI_CPOLY_CPOLY_Pos)        /*!< 0x0000FFFF */
 #define SPI_CPOLY_CPOLY                     SPI_CPOLY_CPOLY_Msk                     /*!< CRC polynomial */
@@ -6629,12 +6578,12 @@ typedef struct
 #define ADC_PCDTO4_PCDTO4_Msk               (0xFFFU << ADC_PCDTO4_PCDTO4_Pos)       /*!< 0x00000FFF */
 #define ADC_PCDTO4_PCDTO4                   ADC_PCDTO4_PCDTO4_Msk                   /*!< Data offset for Preempted channel 4 */
 
-/*******************  Bit definition for ADC_VMHB register  ********************/
+/*******************  Bit definition for ADC_VMHB register  *******************/
 #define ADC_VMHB_VMHB_Pos                   (0U)
 #define ADC_VMHB_VMHB_Msk                   (0xFFFFU << ADC_VMHB_VMHB_Pos)          /*!< 0x0000FFFF */
 #define ADC_VMHB_VMHB                       ADC_VMHB_VMHB_Msk                       /*!< Voltage monitoring high boundary */
 
-/*******************  Bit definition for ADC_VMLB register  ********************/
+/*******************  Bit definition for ADC_VMLB register  *******************/
 #define ADC_VMLB_VMLB_Pos                   (0U)
 #define ADC_VMLB_VMLB_Msk                   (0xFFFFU << ADC_VMLB_VMLB_Pos)          /*!< 0x0000FFFF */
 #define ADC_VMLB_VMLB                       ADC_VMLB_VMLB_Msk                       /*!< Voltage monitoring low boundary */
@@ -7080,7 +7029,7 @@ typedef struct
 #define CAN_TSTS_TMNR_Msk                   (0x3U << CAN_TSTS_TMNR_Pos)             /*!< 0x03000000 */
 #define CAN_TSTS_TMNR                       CAN_TSTS_TMNR_Msk                       /*!< TMNR[1:0] bits (Transmit mailbox number record) */
 
-/*!< TMEF congiguration */
+/*!< TMEF configuration */
 #define CAN_TSTS_TMEF_Pos                   (26U)
 #define CAN_TSTS_TMEF_Msk                   (0x7U << CAN_TSTS_TMEF_Pos)             /*!< 0x1C000000 */
 #define CAN_TSTS_TMEF                       CAN_TSTS_TMEF_Msk                       /*!< TMEF[2:0] bits (Transmit mailbox empty flag) */
@@ -7094,7 +7043,7 @@ typedef struct
 #define CAN_TSTS_TM2EF_Msk                  (0x1U << CAN_TSTS_TM2EF_Pos)            /*!< 0x10000000 */
 #define CAN_TSTS_TM2EF                      CAN_TSTS_TM2EF_Msk                      /*!< Transmit mailbox 2 empty flag */
 
-/*!< TMLPF congiguration */
+/*!< TMLPF configuration */
 #define CAN_TSTS_TMLPF_Pos                  (29U)
 #define CAN_TSTS_TMLPF_Msk                  (0x7U << CAN_TSTS_TMLPF_Pos)            /*!< 0xE0000000 */
 #define CAN_TSTS_TMLPF                      CAN_TSTS_TMLPF_Msk                      /*!< TMLPF[2:0] bits (Transmit mailbox lowest priority flag) */
@@ -7191,7 +7140,7 @@ typedef struct
 #define CAN_ESTS_BOF_Msk                    (0x1U << CAN_ESTS_BOF_Pos)              /*!< 0x00000004 */
 #define CAN_ESTS_BOF                        CAN_ESTS_BOF_Msk                        /*!< Bus-off flag */
 
-/*!< ETR congiguration */
+/*!< ETR configuration */
 #define CAN_ESTS_ETR_Pos                    (4U)
 #define CAN_ESTS_ETR_Msk                    (0x7U << CAN_ESTS_ETR_Pos)              /*!< 0x00000070 */
 #define CAN_ESTS_ETR                        CAN_ESTS_ETR_Msk                        /*!< ETR[2:0] bits (Error type record) */
@@ -7211,7 +7160,7 @@ typedef struct
 #define CAN_BTMG_BRDIV_Msk                  (0xFFFU << CAN_BTMG_BRDIV_Pos)          /*!< 0x00000FFF */
 #define CAN_BTMG_BRDIV                      CAN_BTMG_BRDIV_Msk                      /*!< Baud rate division */
 
-/*!< BTS1 congiguration */
+/*!< BTS1 configuration */
 #define CAN_BTMG_BTS1_Pos                   (16U)
 #define CAN_BTMG_BTS1_Msk                   (0xFU << CAN_BTMG_BTS1_Pos)             /*!< 0x000F0000 */
 #define CAN_BTMG_BTS1                       CAN_BTMG_BTS1_Msk                       /*!< BTS1[3:0] bits (Bit time segment 1) */
@@ -7220,7 +7169,7 @@ typedef struct
 #define CAN_BTMG_BTS1_2                     (0x4U << CAN_BTMG_BTS1_Pos)             /*!< 0x00040000 */
 #define CAN_BTMG_BTS1_3                     (0x8U << CAN_BTMG_BTS1_Pos)             /*!< 0x00080000 */
 
-/*!< BTS2 congiguration */
+/*!< BTS2 configuration */
 #define CAN_BTMG_BTS2_Pos                   (20U)
 #define CAN_BTMG_BTS2_Msk                   (0x7U << CAN_BTMG_BTS2_Pos)             /*!< 0x00700000 */
 #define CAN_BTMG_BTS2                       CAN_BTMG_BTS2_Msk                       /*!< BTS2[2:0] bits (Bit time segment 2) */
@@ -7228,7 +7177,7 @@ typedef struct
 #define CAN_BTMG_BTS2_1                     (0x2U << CAN_BTMG_BTS2_Pos)             /*!< 0x00200000 */
 #define CAN_BTMG_BTS2_2                     (0x4U << CAN_BTMG_BTS2_Pos)             /*!< 0x00400000 */
 
-/*!< RSAW congiguration */
+/*!< RSAW configuration */
 #define CAN_BTMG_RSAW_Pos                   (24U)
 #define CAN_BTMG_RSAW_Msk                   (0x3U << CAN_BTMG_RSAW_Pos)             /*!< 0x03000000 */
 #define CAN_BTMG_RSAW                       CAN_BTMG_RSAW_Msk                       /*!< RSAW[1:0] bits (Resynchronization width) */
@@ -10689,7 +10638,7 @@ typedef struct
 #define QSPI_CMD_W0_SPIADR                  QSPI_CMD_W0_SPIADR_Msk                  /*!< SPI Flash address */
 
 /*****************  Bit definition for QSPI_CMD_W1 register  ******************/
-/*!< ADRLEN congiguration */
+/*!< ADRLEN configuration */
 #define QSPI_CMD_W1_ADRLEN_Pos              (0U)
 #define QSPI_CMD_W1_ADRLEN_Msk              (0x7U << QSPI_CMD_W1_ADRLEN_Pos)        /*!< 0x00000007 */
 #define QSPI_CMD_W1_ADRLEN                  QSPI_CMD_W1_ADRLEN_Msk                  /*!< ADRLEN[2:0] bits (SPI address length) */
@@ -10703,7 +10652,7 @@ typedef struct
 #define QSPI_CMD_W1_ADRLEN_3BYTE            0x00000003U                             /*!< 3-byte address */
 #define QSPI_CMD_W1_ADRLEN_4BYTE            0x00000004U                             /*!< 4-byte address */
 
-/*!< DUM2 congiguration */
+/*!< DUM2 configuration */
 #define QSPI_CMD_W1_DUM2_Pos                (16U)
 #define QSPI_CMD_W1_DUM2_Msk                (0xFFU << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00FF0000 */
 #define QSPI_CMD_W1_DUM2                    QSPI_CMD_W1_DUM2_Msk                    /*!< DUM2[7:0] bits (Second dummy state cycle) */
@@ -10716,7 +10665,7 @@ typedef struct
 #define QSPI_CMD_W1_DUM2_6                  (0x40U << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00400000 */
 #define QSPI_CMD_W1_DUM2_7                  (0x80U << QSPI_CMD_W1_DUM2_Pos)         /*!< 0x00800000 */
 
-/*!< INSLEN congiguration */
+/*!< INSLEN configuration */
 #define QSPI_CMD_W1_INSLEN_Pos              (24U)
 #define QSPI_CMD_W1_INSLEN_Msk              (0x3U << QSPI_CMD_W1_INSLEN_Pos)        /*!< 0x03000000 */
 #define QSPI_CMD_W1_INSLEN                  QSPI_CMD_W1_INSLEN_Msk                  /*!< INSLEN[1:0] bits (Instruction code length) */
@@ -10747,7 +10696,7 @@ typedef struct
 #define QSPI_CMD_W3_RSTSC_Msk               (0x1U << QSPI_CMD_W3_RSTSC_Pos)         /*!< 0x00000008 */
 #define QSPI_CMD_W3_RSTSC                   QSPI_CMD_W3_RSTSC_Msk                   /*!< Read SPI status configuration */
 
-/*!< OPMODE congiguration */
+/*!< OPMODE configuration */
 #define QSPI_CMD_W3_OPMODE_Pos              (5U)
 #define QSPI_CMD_W3_OPMODE_Msk              (0x7U << QSPI_CMD_W3_OPMODE_Pos)        /*!< 0x000000E0 */
 #define QSPI_CMD_W3_OPMODE                  QSPI_CMD_W3_OPMODE_Msk                  /*!< OPMODE[2:0] bits (SPI Operation mode) */
@@ -10771,7 +10720,7 @@ typedef struct
 #define QSPI_CMD_W3_INSC                    QSPI_CMD_W3_INSC_Msk                    /*!< Instruction code */
 
 /******************  Bit definition for QSPI_CTRL register  *******************/
-/*!< CLKDIV congiguration */
+/*!< CLKDIV configuration */
 #define QSPI_CTRL_CLKDIV_Pos                (0U)
 #define QSPI_CTRL_CLKDIV_Msk                (0x7U << QSPI_CTRL_CLKDIV_Pos)          /*!< 0x00000007 */
 #define QSPI_CTRL_CLKDIV                    QSPI_CTRL_CLKDIV_Msk                    /*!< CLKDIV[2:0] bits (Clock divider) */
@@ -10798,7 +10747,7 @@ typedef struct
 #define QSPI_CTRL_ABORT_Msk                 (0x1U << QSPI_CTRL_ABORT_Pos)           /*!< 0x00000100 */
 #define QSPI_CTRL_ABORT                     QSPI_CTRL_ABORT_Msk                     /*!< Refresh all commands/FIFOs and reset state machine */
 
-/*!< BUSY congiguration */
+/*!< BUSY configuration */
 #define QSPI_CTRL_BUSY_Pos                  (16U)
 #define QSPI_CTRL_BUSY_Msk                  (0x7U << QSPI_CTRL_BUSY_Pos)            /*!< 0x00070000 */
 #define QSPI_CTRL_BUSY                      QSPI_CTRL_BUSY_Msk                      /*!< BUSY[2:0] bits (Busy bit of SPI status) */
@@ -10841,7 +10790,7 @@ typedef struct
 #define QSPI_CTRL2_CMDIE_Msk                (0x1U << QSPI_CTRL2_CMDIE_Pos)          /*!< 0x00000002 */
 #define QSPI_CTRL2_CMDIE                    QSPI_CTRL2_CMDIE_Msk                    /*!< Command complete Interrupt enable */
 
-/*!< TXFIFO_THOD congiguration */
+/*!< TXFIFO_THOD configuration */
 #define QSPI_CTRL2_TXFIFO_THOD_Pos          (8U)
 #define QSPI_CTRL2_TXFIFO_THOD_Msk          (0x3U << QSPI_CTRL2_TXFIFO_THOD_Pos)    /*!< 0x00000300 */
 #define QSPI_CTRL2_TXFIFO_THOD              QSPI_CTRL2_TXFIFO_THOD_Msk              /*!< TXFIFO_THOD[1:0] bits (Program the level value to trigger TX FIFO threshold IRQ) */
@@ -10852,7 +10801,7 @@ typedef struct
 #define QSPI_CTRL2_TXFIFO_THOD_16WORD       0x00000100U                             /*!< 16 WORD */
 #define QSPI_CTRL2_TXFIFO_THOD_24WORD       0x00000200U                             /*!< 24 WORD */
 
-/*!< RXFIFO_THOD congiguration */
+/*!< RXFIFO_THOD configuration */
 #define QSPI_CTRL2_RXFIFO_THOD_Pos          (12U)
 #define QSPI_CTRL2_RXFIFO_THOD_Msk          (0x3U << QSPI_CTRL2_RXFIFO_THOD_Pos)    /*!< 0x00003000 */
 #define QSPI_CTRL2_RXFIFO_THOD              QSPI_CTRL2_RXFIFO_THOD_Msk              /*!< RXFIFO_THOD[1:0] bits (Program the level value to trigger RX FIFO threshold IRQ) */
@@ -10879,7 +10828,7 @@ typedef struct
 #define QSPI_FSIZE_SPIFSIZE                 QSPI_FSIZE_SPIFSIZE_Msk                 /*!< SPI flash size */
 
 /***************  Bit definition for QSPI_XIP_CMD_W0 register  ****************/
-/*!< XIPR_DUM2 congiguration */
+/*!< XIPR_DUM2 configuration */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_Pos       (0U)
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_Msk       (0xFFU << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x000000FF */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2           QSPI_XIP_CMD_W0_XIPR_DUM2_Msk            /*!< XIPR_DUM2[7:0] bits (XIP read second dummy cycle) */
@@ -10892,7 +10841,7 @@ typedef struct
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_6         (0x40U << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x00000040 */
 #define QSPI_XIP_CMD_W0_XIPR_DUM2_7         (0x80U << QSPI_XIP_CMD_W0_XIPR_DUM2_Pos) /*!< 0x00000080 */
 
-/*!< XIPR_OPMODE congiguration */
+/*!< XIPR_OPMODE configuration */
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE_Pos     (8U)                                      /*!< 0x00000700 */
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE_Msk     (0x7U << QSPI_XIP_CMD_W0_XIPR_OPMODE_Pos)
 #define QSPI_XIP_CMD_W0_XIPR_OPMODE         QSPI_XIP_CMD_W0_XIPR_OPMODE_Msk           /*!< XIPR_OPMODE[2:0] bits (XIP read operation mode) */
@@ -10916,7 +10865,7 @@ typedef struct
 #define QSPI_XIP_CMD_W0_XIPR_INSC           QSPI_XIP_CMD_W0_XIPR_INSC_Msk           /*!< XIP read instruction code */
 
 /***************  Bit definition for QSPI_XIP_CMD_W1 register  ****************/
-/*!< XIPW_DUM2 congiguration */
+/*!< XIPW_DUM2 configuration */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_Pos       (0U)
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_Msk       (0xFFU << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x000000FF */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2           QSPI_XIP_CMD_W1_XIPW_DUM2_Msk            /*!< XIPW_DUM2[7:0] bits (XIP write second dummy cycle) */
@@ -10929,7 +10878,7 @@ typedef struct
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_6         (0x40U << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x00000040 */
 #define QSPI_XIP_CMD_W1_XIPW_DUM2_7         (0x80U << QSPI_XIP_CMD_W1_XIPW_DUM2_Pos) /*!< 0x00000080 */
 
-/*!< XIPW_OPMODE congiguration */
+/*!< XIPW_OPMODE configuration */
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE_Pos     (8U)                                      /*!< 0x00000700 */
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE_Msk     (0x7U << QSPI_XIP_CMD_W1_XIPW_OPMODE_Pos)
 #define QSPI_XIP_CMD_W1_XIPW_OPMODE         QSPI_XIP_CMD_W1_XIPW_OPMODE_Msk           /*!< XIPW_OPMODE[2:0] bits (XIP write operation mode) */
@@ -11002,7 +10951,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for DEBUG_IDCODE register  *****************/
-/*!< PID congiguration */
+/*!< PID configuration */
 #define DEBUG_IDCODE_PID_Pos                (0U)
 #define DEBUG_IDCODE_PID_Msk                (0xFFFFFFFFU << DEBUG_IDCODE_PID_Pos)   /*!< 0xFFFFFFFF */
 #define DEBUG_IDCODE_PID                    DEBUG_IDCODE_PID_Msk                    /*!< PID[31:0] bits (PID information) */
@@ -11109,7 +11058,7 @@ typedef struct
 #define DEBUG_APB2_PAUSE_TMR11_PAUSE        DEBUG_APB2_PAUSE_TMR11_PAUSE_Msk        /*!< TMR11 pause control bit */
 
 /*****************  Bit definition for DEBUG_SER_ID register  *****************/
-/*!< REV_ID congiguration */
+/*!< REV_ID configuration */
 #define DEBUG_SER_ID_REV_ID_Pos             (0U)
 #define DEBUG_SER_ID_REV_ID_Msk             (0x7U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000007 */
 #define DEBUG_SER_ID_REV_ID                 DEBUG_SER_ID_REV_ID_Msk                 /*!< REV_ID[2:0] bits (Revision ID) */
@@ -11117,7 +11066,7 @@ typedef struct
 #define DEBUG_SER_ID_REV_ID_1               (0x2U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000002 */
 #define DEBUG_SER_ID_REV_ID_2               (0x4U << DEBUG_SER_ID_REV_ID_Pos)       /*!< 0x00000004 */
 
-/*!< SER_ID congiguration */
+/*!< SER_ID configuration */
 #define DEBUG_SER_ID_SER_ID_Pos             (8U)
 #define DEBUG_SER_ID_SER_ID_Msk             (0xFFU << DEBUG_SER_ID_SER_ID_Pos)      /*!< 0x0000FF00 */
 #define DEBUG_SER_ID_SER_ID                 DEBUG_SER_ID_SER_ID_Msk                 /*!< SER_ID[7:0] bits (Serial ID) */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415cx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415cx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f415cx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian
-  * @version v2.1.6
-  * @date    13-Dec-2024
+  * @version v2.1.8
+  * @date    24-Nov-2025
   * @brief   AT32F415Cx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.6
+  * @brief CMSIS Device version number V2.1.8
   */
 #define __AT32F415_LIBRARY_VERSION_MAJOR   (0x02) /*!< [31:24] major version */
 #define __AT32F415_LIBRARY_VERSION_MIDDLE  (0x01) /*!< [23:16] middle version */
-#define __AT32F415_LIBRARY_VERSION_MINOR   (0x06) /*!< [15:8]  minor version */
+#define __AT32F415_LIBRARY_VERSION_MINOR   (0x08) /*!< [15:8]  minor version */
 #define __AT32F415_LIBRARY_VERSION_RC      (0x00) /*!< [7:0]   release candidate */
 #define __AT32F415_LIBRARY_VERSION         ((__AT32F415_LIBRARY_VERSION_MAJOR  << 24)\
                                            |(__AT32F415_LIBRARY_VERSION_MIDDLE << 16)\
@@ -99,7 +99,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                   */
 
 /******  AT32 specific Interrupt Numbers **********************************************************/
-  WWDT_IRQn                   = 0,      /*!< Window WatchDog Timer Interrupt                      */
+  WWDT_IRQn                   = 0,      /*!< Window WATCHDOG Timer Interrupt                      */
   PVM_IRQn                    = 1,      /*!< PVM Interrupt linked to EXINT16                      */
   TAMPER_IRQn                 = 2,      /*!< Tamper Interrupt linked to EXINT21                   */
   ERTC_WKUP_IRQn              = 3,      /*!< ERTC Wake Up Interrupt linked to EXINT22             */
@@ -243,8 +243,8 @@ typedef struct
   __IO uint32_t ESTS;                                /*!< CAN error status register,                   Address offset: 0x018         */
   __IO uint32_t BTMG;                                /*!< CAN bit timing register,                     Address offset: 0x01C         */
   uint32_t      RESERVED0[88];                       /*!< Reserved,                                    Address offset: 0x020 ~ 0x17C */
-  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX Mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
-  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO Mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
+  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
+  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
   uint32_t      RESERVED1[12];                       /*!< Reserved,                                    Address offset: 0x1D0 ~ 0x1FC */
   __IO uint32_t FCTRL;                               /*!< CAN filter control register,                 Address offset: 0x200         */
   __IO uint32_t FMCFG;                               /*!< CAN filter mode configuration register,      Address offset: 0x204         */
@@ -274,12 +274,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t DT;          /*!< CRC Data register,                           Address offset: 0x00 */
-  __IO uint32_t CDT;         /*!< CRC Common data register,                    Address offset: 0x04 */
-  __IO uint32_t CTRL;        /*!< CRC Control register,                        Address offset: 0x08 */
+  __IO uint32_t DT;          /*!< CRC data register,                           Address offset: 0x00 */
+  __IO uint32_t CDT;         /*!< CRC common data register,                    Address offset: 0x04 */
+  __IO uint32_t CTRL;        /*!< CRC control register,                        Address offset: 0x08 */
   uint32_t      RESERVED;    /*!< Reserved,                                    Address offset: 0x0C */
-  __IO uint32_t IDT;         /*!< CRC Initialization register,                 Address offset: 0x10 */
-  __IO uint32_t POLY;        /*!< CRC Polynomial register,                     Address offset: 0x14 */
+  __IO uint32_t IDT;         /*!< CRC initialization register,                 Address offset: 0x10 */
+  __IO uint32_t POLY;        /*!< CRC polynomial register,                     Address offset: 0x14 */
 } CRC_TypeDef;
 
 /**
@@ -288,23 +288,23 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;            /*!< CRM Clock control register,                  Address offset: 0x00        */
-  __IO uint32_t CFG;             /*!< CRM Clock configuration register,            Address offset: 0x04        */
-  __IO uint32_t CLKINT;          /*!< CRM Clock interrupt register,                Address offset: 0x08        */
+  __IO uint32_t CTRL;            /*!< CRM clock control register,                  Address offset: 0x00        */
+  __IO uint32_t CFG;             /*!< CRM clock configuration register,            Address offset: 0x04        */
+  __IO uint32_t CLKINT;          /*!< CRM clock interrupt register,                Address offset: 0x08        */
   __IO uint32_t APB2RST;         /*!< CRM APB2 peripheral reset register,          Address offset: 0x0C        */
   __IO uint32_t APB1RST;         /*!< CRM APB1 peripheral reset register,          Address offset: 0x10        */
-  __IO uint32_t AHBEN;           /*!< CRM APB peripheral clock enable register,    Address offset: 0x14        */
+  __IO uint32_t AHBEN;           /*!< CRM AHB peripheral clock enable register,    Address offset: 0x14        */
   __IO uint32_t APB2EN;          /*!< CRM APB2 peripheral clock enable register,   Address offset: 0x18        */
   __IO uint32_t APB1EN;          /*!< CRM APB1 peripheral clock enable register,   Address offset: 0x1C        */
-  __IO uint32_t BPDC;            /*!< CRM Battery powered domain control register, Address offset: 0x20        */
-  __IO uint32_t CTRLSTS;         /*!< CRM Control/status register,                 Address offset: 0x24        */
-  __IO uint32_t AHBRST;          /*!< CRM APB peripheral reset register,           Address offset: 0x28        */
+  __IO uint32_t BPDC;            /*!< CRM battery powered domain control register, Address offset: 0x20        */
+  __IO uint32_t CTRLSTS;         /*!< CRM control/status register,                 Address offset: 0x24        */
+  __IO uint32_t AHBRST;          /*!< CRM AHB peripheral reset register,           Address offset: 0x28        */
   __IO uint32_t PLL;             /*!< CRM PLL configuration register,              Address offset: 0x2C        */
-  __IO uint32_t MISC1;           /*!< CRM Additional register 1,                   Address offset: 0x30        */
+  __IO uint32_t MISC1;           /*!< CRM additional register 1,                   Address offset: 0x30        */
   uint32_t      RESERVED0[4];    /*!< Reserved,                                    Address offset: 0x34 ~ 0x40 */
   __IO uint32_t OTG_EXTCTRL;     /*!< CRM OTG_FS extended control register,        Address offset: 0x44        */
   uint32_t      RESERVED1[3];    /*!< Reserved,                                    Address offset: 0x48 - 0x50 */
-  __IO uint32_t MISC2;           /*!< CRM Additional register 2,                   Address offset: 0x54        */
+  __IO uint32_t MISC2;           /*!< CRM additional register 2,                   Address offset: 0x54        */
 } CRM_TypeDef;
 
 /**
@@ -334,8 +334,8 @@ typedef struct
   __IO uint32_t STS;             /*!< DMA interrupt status register,               Address offset: 0x00        */
   __IO uint32_t CLR;             /*!< DMA interrupt flag clear register,           Address offset: 0x04        */
   uint32_t      RESERVED[38];    /*!< Reserved,                                    Address offset: 0x08 ~ 0x9C */
-  __IO uint32_t SRC_SEL0;        /*!< DMA Channel source register 0,               Address offset: 0xA0        */
-  __IO uint32_t SRC_SEL1;        /*!< DMA Channel source register 1,               Address offset: 0xA4        */
+  __IO uint32_t SRC_SEL0;        /*!< DMA channel source register 0,               Address offset: 0xA0        */
+  __IO uint32_t SRC_SEL1;        /*!< DMA channel source register 1,               Address offset: 0xA4        */
 } DMA_TypeDef;
 
 /**
@@ -392,12 +392,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t INTEN;      /*!< EXINT Interrupt enable register,             Address offset: 0x00 */
-  __IO uint32_t EVTEN;      /*!< EXINT Event enable register,                 Address offset: 0x04 */
-  __IO uint32_t POLCFG1;    /*!< EXINT Polarity configuration register 1,     Address offset: 0x08 */
-  __IO uint32_t POLCFG2;    /*!< EXINT Polarity configuration register 2,     Address offset: 0x0C */
-  __IO uint32_t SWTRG;      /*!< EXINT Software trigger register,             Address offset: 0x10 */
-  __IO uint32_t INTSTS;     /*!< EXINT Interrupt status register,             Address offset: 0x14 */
+  __IO uint32_t INTEN;      /*!< EXINT interrupt enable register,             Address offset: 0x00 */
+  __IO uint32_t EVTEN;      /*!< EXINT event enable register,                 Address offset: 0x04 */
+  __IO uint32_t POLCFG1;    /*!< EXINT polarity configuration register 1,     Address offset: 0x08 */
+  __IO uint32_t POLCFG2;    /*!< EXINT polarity configuration register 2,     Address offset: 0x0C */
+  __IO uint32_t SWTRG;      /*!< EXINT software trigger register,             Address offset: 0x10 */
+  __IO uint32_t INTSTS;     /*!< EXINT interrupt status register,             Address offset: 0x14 */
 } EXINT_TypeDef;
 
 /**
@@ -413,7 +413,7 @@ typedef struct
   __IO uint32_t CTRL;              /*!< FLASH control register,                      Address offset: 0x10         */
   __IO uint32_t ADDR;              /*!< FLASH address register,                      Address offset: 0x14         */
   uint32_t      RESERVED0;         /*!< Reserved,                                    Address offset: 0x18         */
-  __IO uint32_t USD;               /*!< FLASH user system data register,             Address offset: 0x1C         */
+  __IO uint32_t FUSD;              /*!< FLASH user system data register,             Address offset: 0x1C         */
   __IO uint32_t EPPS;              /*!< FLASH erase/program protection status reg,   Address offset: 0x20         */
   uint32_t      RESERVED1[20];     /*!< Reserved,                                    Address offset: 0x24 ~ 0x70  */
   __IO uint32_t SLIB_STS0;         /*!< FLASH security library status register 0,    Address offset: 0x74         */
@@ -437,15 +437,15 @@ typedef struct
 
 typedef struct
 {
-  __IO uint16_t FAP;               /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
-  __IO uint16_t SSB;               /*!< USD System configuration byte,               Address offset: 0x1FFF_F802               */
-  __IO uint16_t DATA0;             /*!< USD User data 0,                             Address offset: 0x1FFF_F804               */
-  __IO uint16_t DATA1;             /*!< USD User data 1,                             Address offset: 0x1FFF_F806               */
-  __IO uint16_t EPP0;              /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
-  __IO uint16_t EPP1;              /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
-  __IO uint16_t EPP2;              /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
-  __IO uint16_t EPP3;              /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
-  __IO uint16_t DATA[504];         /*!< USD User data 2 ~ 505,                       Address offset: 0x1FFF_F810 ~ 0x1FFF_FBFC */
+  __IO uint16_t FAP;          /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
+  __IO uint16_t SSB;          /*!< USD system configuration byte,               Address offset: 0x1FFF_F802               */
+  __IO uint16_t DATA0;        /*!< USD user data 0,                             Address offset: 0x1FFF_F804               */
+  __IO uint16_t DATA1;        /*!< USD user data 1,                             Address offset: 0x1FFF_F806               */
+  __IO uint16_t EPP0;         /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
+  __IO uint16_t EPP1;         /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
+  __IO uint16_t EPP2;         /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
+  __IO uint16_t EPP3;         /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
+  __IO uint16_t DATA[504];    /*!< USD user data 2 ~ 505,                       Address offset: 0x1FFF_F810 ~ 0x1FFF_FBFC */
 } USD_TypeDef;
 
 /**
@@ -469,7 +469,7 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t EVTOUT;       /*!< IOMUX Event output control register,         Address offset: 0x00        */
+  __IO uint32_t EVTOUT;       /*!< IOMUX event output control register,         Address offset: 0x00        */
   __IO uint32_t REMAP;        /*!< IOMUX remap register 1,                      Address offset: 0x04        */
   __IO uint32_t EXINTC[4];    /*!< IOMUX external interrupt config register x,  Address offset: 0x08 ~ 0x14 */
   uint32_t      RESERVED;     /*!< Reserved,                                    Address offset: 0x18        */
@@ -488,14 +488,14 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL1;      /*!< I2C Control register 1,                      Address offset: 0x00 */
-  __IO uint32_t CTRL2;      /*!< I2C Control register 2,                      Address offset: 0x04 */
-  __IO uint32_t OADDR1;     /*!< I2C Own address register 1,                  Address offset: 0x08 */
-  __IO uint32_t OADDR2;     /*!< I2C Own address register 2,                  Address offset: 0x0C */
-  __IO uint32_t DT;         /*!< I2C Data register,                           Address offset: 0x10 */
-  __IO uint32_t STS1;       /*!< I2C Status register 1,                       Address offset: 0x14 */
-  __IO uint32_t STS2;       /*!< I2C Status register 2,                       Address offset: 0x18 */
-  __IO uint32_t CLKCTRL;    /*!< I2C Clock control register,                  Address offset: 0x1C */
+  __IO uint32_t CTRL1;      /*!< I2C control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CTRL2;      /*!< I2C control register 2,                      Address offset: 0x04 */
+  __IO uint32_t OADDR1;     /*!< I2C own address register 1,                  Address offset: 0x08 */
+  __IO uint32_t OADDR2;     /*!< I2C own address register 2,                  Address offset: 0x0C */
+  __IO uint32_t DT;         /*!< I2C data register,                           Address offset: 0x10 */
+  __IO uint32_t STS1;       /*!< I2C status register 1,                       Address offset: 0x14 */
+  __IO uint32_t STS2;       /*!< I2C status register 2,                       Address offset: 0x18 */
+  __IO uint32_t CLKCTRL;    /*!< I2C clock control register,                  Address offset: 0x1C */
   __IO uint32_t TMRISE;     /*!< I2C timer rise time register,                Address offset: 0x20 */
 } I2C_TypeDef;
 
@@ -505,8 +505,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;       /*!< PWC Power control register,                  Address offset: 0x00 */
-  __IO uint32_t CTRLSTS;    /*!< PWC Power control/status register,           Address offset: 0x04 */
+  __IO uint32_t CTRL;       /*!< PWC power control register,                  Address offset: 0x00 */
+  __IO uint32_t CTRLSTS;    /*!< PWC power control/status register,           Address offset: 0x04 */
 } PWC_TypeDef;
 
 /**
@@ -577,7 +577,7 @@ typedef struct
   __IO uint32_t C2DT;       /*!< TMR channel 2 data register,                 Address offset: 0x38 */
   __IO uint32_t C3DT;       /*!< TMR channel 3 data register,                 Address offset: 0x3C */
   __IO uint32_t C4DT;       /*!< TMR channel 4 data register,                 Address offset: 0x40 */
-  __IO uint32_t BRK;        /*!< TMR break register,                          Address offset: 0x44 */
+  __IO uint32_t BRK;        /*!< TMR brake register,                          Address offset: 0x44 */
   __IO uint32_t DMACTRL;    /*!< TMR DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMADT;      /*!< TMR DMA data register,                       Address offset: 0x4C */
 } TMR_TypeDef;
@@ -603,10 +603,10 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD;    /*!< WDT Command register,                        Address offset: 0x00 */
-  __IO uint32_t DIV;    /*!< WDT Divider register,                        Address offset: 0x04 */
-  __IO uint32_t RLD;    /*!< WDT Reload register,                         Address offset: 0x08 */
-  __IO uint32_t STS;    /*!< WDT Status register,                         Address offset: 0x0C */
+  __IO uint32_t CMD;    /*!< WDT command register,                        Address offset: 0x00 */
+  __IO uint32_t DIV;    /*!< WDT divider register,                        Address offset: 0x04 */
+  __IO uint32_t RLD;    /*!< WDT reload register,                         Address offset: 0x08 */
+  __IO uint32_t STS;    /*!< WDT status register,                         Address offset: 0x0C */
 } WDT_TypeDef;
 
 /**
@@ -615,9 +615,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;    /*!< WWDT Control register,                       Address offset: 0x00 */
-  __IO uint32_t CFG;     /*!< WWDT Configuration register,                 Address offset: 0x04 */
-  __IO uint32_t STS;     /*!< WWDT Status register,                        Address offset: 0x08 */
+  __IO uint32_t CTRL;    /*!< WWDT control register,                       Address offset: 0x00 */
+  __IO uint32_t CFG;     /*!< WWDT configuration register,                 Address offset: 0x04 */
+  __IO uint32_t STS;     /*!< WWDT status register,                        Address offset: 0x08 */
 } WWDT_TypeDef;
 
 /**
@@ -682,6 +682,7 @@ typedef struct
 #define DMA1_Channel5_BASE           (AHBPERIPH_BASE + 0x00000058U)  /*!< DMA1 Channel 5 base address                    */
 #define DMA1_Channel6_BASE           (AHBPERIPH_BASE + 0x0000006CU)  /*!< DMA1 Channel 6 base address                    */
 #define DMA1_Channel7_BASE           (AHBPERIPH_BASE + 0x00000080U)  /*!< DMA1 Channel 7 base address                    */
+
 #define DMA2_BASE                    (AHBPERIPH_BASE + 0x00000400U)  /*!< DMA2 base address                              */
 #define DMA2_Channel1_BASE           (AHBPERIPH_BASE + 0x00000408U)  /*!< DMA2 Channel 1 base address                    */
 #define DMA2_Channel2_BASE           (AHBPERIPH_BASE + 0x0000041CU)  /*!< DMA2 Channel 2 base address                    */
@@ -690,6 +691,7 @@ typedef struct
 #define DMA2_Channel5_BASE           (AHBPERIPH_BASE + 0x00000458U)  /*!< DMA2 Channel 5 base address                    */
 #define DMA2_Channel6_BASE           (AHBPERIPH_BASE + 0x0000046CU)  /*!< DMA2 Channel 6 base address                    */
 #define DMA2_Channel7_BASE           (AHBPERIPH_BASE + 0x00000480U)  /*!< DMA2 Channel 7 base address                    */
+
 #define CRM_BASE                     (AHBPERIPH_BASE + 0x00001000U)  /*!< CRM base address                               */
 #define CRC_BASE                     (AHBPERIPH_BASE + 0x00003000U)  /*!< CRC base address                               */
 
@@ -794,7 +796,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Power Control (PWC)                            */
+/*                             Power control (PWC)                            */
 /*                                                                            */
 /******************************************************************************/
 
@@ -967,7 +969,7 @@ typedef struct
 #define CRM_CFG_APB2DIV_DIV16               0x00003800U                             /*!< HCLK is divided by 16 */
 
 /*!< ADCDIV configuration */
-#define CRM_CFG_ADCDIV_Msk                  ((0x3U << 14) | (0x1U << 28))           /*!< 0x0100C000 */
+#define CRM_CFG_ADCDIV_Msk                  ((0x3U << 14) | (0x1U << 28))           /*!< 0x1000C000 */
 #define CRM_CFG_ADCDIV                      CRM_CFG_ADCDIV_Msk                      /*!< ADCDIV[2:0] bits (ADC division) */
 #define CRM_CFG_ADCDIV_0                    (0x1U << 14)                            /*!< 0x00004000 */
 #define CRM_CFG_ADCDIV_1                    (0x2U << 14)                            /*!< 0x00008000 */
@@ -977,8 +979,8 @@ typedef struct
 #define CRM_CFG_ADCDIV_DIV4                 0x00004000U                             /*!< PCLK/4 */
 #define CRM_CFG_ADCDIV_DIV6                 0x00008000U                             /*!< PCLK/6 */
 #define CRM_CFG_ADCDIV_DIV8                 0x0000C000U                             /*!< PCLK/8 */
-#define CRM_CFG_ADCDIV_DIV12                0x10004000U                             /*!< PCLK2/12 */
-#define CRM_CFG_ADCDIV_DIV16                0x1000C000U                             /*!< PCLK2/16 */
+#define CRM_CFG_ADCDIV_DIV12                0x10004000U                             /*!< PCLK/12 */
+#define CRM_CFG_ADCDIV_DIV16                0x1000C000U                             /*!< PCLK/16 */
 
 #define CRM_CFG_PLLRCS_Pos                  (16U)
 #define CRM_CFG_PLLRCS_Msk                  (0x1U << CRM_CFG_PLLRCS_Pos)            /*!< 0x00010000 */
@@ -1140,7 +1142,7 @@ typedef struct
 #define CRM_MISC1_CLKSEL_USB                CRM_MISC1_CLKOUT_SEL_USB
 #define CRM_MISC1_CLKSEL_ADC                CRM_MISC1_CLKOUT_SEL_ADC
 
-/*!<***************  Bit definition for CRM_CLKINT register  ******************/
+/******************  Bit definition for CRM_CLKINT register  ******************/
 #define CRM_CLKINT_LICKSTBLF_Pos            (0U)
 #define CRM_CLKINT_LICKSTBLF_Msk            (0x1U << CRM_CLKINT_LICKSTBLF_Pos)      /*!< 0x00000001 */
 #define CRM_CLKINT_LICKSTBLF                CRM_CLKINT_LICKSTBLF_Msk                /*!< LICK stable interrupt flag */
@@ -1394,7 +1396,7 @@ typedef struct
 #define CRM_BPDC_LEXTBYPS_Msk               (0x1U << CRM_BPDC_LEXTBYPS_Pos)         /*!< 0x00000004 */
 #define CRM_BPDC_LEXTBYPS                   CRM_BPDC_LEXTBYPS_Msk                   /*!< External low-speed crystal bypass */
 
-/*!< ERTCSEL congiguration */
+/*!< ERTCSEL configuration */
 #define CRM_BPDC_ERTCSEL_Pos                (8U)
 #define CRM_BPDC_ERTCSEL_Msk                (0x3U << CRM_BPDC_ERTCSEL_Pos)          /*!< 0x00000300 */
 #define CRM_BPDC_ERTCSEL                    CRM_BPDC_ERTCSEL_Msk                    /*!< ERTCSEL[1:0] bits (ERTC clock selection) */
@@ -1448,7 +1450,7 @@ typedef struct
 #define CRM_AHBRST_OTGFSRST                 CRM_AHBRST_OTGFSRST_Msk                 /*!< OTGFS reset */
 
 /*******************  Bit definition for CRM_PLL register  ********************/
-/*!< PLL_FR congiguration */
+/*!< PLL_FR configuration */
 #define CRM_PLL_PLL_FR_Pos                  (0U)
 #define CRM_PLL_PLL_FR_Msk                  (0x7U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000007 */
 #define CRM_PLL_PLL_FR                      CRM_PLL_PLL_FR_Msk                      /*!< PLL_FR[2:0] bits (PLL post-division factor) */
@@ -1456,7 +1458,7 @@ typedef struct
 #define CRM_PLL_PLL_FR_1                    (0x2U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000002 */
 #define CRM_PLL_PLL_FR_2                    (0x4U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000004 */
 
-/*!< PLL_MS congiguration */
+/*!< PLL_MS configuration */
 #define CRM_PLL_PLL_MS_Pos                  (4U)
 #define CRM_PLL_PLL_MS_Msk                  (0xFU << CRM_PLL_PLL_MS_Pos)            /*!< 0x000000F0 */
 #define CRM_PLL_PLL_MS                      CRM_PLL_PLL_MS_Msk                      /*!< PLL_MS[3:0] bits (PLL pre-division) */
@@ -1465,7 +1467,7 @@ typedef struct
 #define CRM_PLL_PLL_MS_2                    (0x4U << CRM_PLL_PLL_MS_Pos)            /*!< 0x00000040 */
 #define CRM_PLL_PLL_MS_3                    (0x8U << CRM_PLL_PLL_MS_Pos)            /*!< 0x00000080 */
 
-/*!< PLL_NS congiguration */
+/*!< PLL_NS configuration */
 #define CRM_PLL_PLL_NS_Pos                  (8U)
 #define CRM_PLL_PLL_NS_Msk                  (0x1FFU << CRM_PLL_PLL_NS_Pos)          /*!< 0x0001FF00 */
 #define CRM_PLL_PLL_NS                      CRM_PLL_PLL_NS_Msk                      /*!< PLL_NS[8:0] bits (PLL multiplication factor) */
@@ -1479,7 +1481,7 @@ typedef struct
 #define CRM_PLL_PLL_NS_7                    (0x080U << CRM_PLL_PLL_NS_Pos)          /*!< 0x00008000 */
 #define CRM_PLL_PLL_NS_8                    (0x100U << CRM_PLL_PLL_NS_Pos)          /*!< 0x00010000 */
 
-/*!< PLL_FREF congiguration */
+/*!< PLL_FREF configuration */
 #define CRM_PLL_PLL_FREF_Pos                (24U)
 #define CRM_PLL_PLL_FREF_Msk                (0x7U << CRM_PLL_PLL_FREF_Pos)          /*!< 0x07000000 */
 #define CRM_PLL_PLL_FREF                    CRM_PLL_PLL_FREF_Msk                    /*!< PLL_FREF[2:0] bits (PLL input clock selection) */
@@ -1512,7 +1514,7 @@ typedef struct
 #define CRM_MISC1_HICKDIV_Msk               (0x1U << CRM_MISC1_HICKDIV_Pos)         /*!< 0x02000000 */
 #define CRM_MISC1_HICKDIV                   CRM_MISC1_HICKDIV_Msk                   /*!< HICK 6 divider selection */
 
-/*!< CLKOUTDIV congiguration */
+/*!< CLKOUTDIV configuration */
 #define CRM_MISC1_CLKOUTDIV_Pos             (28U)
 #define CRM_MISC1_CLKOUTDIV_Msk             (0xFU << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0xF0000000 */
 #define CRM_MISC1_CLKOUTDIV                 CRM_MISC1_CLKOUTDIV_Msk                 /*!< CLKOUTDIV[3:0] bits (Clock output division) */
@@ -1521,7 +1523,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV_2               (0x4U << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0x40000000 */
 #define CRM_MISC1_CLKOUTDIV_3               (0x8U << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0x80000000 */
 
-#define CRM_MISC1_CLKOUTDIV_DIV1            0x00000000U                             /*!< No clock output */
+#define CRM_MISC1_CLKOUTDIV_DIV1            0x00000000U                             /*!< No clock output division */
 #define CRM_MISC1_CLKOUTDIV_DIV2            0x80000000U                             /*!< Clock output divided by 2 */
 #define CRM_MISC1_CLKOUTDIV_DIV4            0x90000000U                             /*!< Clock output divided by 4 */
 #define CRM_MISC1_CLKOUTDIV_DIV8            0xA0000000U                             /*!< Clock output divided by 8 */
@@ -1540,7 +1542,7 @@ typedef struct
 #define CRM_OTG_EXTCTRL_EP3_RMPEN           CRM_OTG_EXTCTRL_EP3_RMPEN_Msk           /*!< Endpoint 3 remap enable */
 
 /******************  Bit definition for CRM_MISC2 register  *******************/
-/*!< AUTO_STEP_EN congiguration */
+/*!< AUTO_STEP_EN configuration */
 #define CRM_MISC2_AUTO_STEP_EN_Pos          (4U)
 #define CRM_MISC2_AUTO_STEP_EN_Msk          (0x3U << CRM_MISC2_AUTO_STEP_EN_Pos)    /*!< 0x00000030 */
 #define CRM_MISC2_AUTO_STEP_EN              CRM_MISC2_AUTO_STEP_EN_Msk              /*!< AUTO_STEP_EN[1:0] bits (Auto step-by-step SCLK switch enable) */
@@ -1553,12 +1555,12 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                Flash and User System Data Registers (FLASH)                */
+/*                Flash and User System Data registers (FLASH)                */
 /*                                                                            */
 /******************************************************************************/
 
-/*******************  Bit definition for FLASH_PSR register  ******************/
-/*!< WTCYC congiguration */
+/******************  Bit definition for FLASH_PSR register  *******************/
+/*!< WTCYC configuration */
 #define FLASH_PSR_WTCYC_Pos                 (0U)
 #define FLASH_PSR_WTCYC_Msk                 (0x7U << FLASH_PSR_WTCYC_Pos)           /*!< 0x00000007 */
 #define FLASH_PSR_WTCYC                     FLASH_PSR_WTCYC_Msk                     /*!< WTCYC[2:0] bits (Wait cycle) */
@@ -1619,7 +1621,7 @@ typedef struct
 #define FLASH_CTRL_FPRGM                    FLASH_CTRL_FPRGM_Msk                    /*!< Flash program */
 #define FLASH_CTRL_SECERS_Pos               (1U)
 #define FLASH_CTRL_SECERS_Msk               (0x1U << FLASH_CTRL_SECERS_Pos)         /*!< 0x00000002 */
-#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Page erase */
+#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Sector erase */
 #define FLASH_CTRL_BANKERS_Pos              (2U)
 #define FLASH_CTRL_BANKERS_Msk              (0x1U << FLASH_CTRL_BANKERS_Pos)        /*!< 0x00000004 */
 #define FLASH_CTRL_BANKERS                  FLASH_CTRL_BANKERS_Msk                  /*!< Bank erase */
@@ -1661,7 +1663,7 @@ typedef struct
 #define FLASH_USD_FAP_Msk                   (0x1U << FLASH_USD_FAP_Pos)             /*!< 0x00000002 */
 #define FLASH_USD_FAP                       FLASH_USD_FAP_Msk                       /*!< Flash access protection */
 
-/*!< SSB congiguration */
+/*!< SSB configuration */
 #define FLASH_USD_WDT_ATO_EN_Pos            (2U)
 #define FLASH_USD_WDT_ATO_EN_Msk            (0x1U << FLASH_USD_WDT_ATO_EN_Pos)      /*!< 0x00000004 */
 #define FLASH_USD_WDT_ATO_EN                FLASH_USD_WDT_ATO_EN_Msk                /*!< nWDT_ATO_EN */
@@ -1690,7 +1692,7 @@ typedef struct
 #define FLASH_EPPS_EPPS_Msk                 (0xFFFFFFFFU << FLASH_EPPS_EPPS_Pos)    /*!< 0xFFFFFFFF */
 #define FLASH_EPPS_EPPS                     FLASH_EPPS_EPPS_Msk                     /*!< Erase/Program protection status */
 
-/*******************  Bit definition for SLIB_STS0 register *******************/
+/******************  Bit definition for SLIB_STS0 register  *******************/
 #define SLIB_STS0_BTM_AP_ENF_Pos            (0U)
 #define SLIB_STS0_BTM_AP_ENF_Msk            (0x1U << SLIB_STS0_BTM_AP_ENF_Pos)      /*!< 0x00000001 */
 #define SLIB_STS0_BTM_AP_ENF                SLIB_STS0_BTM_AP_ENF_Msk                /*!< Boot memory store application code enabled flag */
@@ -1702,25 +1704,25 @@ typedef struct
 #define SLIB_STS0_SLIB_ENF                  SLIB_STS0_SLIB_ENF_Msk                  /*!< Security library enable flag */
 #define SLIB_STS0_EM_SLIB_DAT_SS_Pos        (16U)
 #define SLIB_STS0_EM_SLIB_DAT_SS_Msk        (0xFFU << SLIB_STS0_EM_SLIB_DAT_SS_Pos) /*!< 0x00FF0000 */
-#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start page */
+#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start sector */
 
-/*******************  Bit definition for SLIB_STS1 register *******************/
+/******************  Bit definition for SLIB_STS1 register  *******************/
 #define SLIB_STS1_SLIB_SS_Pos               (0U)
 #define SLIB_STS1_SLIB_SS_Msk               (0x7FFU << SLIB_STS1_SLIB_SS_Pos)       /*!< 0x000007FF */
-#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start page */
+#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start sector */
 #define SLIB_STS1_SLIB_DAT_SS_Pos           (11U)
 #define SLIB_STS1_SLIB_DAT_SS_Msk           (0x7FFU << SLIB_STS1_SLIB_DAT_SS_Pos)   /*!< 0x003FF800 */
-#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start page */
+#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start sector */
 #define SLIB_STS1_SLIB_ES_Pos               (22U)
 #define SLIB_STS1_SLIB_ES_Msk               (0x3FFU << SLIB_STS1_SLIB_ES_Pos)       /*!< 0xFFC00000 */
-#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end page */
+#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end sector */
 
-/*****************  Bit definition for SLIB_PWD_CLR register ******************/
+/*****************  Bit definition for SLIB_PWD_CLR register  *****************/
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk      (0xFFFFFFFFU << SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos)
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL          SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk          /*!< Security library password clear value */
 
-/*****************  Bit definition for SLIB_MISC_STS register *****************/
+/****************  Bit definition for SLIB_MISC_STS register  *****************/
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Pos      (0U)                                    /*!< 0x00000001 */
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Msk      (0x1U << SLIB_MISC_STS_SLIB_PWD_ERR_Pos)
 #define SLIB_MISC_STS_SLIB_PWD_ERR          SLIB_MISC_STS_SLIB_PWD_ERR_Msk          /*!< Security library password error */
@@ -1731,54 +1733,54 @@ typedef struct
 #define SLIB_MISC_STS_SLIB_ULKF_Msk         (0x1U << SLIB_MISC_STS_SLIB_ULKF_Pos)   /*!< 0x00000004 */
 #define SLIB_MISC_STS_SLIB_ULKF             SLIB_MISC_STS_SLIB_ULKF_Msk             /*!< Security library unlock flag */
 
-/****************  Bit definition for FLASH_CRC_ADDR register *****************/
+/****************  Bit definition for FLASH_CRC_ADDR register  ****************/
 #define FLASH_CRC_ADDR_CRC_ADDR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_ADDR_CRC_ADDR_Msk         (0xFFFFFFFFU << FLASH_CRC_ADDR_CRC_ADDR_Pos)
 #define FLASH_CRC_ADDR_CRC_ADDR             FLASH_CRC_ADDR_CRC_ADDR_Msk             /*!< CRC address */
 
-/****************  Bit definition for FLASH_CRC_CTRL register *****************/
+/****************  Bit definition for FLASH_CRC_CTRL register  ****************/
 #define FLASH_CRC_CTRL_CRC_SN_Pos           (0U)
 #define FLASH_CRC_CTRL_CRC_SN_Msk           (0xFFFFU << FLASH_CRC_CTRL_CRC_SN_Pos)  /*!< 0x0000FFFF */
-#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC page number */
+#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC sector number */
 #define FLASH_CRC_CTRL_CRC_STRT_Pos         (16U)
 #define FLASH_CRC_CTRL_CRC_STRT_Msk         (0x1U << FLASH_CRC_CTRL_CRC_STRT_Pos)   /*!< 0x00010000 */
 #define FLASH_CRC_CTRL_CRC_STRT             FLASH_CRC_CTRL_CRC_STRT_Msk             /*!< CRC start */
 
-/****************  Bit definition for FLASH_CRC_CHKR register *****************/
+/****************  Bit definition for FLASH_CRC_CHKR register  ****************/
 #define FLASH_CRC_CHKR_CRC_CHKR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_CHKR_CRC_CHKR_Msk         (0xFFFFFFFFU << FLASH_CRC_CHKR_CRC_CHKR_Pos)
 #define FLASH_CRC_CHKR_CRC_CHKR             FLASH_CRC_CHKR_CRC_CHKR_Msk             /*!< CRC check result */
 
-/*****************  Bit definition for SLIB_SET_PWD register ******************/
+/*****************  Bit definition for SLIB_SET_PWD register  *****************/
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Msk      (0xFFFFFFFFU << SLIB_SET_PWD_SLIB_PSET_VAL_Pos)
 #define SLIB_SET_PWD_SLIB_PSET_VAL          SLIB_SET_PWD_SLIB_PSET_VAL_Msk          /*!< Security library password setting value */
 
-/****************  Bit definition for SLIB_SET_RANGE register *****************/
+/****************  Bit definition for SLIB_SET_RANGE register  ****************/
 #define SLIB_SET_RANGE_SLIB_SS_SET_Pos      (0U)                                    /*!< 0x000007FF */
 #define SLIB_SET_RANGE_SLIB_SS_SET_Msk      (0x7FFU << SLIB_SET_RANGE_SLIB_SS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start page setting */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Msk     (0x3FF8U << SLIB_SET_RANGE_SLIB_ISS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ISS_SET         SLIB_SET_RANGE_SLIB_ISS_SET_Msk         /*!< Security library instruction start page setting */
+#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start sector setting */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_DSS_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_DSS_SET         SLIB_SET_RANGE_SLIB_DSS_SET_Msk         /*!< Security library data start sector setting */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Pos      (22U)                                   /*!< 0xFFC00000 */
-#define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0xFFCU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end page setting */
+#define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0x3FFU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end sector setting */
 
-/******************  Bit definition for EM_SLIB_SET register ******************/
+/*****************  Bit definition for EM_SLIB_SET register  ******************/
 #define EM_SLIB_SET_EM_SLIB_SET_Pos         (0U)                                    /*!< 0x0000FFFF */
 #define EM_SLIB_SET_EM_SLIB_SET_Msk         (0xFFFFU << EM_SLIB_SET_EM_SLIB_SET_Pos)
 #define EM_SLIB_SET_EM_SLIB_SET             EM_SLIB_SET_EM_SLIB_SET_Msk             /*!< Extension memory sLib setting */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_ISS_SET_Pos)
-#define EM_SLIB_SET_EM_SLIB_ISS_SET         EM_SLIB_SET_EM_SLIB_ISS_SET_Msk         /*!< Extension memory sLib instruction start page setting */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_DSS_SET_Pos)
+#define EM_SLIB_SET_EM_SLIB_DSS_SET         EM_SLIB_SET_EM_SLIB_DSS_SET_Msk         /*!< Extension memory sLib data start sector setting */
 
-/*****************  Bit definition for BTM_MODE_SET register ******************/
+/*****************  Bit definition for BTM_MODE_SET register  *****************/
 #define BTM_MODE_SET_BTM_MODE_SET_Pos       (0U)                                    /*!< 0x000000FF */
 #define BTM_MODE_SET_BTM_MODE_SET_Msk       (0xFFU << BTM_MODE_SET_BTM_MODE_SET_Pos)
 #define BTM_MODE_SET_BTM_MODE_SET           BTM_MODE_SET_BTM_MODE_SET_Msk           /*!< Boot memory mode setting */
 
-/*****************  Bit definition for SLIB_UNLOCK register ******************/
+/*****************  Bit definition for SLIB_UNLOCK register  ******************/
 #define SLIB_UNLOCK_SLIB_UKVAL_Pos          (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_UNLOCK_SLIB_UKVAL_Msk          (0xFFFFFFFFU << SLIB_UNLOCK_SLIB_UKVAL_Pos)
 #define SLIB_UNLOCK_SLIB_UKVAL              SLIB_UNLOCK_SLIB_UKVAL_Msk              /*!< Security library unlock key value */
@@ -2151,7 +2153,7 @@ typedef struct
 #define GPIO_CFGHR_IOFC15_0                 (0x1U << GPIO_CFGHR_IOFC15_Pos)         /*!< 0x40000000 */
 #define GPIO_CFGHR_IOFC15_1                 (0x2U << GPIO_CFGHR_IOFC15_Pos)         /*!< 0x80000000 */
 
-/*!<****************  Bit definition for GPIO_IDT register  *******************/
+/*******************  Bit definition for GPIO_IDT register  *******************/
 #define GPIO_IDT_IDT0_Pos                   (0U)
 #define GPIO_IDT_IDT0_Msk                   (0x1U << GPIO_IDT_IDT0_Pos)             /*!< 0x00000001 */
 #define GPIO_IDT_IDT0                       GPIO_IDT_IDT0_Msk                       /*!< GPIO x input data, pin 0 */
@@ -2572,7 +2574,7 @@ typedef struct
 #define IOMUX_REMAP_TMR1_MUX_Msk            (0x3U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x000000C0 */
 #define IOMUX_REMAP_TMR1_MUX                IOMUX_REMAP_TMR1_MUX_Msk                /*!< TMR1_MUX[1:0] bits (TMR1 IO multiplexing) */
 #define IOMUX_REMAP_TMR1_MUX_0              (0x1U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x00000040 */
-#define IOMUX_REMAP_TMR1_MUX_1              (0x2U << IOMUX_REMAP_TMR1_MUX_Pos       /*!< 0x00000080 */
+#define IOMUX_REMAP_TMR1_MUX_1              (0x2U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x00000080 */
 
 #define IOMUX_REMAP_TMR1_MUX_MUX0           0x00000000U                             /*!< EXT/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BRK/PB12, CH1C/PB13, CH2C/PB14, CH3C/PB15 */
 #define IOMUX_REMAP_TMR1_MUX_MUX1_Pos       (6U)
@@ -2629,18 +2631,18 @@ typedef struct
 #define IOMUX_REMAP_PD01_MUX                IOMUX_REMAP_PD01_MUX_Msk                /*!< PD0/PD1 mapped on HEXT_IN/HEXT_OUT */
 #define IOMUX_REMAP_TMR5CH4_MUX_Pos         (16U)
 #define IOMUX_REMAP_TMR5CH4_MUX_Msk         (0x1U << IOMUX_REMAP_TMR5CH4_MUX_Pos)   /*!< 0x00010000 */
-#define IOMUX_REMAP_TMR5CH4_MUX             IOMUX_REMAP_TMR5CH4_MUX_Msk             /*!< TMR5 channel 4 multiplexing */
+#define IOMUX_REMAP_TMR5CH4_MUX             IOMUX_REMAP_TMR5CH4_MUX_Msk             /*!< TMR5_CH4 multiplexing */
 #define IOMUX_REMAP_ADC1_ETP_MUX_Pos        (17U)
 #define IOMUX_REMAP_ADC1_ETP_MUX_Msk        (0x1U << IOMUX_REMAP_ADC1_ETP_MUX_Pos)  /*!< 0x00020000 */
 #define IOMUX_REMAP_ADC1_ETP_MUX            IOMUX_REMAP_ADC1_ETP_MUX_Msk            /*!< ADC1 external trigger preempted conversion multiplexing */
 #define IOMUX_REMAP_ADC1_ETO_MUX_Pos        (18U)
 #define IOMUX_REMAP_ADC1_ETO_MUX_Msk        (0x1U << IOMUX_REMAP_ADC1_ETO_MUX_Pos)  /*!< 0x00040000 */
-#define IOMUX_REMAP_ADC1_ETO_MUX            IOMUX_REMAP_ADC1_ETO_MUX_Msk            /*!< ADC1 external trigger regular conversion mutiplexing */
+#define IOMUX_REMAP_ADC1_ETO_MUX            IOMUX_REMAP_ADC1_ETO_MUX_Msk            /*!< ADC1 external trigger ordinary conversion multiplexing */
 
 /*!< SWJTAG_MUX configuration */
 #define IOMUX_REMAP_SWJTAG_MUX_Pos          (24U)
 #define IOMUX_REMAP_SWJTAG_MUX_Msk          (0x7U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x07000000 */
-#define IOMUX_REMAP_SWJTAG_MUX              IOMUX_REMAP_SWJTAG_MUX_Msk              /*!< SWJTAG_MUX[2:0] bits (SWD JTAG mutiplexing) */
+#define IOMUX_REMAP_SWJTAG_MUX              IOMUX_REMAP_SWJTAG_MUX_Msk              /*!< SWJTAG_MUX[2:0] bits (SWD_JTAG IO multiplexing) */
 #define IOMUX_REMAP_SWJTAG_MUX_0            (0x1U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x01000000 */
 #define IOMUX_REMAP_SWJTAG_MUX_1            (0x2U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x02000000 */
 #define IOMUX_REMAP_SWJTAG_MUX_2            (0x4U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x04000000 */
@@ -2753,7 +2755,7 @@ typedef struct
 #define IOMUX_EXINTC2_EXINT4_GPF_Msk        (0x1U << IOMUX_EXINTC2_EXINT4_GPF_Pos)  /*!< 0x00000004 */
 #define IOMUX_EXINTC2_EXINT4_GPF            IOMUX_EXINTC2_EXINT4_GPF_Msk            /*!< GPIOF pin 4 */
 
-/* EXINT5 configuration */
+/*!< EXINT5 configuration */
 #define IOMUX_EXINTC2_EXINT5_Pos            (4U)
 #define IOMUX_EXINTC2_EXINT5_Msk            (0xFU << IOMUX_EXINTC2_EXINT5_Pos)      /*!< 0x000000F0 */
 #define IOMUX_EXINTC2_EXINT5                IOMUX_EXINTC2_EXINT5_Msk                /*!< EXINT5[3:0] bits (EXINT5 input source configuration) */
@@ -2888,7 +2890,7 @@ typedef struct
 #define IOMUX_EXINTC3_EXINT11_GPF           IOMUX_EXINTC3_EXINT11_GPF_Msk           /*!< GPIOF pin 11 */
 
 /****************  Bit definition for IOMUX_EXINTC4 register  *****************/
-/* EXINT12 configuration */
+/*!< EXINT12 configuration */
 #define IOMUX_EXINTC4_EXINT12_Pos           (0U)
 #define IOMUX_EXINTC4_EXINT12_Msk           (0xFU << IOMUX_EXINTC4_EXINT12_Pos)     /*!< 0x0000000F */
 #define IOMUX_EXINTC4_EXINT12               IOMUX_EXINTC4_EXINT12_Msk               /*!< EXINT12[3:0] bits (EXINT12 input source configuration) */
@@ -2907,7 +2909,7 @@ typedef struct
 #define IOMUX_EXINTC4_EXINT12_GPF_Msk       (0x1U << IOMUX_EXINTC4_EXINT12_GPF_Pos) /*!< 0x00000004 */
 #define IOMUX_EXINTC4_EXINT12_GPF           IOMUX_EXINTC4_EXINT12_GPF_Msk           /*!< GPIOF pin 12 */
 
-/* EXINT13 configuration */
+/*!< EXINT13 configuration */
 #define IOMUX_EXINTC4_EXINT13_Pos           (4U)
 #define IOMUX_EXINTC4_EXINT13_Msk           (0xFU << IOMUX_EXINTC4_EXINT13_Pos)     /*!< 0x000000F0 */
 #define IOMUX_EXINTC4_EXINT13               IOMUX_EXINTC4_EXINT13_Msk               /*!< EXINT13[3:0] bits (EXINT13 input source configuration) */
@@ -3070,9 +3072,12 @@ typedef struct
 #define IOMUX_REMAP4_TMR3_GMUX_3            (0x8U << IOMUX_REMAP4_TMR3_GMUX_Pos)    /*!< 0x00000800 */
 
 #define IOMUX_REMAP4_TMR3_GMUX_MUX0         0x00000000U                             /*!< CH1/PA6, CH2/PA7, CH3/PB0, CH4/PB1 */
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1_Pos     (8U)                                    /*!< 0x00000100 */
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1_Msk     (0x1U << IOMUX_REMAP4_TMR3_GMUX_MUX1_Pos)
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1         IOMUX_REMAP4_TMR3_GMUX_MUX1_Msk         /*!< CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2_Pos     (9U)                                    /*!< 0x00000200 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2_Msk     (0x1U << IOMUX_REMAP4_TMR3_GMUX_MUX2_Pos)
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2         IOMUX_REMAP4_TMR3_GMUX_MUX2_Msk         /*!< CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3_Pos     (8U)                                    /*!< 0x00000300 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3_Msk     (0x3U << IOMUX_REMAP4_TMR3_GMUX_MUX3_Pos)
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3         IOMUX_REMAP4_TMR3_GMUX_MUX3_Msk         /*!< CH1/PC6, CH2/PC7, CH3/PC8, CH4/PC9 */
 
 /*!< TMR5_GMUX configuration */
 #define IOMUX_REMAP4_TMR5_GMUX_Pos          (16U)
@@ -3089,7 +3094,7 @@ typedef struct
 
 #define IOMUX_REMAP4_TMR5CH4_GMUX_Pos       (19U)
 #define IOMUX_REMAP4_TMR5CH4_GMUX_Msk       (0x1U << IOMUX_REMAP4_TMR5CH4_GMUX_Pos) /*!< 0x00080000 */
-#define IOMUX_REMAP4_TMR5CH4_GMUX           IOMUX_REMAP4_TMR5CH4_GMUX_Msk           /*!< TMR5 channel 4 general multiplexing */
+#define IOMUX_REMAP4_TMR5CH4_GMUX           IOMUX_REMAP4_TMR5CH4_GMUX_Msk           /*!< TMR5_CH4 general multiplexing */
 
 /*****************  Bit definition for IOMUX_REMAP5 register  *****************/
 /*!< I2C1_GMUX configuration */
@@ -3229,15 +3234,15 @@ typedef struct
 /*****************  Bit definition for IOMUX_REMAP7 register  *****************/
 #define IOMUX_REMAP7_ADC1_ETP_GMUX_Pos      (4U)                                    /*!< 0x00000010 */
 #define IOMUX_REMAP7_ADC1_ETP_GMUX_Msk      (0x1U << IOMUX_REMAP7_ADC1_ETP_GMUX_Pos)
-#define IOMUX_REMAP7_ADC1_ETP_GMUX          IOMUX_REMAP7_ADC1_ETP_GMUX_Msk          /*!< ADC1 External trigger preempted conversion general multiplexing */
+#define IOMUX_REMAP7_ADC1_ETP_GMUX          IOMUX_REMAP7_ADC1_ETP_GMUX_Msk          /*!< ADC1 external trigger preempted conversion general multiplexing */
 #define IOMUX_REMAP7_ADC1_ETO_GMUX_Pos      (5U)                                    /*!< 0x00000020 */
 #define IOMUX_REMAP7_ADC1_ETO_GMUX_Msk      (0x1U << IOMUX_REMAP7_ADC1_ETO_GMUX_Pos)
-#define IOMUX_REMAP7_ADC1_ETO_GMUX          IOMUX_REMAP7_ADC1_ETO_GMUX_Msk          /*!< ADC1 external trigger regular conversion general multiplexing */
+#define IOMUX_REMAP7_ADC1_ETO_GMUX          IOMUX_REMAP7_ADC1_ETO_GMUX_Msk          /*!< ADC1 external trigger ordinary conversion general multiplexing */
 
 /*!< SWJTAG_GMUX configuration */
 #define IOMUX_REMAP7_SWJTAG_GMUX_Pos        (16U)
 #define IOMUX_REMAP7_SWJTAG_GMUX_Msk        (0x7U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00070000 */
-#define IOMUX_REMAP7_SWJTAG_GMUX            IOMUX_REMAP7_SWJTAG_GMUX_Msk            /*!< SWJTAG_GMUX[2:0] bits (SWD JTAG IO general mutiplexing) */
+#define IOMUX_REMAP7_SWJTAG_GMUX            IOMUX_REMAP7_SWJTAG_GMUX_Msk            /*!< SWJTAG_GMUX[2:0] bits (SWD_JTAG IO general multiplexing) */
 #define IOMUX_REMAP7_SWJTAG_GMUX_0          (0x1U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00010000 */
 #define IOMUX_REMAP7_SWJTAG_GMUX_1          (0x2U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00020000 */
 #define IOMUX_REMAP7_SWJTAG_GMUX_2          (0x4U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00040000 */
@@ -3395,7 +3400,7 @@ typedef struct
 #define EXINT_INTEN_INTEN22_Msk             (0x1U << EXINT_INTEN_INTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTEN_INTEN22                 EXINT_INTEN_INTEN22_Msk                 /*!< Interrupt enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTEN_INT0                    EXINT_INTEN_INTEN0
 #define EXINT_INTEN_INT1                    EXINT_INTEN_INTEN1
 #define EXINT_INTEN_INT2                    EXINT_INTEN_INTEN2
@@ -3492,7 +3497,7 @@ typedef struct
 #define EXINT_EVTEN_EVTEN22_Msk             (0x1U << EXINT_EVTEN_EVTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_EVTEN_EVTEN22                 EXINT_EVTEN_EVTEN22_Msk                 /*!< Event enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_EVTEN_EVT0                    EXINT_EVTEN_EVTEN0
 #define EXINT_EVTEN_EVT1                    EXINT_EVTEN_EVTEN1
 #define EXINT_EVTEN_EVT2                    EXINT_EVTEN_EVTEN2
@@ -3588,7 +3593,7 @@ typedef struct
 #define EXINT_POLCFG1_RP22_Msk              (0x1U << EXINT_POLCFG1_RP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG1_RP22                  EXINT_POLCFG1_RP22_Msk                  /*!< Rising edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG1_POL0                  EXINT_POLCFG1_RP0
 #define EXINT_POLCFG1_POL1                  EXINT_POLCFG1_RP1
 #define EXINT_POLCFG1_POL2                  EXINT_POLCFG1_RP2
@@ -3684,7 +3689,7 @@ typedef struct
 #define EXINT_POLCFG2_FP22_Msk              (0x1U << EXINT_POLCFG2_FP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG2_FP22                  EXINT_POLCFG2_FP22_Msk                  /*!< Falling edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG2_POL0                  EXINT_POLCFG2_FP0
 #define EXINT_POLCFG2_POL1                  EXINT_POLCFG2_FP1
 #define EXINT_POLCFG2_POL2                  EXINT_POLCFG2_FP2
@@ -3780,7 +3785,7 @@ typedef struct
 #define EXINT_SWTRG_SWT22_Msk               (0x1U << EXINT_SWTRG_SWT22_Pos)         /*!< 0x00400000 */
 #define EXINT_SWTRG_SWT22                   EXINT_SWTRG_SWT22_Msk                   /*!< Software trigger on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_SWTRG_SW0                     EXINT_SWTRG_SWT0
 #define EXINT_SWTRG_SW1                     EXINT_SWTRG_SWT1
 #define EXINT_SWTRG_SW2                     EXINT_SWTRG_SWT2
@@ -3876,7 +3881,7 @@ typedef struct
 #define EXINT_INTSTS_LINE22_Msk             (0x1U << EXINT_INTSTS_LINE22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTSTS_LINE22                 EXINT_INTSTS_LINE22_Msk                 /*!< Status bit for line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTSTS_INT0                   EXINT_INTSTS_LINE0
 #define EXINT_INTSTS_INT1                   EXINT_INTSTS_LINE1
 #define EXINT_INTSTS_INT2                   EXINT_INTSTS_LINE2
@@ -4326,8 +4331,8 @@ typedef struct
 
 /******************  Bit definition for I2C_OADDR1 register  ******************/
 /*!< ADDR1 configuration */
-#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface Address */
-#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface Address */
+#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface address */
+#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface address */
 
 #define I2C_OADDR1_ADDR1_0_Pos              (0U)
 #define I2C_OADDR1_ADDR1_0_Msk              (0x1U << I2C_OADDR1_ADDR1_0_Pos)        /*!< 0x00000001 */
@@ -4690,7 +4695,7 @@ typedef struct
 #define SPI_CTRL1_NTC                       SPI_CTRL1_NTC_Msk                       /*!< Transmit CRC next */
 #define SPI_CTRL1_CCEN_Pos                  (13U)
 #define SPI_CTRL1_CCEN_Msk                  (0x1U << SPI_CTRL1_CCEN_Pos)            /*!< 0x00002000 */
-#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< RC calculation enable */
+#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< CRC calculation enable */
 #define SPI_CTRL1_SLBTD_Pos                 (14U)
 #define SPI_CTRL1_SLBTD_Msk                 (0x1U << SPI_CTRL1_SLBTD_Pos)           /*!< 0x00004000 */
 #define SPI_CTRL1_SLBTD                     SPI_CTRL1_SLBTD_Msk                     /*!< Single line bidirectional half-duplex transmission direction */
@@ -4752,7 +4757,7 @@ typedef struct
 #define SPI_DT_DT_Msk                       (0xFFFFU << SPI_DT_DT_Pos)              /*!< 0x0000FFFF */
 #define SPI_DT_DT                           SPI_DT_DT_Msk                           /*!< Data value */
 
-/*******************  Bit definition for SPI_CPOLY register  ******************/
+/******************  Bit definition for SPI_CPOLY register  *******************/
 #define SPI_CPOLY_CPOLY_Pos                 (0U)
 #define SPI_CPOLY_CPOLY_Msk                 (0xFFFFU << SPI_CPOLY_CPOLY_Pos)        /*!< 0x0000FFFF */
 #define SPI_CPOLY_CPOLY                     SPI_CPOLY_CPOLY_Msk                     /*!< CRC polynomial */
@@ -5975,12 +5980,12 @@ typedef struct
 #define ADC_PCDTO4_PCDTO4_Msk               (0xFFFU << ADC_PCDTO4_PCDTO4_Pos)       /*!< 0x00000FFF */
 #define ADC_PCDTO4_PCDTO4                   ADC_PCDTO4_PCDTO4_Msk                   /*!< Data offset for Preempted channel 4 */
 
-/*******************  Bit definition for ADC_VMHB register  ********************/
+/*******************  Bit definition for ADC_VMHB register  *******************/
 #define ADC_VMHB_VMHB_Pos                   (0U)
 #define ADC_VMHB_VMHB_Msk                   (0xFFFU << ADC_VMHB_VMHB_Pos)           /*!< 0x00000FFF */
 #define ADC_VMHB_VMHB                       ADC_VMHB_VMHB_Msk                       /*!< Voltage monitoring high boundary */
 
-/*******************  Bit definition for ADC_VMLB register  ********************/
+/*******************  Bit definition for ADC_VMLB register  *******************/
 #define ADC_VMLB_VMLB_Pos                   (0U)
 #define ADC_VMLB_VMLB_Msk                   (0xFFFU << ADC_VMLB_VMLB_Pos)           /*!< 0x00000FFF */
 #define ADC_VMLB_VMLB                       ADC_VMLB_VMLB_Msk                       /*!< Voltage monitoring low boundary */
@@ -6348,7 +6353,7 @@ typedef struct
 #define CAN_TSTS_TMNR_Msk                   (0x3U << CAN_TSTS_TMNR_Pos)             /*!< 0x03000000 */
 #define CAN_TSTS_TMNR                       CAN_TSTS_TMNR_Msk                       /*!< TMNR[1:0] bits (Transmit mailbox number record) */
 
-/*!< TMEF congiguration */
+/*!< TMEF configuration */
 #define CAN_TSTS_TMEF_Pos                   (26U)
 #define CAN_TSTS_TMEF_Msk                   (0x7U << CAN_TSTS_TMEF_Pos)             /*!< 0x1C000000 */
 #define CAN_TSTS_TMEF                       CAN_TSTS_TMEF_Msk                       /*!< TMEF[2:0] bits (Transmit mailbox empty flag) */
@@ -6362,7 +6367,7 @@ typedef struct
 #define CAN_TSTS_TM2EF_Msk                  (0x1U << CAN_TSTS_TM2EF_Pos)            /*!< 0x10000000 */
 #define CAN_TSTS_TM2EF                      CAN_TSTS_TM2EF_Msk                      /*!< Transmit mailbox 2 empty flag */
 
-/*!< TMLPF congiguration */
+/*!< TMLPF configuration */
 #define CAN_TSTS_TMLPF_Pos                  (29U)
 #define CAN_TSTS_TMLPF_Msk                  (0x7U << CAN_TSTS_TMLPF_Pos)            /*!< 0xE0000000 */
 #define CAN_TSTS_TMLPF                      CAN_TSTS_TMLPF_Msk                      /*!< TMLPF[2:0] bits (Transmit mailbox lowest priority flag) */
@@ -6459,7 +6464,7 @@ typedef struct
 #define CAN_ESTS_BOF_Msk                    (0x1U << CAN_ESTS_BOF_Pos)              /*!< 0x00000004 */
 #define CAN_ESTS_BOF                        CAN_ESTS_BOF_Msk                        /*!< Bus-off flag */
 
-/*!< ETR congiguration */
+/*!< ETR configuration */
 #define CAN_ESTS_ETR_Pos                    (4U)
 #define CAN_ESTS_ETR_Msk                    (0x7U << CAN_ESTS_ETR_Pos)              /*!< 0x00000070 */
 #define CAN_ESTS_ETR                        CAN_ESTS_ETR_Msk                        /*!< ETR[2:0] bits (Error type record) */
@@ -6479,7 +6484,7 @@ typedef struct
 #define CAN_BTMG_BRDIV_Msk                  (0xFFFU << CAN_BTMG_BRDIV_Pos)          /*!< 0x00000FFF */
 #define CAN_BTMG_BRDIV                      CAN_BTMG_BRDIV_Msk                      /*!< Baud rate division */
 
-/*!< BTS1 congiguration */
+/*!< BTS1 configuration */
 #define CAN_BTMG_BTS1_Pos                   (16U)
 #define CAN_BTMG_BTS1_Msk                   (0xFU << CAN_BTMG_BTS1_Pos)             /*!< 0x000F0000 */
 #define CAN_BTMG_BTS1                       CAN_BTMG_BTS1_Msk                       /*!< BTS1[3:0] bits (Bit time segment 1) */
@@ -6488,7 +6493,7 @@ typedef struct
 #define CAN_BTMG_BTS1_2                     (0x4U << CAN_BTMG_BTS1_Pos)             /*!< 0x00040000 */
 #define CAN_BTMG_BTS1_3                     (0x8U << CAN_BTMG_BTS1_Pos)             /*!< 0x00080000 */
 
-/*!< BTS2 congiguration */
+/*!< BTS2 configuration */
 #define CAN_BTMG_BTS2_Pos                   (20U)
 #define CAN_BTMG_BTS2_Msk                   (0x7U << CAN_BTMG_BTS2_Pos)             /*!< 0x00700000 */
 #define CAN_BTMG_BTS2                       CAN_BTMG_BTS2_Msk                       /*!< BTS2[2:0] bits (Bit time segment 2) */
@@ -6496,7 +6501,7 @@ typedef struct
 #define CAN_BTMG_BTS2_1                     (0x2U << CAN_BTMG_BTS2_Pos)             /*!< 0x00200000 */
 #define CAN_BTMG_BTS2_2                     (0x4U << CAN_BTMG_BTS2_Pos)             /*!< 0x00400000 */
 
-/*!< RSAW congiguration */
+/*!< RSAW configuration */
 #define CAN_BTMG_RSAW_Pos                   (24U)
 #define CAN_BTMG_RSAW_Msk                   (0x3U << CAN_BTMG_RSAW_Pos)             /*!< 0x03000000 */
 #define CAN_BTMG_RSAW                       CAN_BTMG_RSAW_Msk                       /*!< RSAW[1:0] bits (Resynchronization width) */
@@ -9730,7 +9735,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for SDIO_PWRCTRL register  *****************/
-/*!< PS congiguration */
+/*!< PS configuration */
 #define SDIO_PWRCTRL_PS_Pos                 (0U)
 #define SDIO_PWRCTRL_PS_Msk                 (0x3U << SDIO_PWRCTRL_PS_Pos)           /*!< 0x00000003 */
 #define SDIO_PWRCTRL_PS                     SDIO_PWRCTRL_PS_Msk                     /*!< PS[1:0] bits (Power switch) */
@@ -9750,7 +9755,7 @@ typedef struct
 #define SDIO_CLKCTRL_BYPSEN_Msk             (0x1U << SDIO_CLKCTRL_BYPSEN_Pos)       /*!< 0x00000400 */
 #define SDIO_CLKCTRL_BYPSEN                 SDIO_CLKCTRL_BYPSEN_Msk                 /*!< Clock divider bypass enable bit */
 
-/*!< BUSWS congiguration */
+/*!< BUSWS configuration */
 #define SDIO_CLKCTRL_BUSWS_Pos              (11U)
 #define SDIO_CLKCTRL_BUSWS_Msk              (0x3U << SDIO_CLKCTRL_BUSWS_Pos)        /*!< 0x00001800 */
 #define SDIO_CLKCTRL_BUSWS                  SDIO_CLKCTRL_BUSWS_Msk                  /*!< BUSWS[1:0] bits (Bus width selection) */
@@ -9774,7 +9779,7 @@ typedef struct
 #define SDIO_CMD_CMDIDX_Msk                 (0x3FU << SDIO_CMD_CMDIDX_Pos)          /*!< 0x0000003F */
 #define SDIO_CMD_CMDIDX                     SDIO_CMD_CMDIDX_Msk                     /*!< Command index */
 
-/*!< RSPWT congiguration */
+/*!< RSPWT configuration */
 #define SDIO_CMD_RSPWT_Pos                  (6U)
 #define SDIO_CMD_RSPWT_Msk                  (0x3U << SDIO_CMD_RSPWT_Pos)            /*!< 0x000000C0 */
 #define SDIO_CMD_RSPWT                      SDIO_CMD_RSPWT_Msk                      /*!< RSPWT[1:0] bits (Wait for response bits) */
@@ -9843,7 +9848,7 @@ typedef struct
 #define SDIO_DTCTRL_DMAEN_Msk               (0x1U << SDIO_DTCTRL_DMAEN_Pos)         /*!< 0x00000008 */
 #define SDIO_DTCTRL_DMAEN                   SDIO_DTCTRL_DMAEN_Msk                   /*!< DMA enable bit */
 
-/*!< BLKSIZE congiguration */
+/*!< BLKSIZE configuration */
 #define SDIO_DTCTRL_BLKSIZE_Pos             (4U)
 #define SDIO_DTCTRL_BLKSIZE_Msk             (0xFU << SDIO_DTCTRL_BLKSIZE_Pos)       /*!< 0x000000F0 */
 #define SDIO_DTCTRL_BLKSIZE                 SDIO_DTCTRL_BLKSIZE_Msk                 /*!< BLKSIZE[3:0] bits (Data block size) */
@@ -10050,7 +10055,7 @@ typedef struct
 #define SDIO_INTEN_IOIFIEN_Msk              (0x1U << SDIO_INTEN_IOIFIEN_Pos)        /*!< 0x00400000 */
 #define SDIO_INTEN_IOIFIEN                  SDIO_INTEN_IOIFIEN_Msk                  /*!< SD I/O mode received interrupt enable */
 
-/*****************  Bit definition for SDIO_BUFCNTR register  ******************/
+/*****************  Bit definition for SDIO_BUFCNTR register  *****************/
 #define SDIO_BUFCNTR_CNT_Pos                (0U)
 #define SDIO_BUFCNTR_CNT_Msk                (0xFFFFFFU << SDIO_BUFCNTR_CNT_Pos)     /*!< 0x00FFFFFF */
 #define SDIO_BUFCNTR_CNT                    SDIO_BUFCNTR_CNT_Msk                    /*!< Number of words to be written to or read from the BUF */
@@ -10062,7 +10067,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Comparator (COMP)                              */
+/*                              Comparator (CMP)                              */
 /*                                                                            */
 /******************************************************************************/
 
@@ -10077,7 +10082,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1SSEL_Msk           (0x1U << CMP_CTRLSTS1_CMP1SSEL_Pos)     /*!< 0x00000004 */
 #define CMP_CTRLSTS1_CMP1SSEL               CMP_CTRLSTS1_CMP1SSEL_Msk               /*!< Comparator 1 speed selection */
 
-/*!< CMP1INVSEL congiguration */
+/*!< CMP1INVSEL configuration */
 #define CMP_CTRLSTS1_CMP1INVSEL_Pos         (4U)
 #define CMP_CTRLSTS1_CMP1INVSEL_Msk         (0x7U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000070 */
 #define CMP_CTRLSTS1_CMP1INVSEL             CMP_CTRLSTS1_CMP1INVSEL_Msk             /*!< CMP1INVSEL[2:0] bits (Comparator 1 inverting selection) */
@@ -10085,7 +10090,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1INVSEL_1           (0x2U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000020 */
 #define CMP_CTRLSTS1_CMP1INVSEL_2           (0x4U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000040 */
 
-/*!< CMP1TAG congiguration */
+/*!< CMP1TAG configuration */
 #define CMP_CTRLSTS1_CMP1TAG_Pos            (8U)
 #define CMP_CTRLSTS1_CMP1TAG_Msk            (0x7U << CMP_CTRLSTS1_CMP1TAG_Pos)      /*!< 0x00000700 */
 #define CMP_CTRLSTS1_CMP1TAG                CMP_CTRLSTS1_CMP1TAG_Msk                /*!< CMP1TAG[2:0] bits (Comparator 1 output target) */
@@ -10097,7 +10102,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1P_Msk              (0x1U << CMP_CTRLSTS1_CMP1P_Pos)        /*!< 0x00000800 */
 #define CMP_CTRLSTS1_CMP1P                  CMP_CTRLSTS1_CMP1P_Msk                  /*!< Comparator 1 polarity */
 
-/*!< CMP1HYST congiguration */
+/*!< CMP1HYST configuration */
 #define CMP_CTRLSTS1_CMP1HYST_Pos           (12U)
 #define CMP_CTRLSTS1_CMP1HYST_Msk           (0x3U << CMP_CTRLSTS1_CMP1HYST_Pos)     /*!< 0x00003000 */
 #define CMP_CTRLSTS1_CMP1HYST               CMP_CTRLSTS1_CMP1HYST_Msk               /*!< CMP1HYST[1:0] bits (Comparator 1 hysteresis) */
@@ -10117,7 +10122,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2SSEL_Msk           (0x1U << CMP_CTRLSTS1_CMP2SSEL_Pos)     /*!< 0x00040000 */
 #define CMP_CTRLSTS1_CMP2SSEL               CMP_CTRLSTS1_CMP2SSEL_Msk               /*!< Comparator 2 speed selection */
 
-/*!< CMP2INVSEL congiguration */
+/*!< CMP2INVSEL configuration */
 #define CMP_CTRLSTS1_CMP2INVSEL_Pos         (20U)
 #define CMP_CTRLSTS1_CMP2INVSEL_Msk         (0x7U << CMP_CTRLSTS1_CMP2INVSEL_Pos)   /*!< 0x00700000 */
 #define CMP_CTRLSTS1_CMP2INVSEL             CMP_CTRLSTS1_CMP2INVSEL_Msk             /*!< CMP2INVSEL[2:0] bits (Comparator 2 inverting selection) */
@@ -10129,7 +10134,7 @@ typedef struct
 #define CMP_CTRLSTS1_DCMPEN_Msk             (0x1U << CMP_CTRLSTS1_DCMPEN_Pos)       /*!< 0x00800000 */
 #define CMP_CTRLSTS1_DCMPEN                 CMP_CTRLSTS1_DCMPEN_Msk                 /*!< Double comparator mode enable */
 
-/*!< CMP2TAG congiguration */
+/*!< CMP2TAG configuration */
 #define CMP_CTRLSTS1_CMP2TAG_Pos            (24U)
 #define CMP_CTRLSTS1_CMP2TAG_Msk            (0x7U << CMP_CTRLSTS1_CMP2TAG_Pos)      /*!< 0x07000000 */
 #define CMP_CTRLSTS1_CMP2TAG                CMP_CTRLSTS1_CMP2TAG_Msk                /*!< CMP2TAG[2:0] bits (Comparator 2 output target) */
@@ -10141,7 +10146,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2P_Msk              (0x1U << CMP_CTRLSTS1_CMP2P_Pos)        /*!< 0x08000000 */
 #define CMP_CTRLSTS1_CMP2P                  CMP_CTRLSTS1_CMP2P_Msk                  /*!< Comparator 2 polarity */
 
-/*!< CMP2HYST congiguration */
+/*!< CMP2HYST configuration */
 #define CMP_CTRLSTS1_CMP2HYST_Pos           (28U)
 #define CMP_CTRLSTS1_CMP2HYST_Msk           (0x3U << CMP_CTRLSTS1_CMP2HYST_Pos)     /*!< 0x30000000 */
 #define CMP_CTRLSTS1_CMP2HYST               CMP_CTRLSTS1_CMP2HYST_Msk               /*!< CMP2HYST[1:0] bits (Comparator 2 hysteresis) */
@@ -10156,14 +10161,14 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2WP                 CMP_CTRLSTS1_CMP2WP_Msk                 /*!< Comparator 2 write protect */
 
 /*****************  Bit definition for CMP_CTRLSTS2 register  *****************/
-/*!< CMP1NINVSEL congiguration */
+/*!< CMP1NINVSEL configuration */
 #define CMP_CTRLSTS2_CMP1NINVSEL_Pos        (0U)
 #define CMP_CTRLSTS2_CMP1NINVSEL_Msk        (0x3U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000003 */
 #define CMP_CTRLSTS2_CMP1NINVSEL            CMP_CTRLSTS2_CMP1NINVSEL_Msk            /*!< CMP1NINVSEL[1:0] bits (Comparator 1 non-inverting input selection) */
 #define CMP_CTRLSTS2_CMP1NINVSEL_0          (0x1U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000001 */
 #define CMP_CTRLSTS2_CMP1NINVSEL_1          (0x2U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000002 */
 
-/*!< CMP2NINVSEL congiguration */
+/*!< CMP2NINVSEL configuration */
 #define CMP_CTRLSTS2_CMP2NINVSEL_Pos        (16U)
 #define CMP_CTRLSTS2_CMP2NINVSEL_Msk        (0x3U << CMP_CTRLSTS2_CMP2NINVSEL_Pos)  /*!< 0x00030000 */
 #define CMP_CTRLSTS2_CMP2NINVSEL            CMP_CTRLSTS2_CMP2NINVSEL_Msk            /*!< CMP2NINVSEL[1:0] bits (Comparator 2 non-inverting input selection) */
@@ -10177,7 +10182,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for DEBUG_IDCODE register  *****************/
-/*!< PID congiguration */
+/*!< PID configuration */
 #define DEBUG_IDCODE_PID_Pos                (0U)
 #define DEBUG_IDCODE_PID_Msk                (0xFFFFFFFFU << DEBUG_IDCODE_PID_Pos)   /*!< 0xFFFFFFFF */
 #define DEBUG_IDCODE_PID                    DEBUG_IDCODE_PID_Msk                    /*!< PID[31:0] bits (PID information) */
@@ -10228,7 +10233,7 @@ typedef struct
 #define DEBUG_CTRL_TRACE_IOEN_Msk           (0x1U << DEBUG_CTRL_TRACE_IOEN_Pos)     /*!< 0x00000020 */
 #define DEBUG_CTRL_TRACE_IOEN               DEBUG_CTRL_TRACE_IOEN_Msk               /*!< Trace pin assignment enable */
 
-/*!< TRACE_MODE congiguration */
+/*!< TRACE_MODE configuration */
 #define DEBUG_CTRL_TRACE_MODE_Pos           (6U)
 #define DEBUG_CTRL_TRACE_MODE_Msk           (0x3U << DEBUG_CTRL_TRACE_MODE_Pos)     /*!< 0x000000C0 */
 #define DEBUG_CTRL_TRACE_MODE               DEBUG_CTRL_TRACE_MODE_Msk               /*!< TRACE_MODE[1:0] bits (Trace pin assignment control) */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415kx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415kx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f415kx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian
-  * @version v2.1.6
-  * @date    13-Dec-2024
+  * @version v2.1.8
+  * @date    24-Nov-2025
   * @brief   AT32F415Kx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.6
+  * @brief CMSIS Device version number V2.1.8
   */
 #define __AT32F415_LIBRARY_VERSION_MAJOR   (0x02) /*!< [31:24] major version */
 #define __AT32F415_LIBRARY_VERSION_MIDDLE  (0x01) /*!< [23:16] middle version */
-#define __AT32F415_LIBRARY_VERSION_MINOR   (0x06) /*!< [15:8]  minor version */
+#define __AT32F415_LIBRARY_VERSION_MINOR   (0x08) /*!< [15:8]  minor version */
 #define __AT32F415_LIBRARY_VERSION_RC      (0x00) /*!< [7:0]   release candidate */
 #define __AT32F415_LIBRARY_VERSION         ((__AT32F415_LIBRARY_VERSION_MAJOR  << 24)\
                                            |(__AT32F415_LIBRARY_VERSION_MIDDLE << 16)\
@@ -99,7 +99,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                   */
 
 /******  AT32 specific Interrupt Numbers **********************************************************/
-  WWDT_IRQn                   = 0,      /*!< Window WatchDog Timer Interrupt                      */
+  WWDT_IRQn                   = 0,      /*!< Window WATCHDOG Timer Interrupt                      */
   PVM_IRQn                    = 1,      /*!< PVM Interrupt linked to EXINT16                      */
   TAMPER_IRQn                 = 2,      /*!< Tamper Interrupt linked to EXINT21                   */
   ERTC_WKUP_IRQn              = 3,      /*!< ERTC Wake Up Interrupt linked to EXINT22             */
@@ -242,8 +242,8 @@ typedef struct
   __IO uint32_t ESTS;                                /*!< CAN error status register,                   Address offset: 0x018         */
   __IO uint32_t BTMG;                                /*!< CAN bit timing register,                     Address offset: 0x01C         */
   uint32_t      RESERVED0[88];                       /*!< Reserved,                                    Address offset: 0x020 ~ 0x17C */
-  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX Mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
-  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO Mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
+  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
+  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
   uint32_t      RESERVED1[12];                       /*!< Reserved,                                    Address offset: 0x1D0 ~ 0x1FC */
   __IO uint32_t FCTRL;                               /*!< CAN filter control register,                 Address offset: 0x200         */
   __IO uint32_t FMCFG;                               /*!< CAN filter mode configuration register,      Address offset: 0x204         */
@@ -273,12 +273,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t DT;          /*!< CRC Data register,                           Address offset: 0x00 */
-  __IO uint32_t CDT;         /*!< CRC Common data register,                    Address offset: 0x04 */
-  __IO uint32_t CTRL;        /*!< CRC Control register,                        Address offset: 0x08 */
+  __IO uint32_t DT;          /*!< CRC data register,                           Address offset: 0x00 */
+  __IO uint32_t CDT;         /*!< CRC common data register,                    Address offset: 0x04 */
+  __IO uint32_t CTRL;        /*!< CRC control register,                        Address offset: 0x08 */
   uint32_t      RESERVED;    /*!< Reserved,                                    Address offset: 0x0C */
-  __IO uint32_t IDT;         /*!< CRC Initialization register,                 Address offset: 0x10 */
-  __IO uint32_t POLY;        /*!< CRC Polynomial register,                     Address offset: 0x14 */
+  __IO uint32_t IDT;         /*!< CRC initialization register,                 Address offset: 0x10 */
+  __IO uint32_t POLY;        /*!< CRC polynomial register,                     Address offset: 0x14 */
 } CRC_TypeDef;
 
 /**
@@ -287,23 +287,23 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;            /*!< CRM Clock control register,                  Address offset: 0x00        */
-  __IO uint32_t CFG;             /*!< CRM Clock configuration register,            Address offset: 0x04        */
-  __IO uint32_t CLKINT;          /*!< CRM Clock interrupt register,                Address offset: 0x08        */
+  __IO uint32_t CTRL;            /*!< CRM clock control register,                  Address offset: 0x00        */
+  __IO uint32_t CFG;             /*!< CRM clock configuration register,            Address offset: 0x04        */
+  __IO uint32_t CLKINT;          /*!< CRM clock interrupt register,                Address offset: 0x08        */
   __IO uint32_t APB2RST;         /*!< CRM APB2 peripheral reset register,          Address offset: 0x0C        */
   __IO uint32_t APB1RST;         /*!< CRM APB1 peripheral reset register,          Address offset: 0x10        */
-  __IO uint32_t AHBEN;           /*!< CRM APB peripheral clock enable register,    Address offset: 0x14        */
+  __IO uint32_t AHBEN;           /*!< CRM AHB peripheral clock enable register,    Address offset: 0x14        */
   __IO uint32_t APB2EN;          /*!< CRM APB2 peripheral clock enable register,   Address offset: 0x18        */
   __IO uint32_t APB1EN;          /*!< CRM APB1 peripheral clock enable register,   Address offset: 0x1C        */
-  __IO uint32_t BPDC;            /*!< CRM Battery powered domain control register, Address offset: 0x20        */
-  __IO uint32_t CTRLSTS;         /*!< CRM Control/status register,                 Address offset: 0x24        */
-  __IO uint32_t AHBRST;          /*!< CRM APB peripheral reset register,           Address offset: 0x28        */
+  __IO uint32_t BPDC;            /*!< CRM battery powered domain control register, Address offset: 0x20        */
+  __IO uint32_t CTRLSTS;         /*!< CRM control/status register,                 Address offset: 0x24        */
+  __IO uint32_t AHBRST;          /*!< CRM AHB peripheral reset register,           Address offset: 0x28        */
   __IO uint32_t PLL;             /*!< CRM PLL configuration register,              Address offset: 0x2C        */
-  __IO uint32_t MISC1;           /*!< CRM Additional register 1,                   Address offset: 0x30        */
+  __IO uint32_t MISC1;           /*!< CRM additional register 1,                   Address offset: 0x30        */
   uint32_t      RESERVED0[4];    /*!< Reserved,                                    Address offset: 0x34 ~ 0x40 */
   __IO uint32_t OTG_EXTCTRL;     /*!< CRM OTG_FS extended control register,        Address offset: 0x44        */
   uint32_t      RESERVED1[3];    /*!< Reserved,                                    Address offset: 0x48 - 0x50 */
-  __IO uint32_t MISC2;           /*!< CRM Additional register 2,                   Address offset: 0x54        */
+  __IO uint32_t MISC2;           /*!< CRM additional register 2,                   Address offset: 0x54        */
 } CRM_TypeDef;
 
 /**
@@ -333,8 +333,8 @@ typedef struct
   __IO uint32_t STS;             /*!< DMA interrupt status register,               Address offset: 0x00        */
   __IO uint32_t CLR;             /*!< DMA interrupt flag clear register,           Address offset: 0x04        */
   uint32_t      RESERVED[38];    /*!< Reserved,                                    Address offset: 0x08 ~ 0x9C */
-  __IO uint32_t SRC_SEL0;        /*!< DMA Channel source register 0,               Address offset: 0xA0        */
-  __IO uint32_t SRC_SEL1;        /*!< DMA Channel source register 1,               Address offset: 0xA4        */
+  __IO uint32_t SRC_SEL0;        /*!< DMA channel source register 0,               Address offset: 0xA0        */
+  __IO uint32_t SRC_SEL1;        /*!< DMA channel source register 1,               Address offset: 0xA4        */
 } DMA_TypeDef;
 
 /**
@@ -391,12 +391,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t INTEN;      /*!< EXINT Interrupt enable register,             Address offset: 0x00 */
-  __IO uint32_t EVTEN;      /*!< EXINT Event enable register,                 Address offset: 0x04 */
-  __IO uint32_t POLCFG1;    /*!< EXINT Polarity configuration register 1,     Address offset: 0x08 */
-  __IO uint32_t POLCFG2;    /*!< EXINT Polarity configuration register 2,     Address offset: 0x0C */
-  __IO uint32_t SWTRG;      /*!< EXINT Software trigger register,             Address offset: 0x10 */
-  __IO uint32_t INTSTS;     /*!< EXINT Interrupt status register,             Address offset: 0x14 */
+  __IO uint32_t INTEN;      /*!< EXINT interrupt enable register,             Address offset: 0x00 */
+  __IO uint32_t EVTEN;      /*!< EXINT event enable register,                 Address offset: 0x04 */
+  __IO uint32_t POLCFG1;    /*!< EXINT polarity configuration register 1,     Address offset: 0x08 */
+  __IO uint32_t POLCFG2;    /*!< EXINT polarity configuration register 2,     Address offset: 0x0C */
+  __IO uint32_t SWTRG;      /*!< EXINT software trigger register,             Address offset: 0x10 */
+  __IO uint32_t INTSTS;     /*!< EXINT interrupt status register,             Address offset: 0x14 */
 } EXINT_TypeDef;
 
 /**
@@ -412,7 +412,7 @@ typedef struct
   __IO uint32_t CTRL;              /*!< FLASH control register,                      Address offset: 0x10         */
   __IO uint32_t ADDR;              /*!< FLASH address register,                      Address offset: 0x14         */
   uint32_t      RESERVED0;         /*!< Reserved,                                    Address offset: 0x18         */
-  __IO uint32_t USD;               /*!< FLASH user system data register,             Address offset: 0x1C         */
+  __IO uint32_t FUSD;              /*!< FLASH user system data register,             Address offset: 0x1C         */
   __IO uint32_t EPPS;              /*!< FLASH erase/program protection status reg,   Address offset: 0x20         */
   uint32_t      RESERVED1[20];     /*!< Reserved,                                    Address offset: 0x24 ~ 0x70  */
   __IO uint32_t SLIB_STS0;         /*!< FLASH security library status register 0,    Address offset: 0x74         */
@@ -436,15 +436,15 @@ typedef struct
 
 typedef struct
 {
-  __IO uint16_t FAP;               /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
-  __IO uint16_t SSB;               /*!< USD System configuration byte,               Address offset: 0x1FFF_F802               */
-  __IO uint16_t DATA0;             /*!< USD User data 0,                             Address offset: 0x1FFF_F804               */
-  __IO uint16_t DATA1;             /*!< USD User data 1,                             Address offset: 0x1FFF_F806               */
-  __IO uint16_t EPP0;              /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
-  __IO uint16_t EPP1;              /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
-  __IO uint16_t EPP2;              /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
-  __IO uint16_t EPP3;              /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
-  __IO uint16_t DATA[504];         /*!< USD User data 2 ~ 505,                       Address offset: 0x1FFF_F810 ~ 0x1FFF_FBFC */
+  __IO uint16_t FAP;          /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
+  __IO uint16_t SSB;          /*!< USD system configuration byte,               Address offset: 0x1FFF_F802               */
+  __IO uint16_t DATA0;        /*!< USD user data 0,                             Address offset: 0x1FFF_F804               */
+  __IO uint16_t DATA1;        /*!< USD user data 1,                             Address offset: 0x1FFF_F806               */
+  __IO uint16_t EPP0;         /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
+  __IO uint16_t EPP1;         /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
+  __IO uint16_t EPP2;         /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
+  __IO uint16_t EPP3;         /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
+  __IO uint16_t DATA[504];    /*!< USD user data 2 ~ 505,                       Address offset: 0x1FFF_F810 ~ 0x1FFF_FBFC */
 } USD_TypeDef;
 
 /**
@@ -468,7 +468,7 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t EVTOUT;       /*!< IOMUX Event output control register,         Address offset: 0x00        */
+  __IO uint32_t EVTOUT;       /*!< IOMUX event output control register,         Address offset: 0x00        */
   __IO uint32_t REMAP;        /*!< IOMUX remap register 1,                      Address offset: 0x04        */
   __IO uint32_t EXINTC[4];    /*!< IOMUX external interrupt config register x,  Address offset: 0x08 ~ 0x14 */
   uint32_t      RESERVED;     /*!< Reserved,                                    Address offset: 0x18        */
@@ -487,14 +487,14 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL1;      /*!< I2C Control register 1,                      Address offset: 0x00 */
-  __IO uint32_t CTRL2;      /*!< I2C Control register 2,                      Address offset: 0x04 */
-  __IO uint32_t OADDR1;     /*!< I2C Own address register 1,                  Address offset: 0x08 */
-  __IO uint32_t OADDR2;     /*!< I2C Own address register 2,                  Address offset: 0x0C */
-  __IO uint32_t DT;         /*!< I2C Data register,                           Address offset: 0x10 */
-  __IO uint32_t STS1;       /*!< I2C Status register 1,                       Address offset: 0x14 */
-  __IO uint32_t STS2;       /*!< I2C Status register 2,                       Address offset: 0x18 */
-  __IO uint32_t CLKCTRL;    /*!< I2C Clock control register,                  Address offset: 0x1C */
+  __IO uint32_t CTRL1;      /*!< I2C control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CTRL2;      /*!< I2C control register 2,                      Address offset: 0x04 */
+  __IO uint32_t OADDR1;     /*!< I2C own address register 1,                  Address offset: 0x08 */
+  __IO uint32_t OADDR2;     /*!< I2C own address register 2,                  Address offset: 0x0C */
+  __IO uint32_t DT;         /*!< I2C data register,                           Address offset: 0x10 */
+  __IO uint32_t STS1;       /*!< I2C status register 1,                       Address offset: 0x14 */
+  __IO uint32_t STS2;       /*!< I2C status register 2,                       Address offset: 0x18 */
+  __IO uint32_t CLKCTRL;    /*!< I2C clock control register,                  Address offset: 0x1C */
   __IO uint32_t TMRISE;     /*!< I2C timer rise time register,                Address offset: 0x20 */
 } I2C_TypeDef;
 
@@ -504,8 +504,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;       /*!< PWC Power control register,                  Address offset: 0x00 */
-  __IO uint32_t CTRLSTS;    /*!< PWC Power control/status register,           Address offset: 0x04 */
+  __IO uint32_t CTRL;       /*!< PWC power control register,                  Address offset: 0x00 */
+  __IO uint32_t CTRLSTS;    /*!< PWC power control/status register,           Address offset: 0x04 */
 } PWC_TypeDef;
 
 /**
@@ -576,7 +576,7 @@ typedef struct
   __IO uint32_t C2DT;       /*!< TMR channel 2 data register,                 Address offset: 0x38 */
   __IO uint32_t C3DT;       /*!< TMR channel 3 data register,                 Address offset: 0x3C */
   __IO uint32_t C4DT;       /*!< TMR channel 4 data register,                 Address offset: 0x40 */
-  __IO uint32_t BRK;        /*!< TMR break register,                          Address offset: 0x44 */
+  __IO uint32_t BRK;        /*!< TMR brake register,                          Address offset: 0x44 */
   __IO uint32_t DMACTRL;    /*!< TMR DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMADT;      /*!< TMR DMA data register,                       Address offset: 0x4C */
 } TMR_TypeDef;
@@ -602,10 +602,10 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD;    /*!< WDT Command register,                        Address offset: 0x00 */
-  __IO uint32_t DIV;    /*!< WDT Divider register,                        Address offset: 0x04 */
-  __IO uint32_t RLD;    /*!< WDT Reload register,                         Address offset: 0x08 */
-  __IO uint32_t STS;    /*!< WDT Status register,                         Address offset: 0x0C */
+  __IO uint32_t CMD;    /*!< WDT command register,                        Address offset: 0x00 */
+  __IO uint32_t DIV;    /*!< WDT divider register,                        Address offset: 0x04 */
+  __IO uint32_t RLD;    /*!< WDT reload register,                         Address offset: 0x08 */
+  __IO uint32_t STS;    /*!< WDT status register,                         Address offset: 0x0C */
 } WDT_TypeDef;
 
 /**
@@ -614,9 +614,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;    /*!< WWDT Control register,                       Address offset: 0x00 */
-  __IO uint32_t CFG;     /*!< WWDT Configuration register,                 Address offset: 0x04 */
-  __IO uint32_t STS;     /*!< WWDT Status register,                        Address offset: 0x08 */
+  __IO uint32_t CTRL;    /*!< WWDT control register,                       Address offset: 0x00 */
+  __IO uint32_t CFG;     /*!< WWDT configuration register,                 Address offset: 0x04 */
+  __IO uint32_t STS;     /*!< WWDT status register,                        Address offset: 0x08 */
 } WWDT_TypeDef;
 
 /**
@@ -680,6 +680,7 @@ typedef struct
 #define DMA1_Channel5_BASE           (AHBPERIPH_BASE + 0x00000058U)  /*!< DMA1 Channel 5 base address                    */
 #define DMA1_Channel6_BASE           (AHBPERIPH_BASE + 0x0000006CU)  /*!< DMA1 Channel 6 base address                    */
 #define DMA1_Channel7_BASE           (AHBPERIPH_BASE + 0x00000080U)  /*!< DMA1 Channel 7 base address                    */
+
 #define DMA2_BASE                    (AHBPERIPH_BASE + 0x00000400U)  /*!< DMA2 base address                              */
 #define DMA2_Channel1_BASE           (AHBPERIPH_BASE + 0x00000408U)  /*!< DMA2 Channel 1 base address                    */
 #define DMA2_Channel2_BASE           (AHBPERIPH_BASE + 0x0000041CU)  /*!< DMA2 Channel 2 base address                    */
@@ -688,6 +689,7 @@ typedef struct
 #define DMA2_Channel5_BASE           (AHBPERIPH_BASE + 0x00000458U)  /*!< DMA2 Channel 5 base address                    */
 #define DMA2_Channel6_BASE           (AHBPERIPH_BASE + 0x0000046CU)  /*!< DMA2 Channel 6 base address                    */
 #define DMA2_Channel7_BASE           (AHBPERIPH_BASE + 0x00000480U)  /*!< DMA2 Channel 7 base address                    */
+
 #define CRM_BASE                     (AHBPERIPH_BASE + 0x00001000U)  /*!< CRM base address                               */
 #define CRC_BASE                     (AHBPERIPH_BASE + 0x00003000U)  /*!< CRC base address                               */
 
@@ -791,7 +793,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Power Control (PWC)                            */
+/*                             Power control (PWC)                            */
 /*                                                                            */
 /******************************************************************************/
 
@@ -964,7 +966,7 @@ typedef struct
 #define CRM_CFG_APB2DIV_DIV16               0x00003800U                             /*!< HCLK is divided by 16 */
 
 /*!< ADCDIV configuration */
-#define CRM_CFG_ADCDIV_Msk                  ((0x3U << 14) | (0x1U << 28))           /*!< 0x0100C000 */
+#define CRM_CFG_ADCDIV_Msk                  ((0x3U << 14) | (0x1U << 28))           /*!< 0x1000C000 */
 #define CRM_CFG_ADCDIV                      CRM_CFG_ADCDIV_Msk                      /*!< ADCDIV[2:0] bits (ADC division) */
 #define CRM_CFG_ADCDIV_0                    (0x1U << 14)                            /*!< 0x00004000 */
 #define CRM_CFG_ADCDIV_1                    (0x2U << 14)                            /*!< 0x00008000 */
@@ -974,8 +976,8 @@ typedef struct
 #define CRM_CFG_ADCDIV_DIV4                 0x00004000U                             /*!< PCLK/4 */
 #define CRM_CFG_ADCDIV_DIV6                 0x00008000U                             /*!< PCLK/6 */
 #define CRM_CFG_ADCDIV_DIV8                 0x0000C000U                             /*!< PCLK/8 */
-#define CRM_CFG_ADCDIV_DIV12                0x10004000U                             /*!< PCLK2/12 */
-#define CRM_CFG_ADCDIV_DIV16                0x1000C000U                             /*!< PCLK2/16 */
+#define CRM_CFG_ADCDIV_DIV12                0x10004000U                             /*!< PCLK/12 */
+#define CRM_CFG_ADCDIV_DIV16                0x1000C000U                             /*!< PCLK/16 */
 
 #define CRM_CFG_PLLRCS_Pos                  (16U)
 #define CRM_CFG_PLLRCS_Msk                  (0x1U << CRM_CFG_PLLRCS_Pos)            /*!< 0x00010000 */
@@ -1137,7 +1139,7 @@ typedef struct
 #define CRM_MISC1_CLKSEL_USB                CRM_MISC1_CLKOUT_SEL_USB
 #define CRM_MISC1_CLKSEL_ADC                CRM_MISC1_CLKOUT_SEL_ADC
 
-/*!<***************  Bit definition for CRM_CLKINT register  ******************/
+/******************  Bit definition for CRM_CLKINT register  ******************/
 #define CRM_CLKINT_LICKSTBLF_Pos            (0U)
 #define CRM_CLKINT_LICKSTBLF_Msk            (0x1U << CRM_CLKINT_LICKSTBLF_Pos)      /*!< 0x00000001 */
 #define CRM_CLKINT_LICKSTBLF                CRM_CLKINT_LICKSTBLF_Msk                /*!< LICK stable interrupt flag */
@@ -1385,7 +1387,7 @@ typedef struct
 #define CRM_BPDC_LEXTBYPS_Msk               (0x1U << CRM_BPDC_LEXTBYPS_Pos)         /*!< 0x00000004 */
 #define CRM_BPDC_LEXTBYPS                   CRM_BPDC_LEXTBYPS_Msk                   /*!< External low-speed crystal bypass */
 
-/*!< ERTCSEL congiguration */
+/*!< ERTCSEL configuration */
 #define CRM_BPDC_ERTCSEL_Pos                (8U)
 #define CRM_BPDC_ERTCSEL_Msk                (0x3U << CRM_BPDC_ERTCSEL_Pos)          /*!< 0x00000300 */
 #define CRM_BPDC_ERTCSEL                    CRM_BPDC_ERTCSEL_Msk                    /*!< ERTCSEL[1:0] bits (ERTC clock selection) */
@@ -1439,7 +1441,7 @@ typedef struct
 #define CRM_AHBRST_OTGFSRST                 CRM_AHBRST_OTGFSRST_Msk                 /*!< OTGFS reset */
 
 /*******************  Bit definition for CRM_PLL register  ********************/
-/*!< PLL_FR congiguration */
+/*!< PLL_FR configuration */
 #define CRM_PLL_PLL_FR_Pos                  (0U)
 #define CRM_PLL_PLL_FR_Msk                  (0x7U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000007 */
 #define CRM_PLL_PLL_FR                      CRM_PLL_PLL_FR_Msk                      /*!< PLL_FR[2:0] bits (PLL post-division factor) */
@@ -1447,7 +1449,7 @@ typedef struct
 #define CRM_PLL_PLL_FR_1                    (0x2U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000002 */
 #define CRM_PLL_PLL_FR_2                    (0x4U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000004 */
 
-/*!< PLL_MS congiguration */
+/*!< PLL_MS configuration */
 #define CRM_PLL_PLL_MS_Pos                  (4U)
 #define CRM_PLL_PLL_MS_Msk                  (0xFU << CRM_PLL_PLL_MS_Pos)            /*!< 0x000000F0 */
 #define CRM_PLL_PLL_MS                      CRM_PLL_PLL_MS_Msk                      /*!< PLL_MS[3:0] bits (PLL pre-division) */
@@ -1456,7 +1458,7 @@ typedef struct
 #define CRM_PLL_PLL_MS_2                    (0x4U << CRM_PLL_PLL_MS_Pos)            /*!< 0x00000040 */
 #define CRM_PLL_PLL_MS_3                    (0x8U << CRM_PLL_PLL_MS_Pos)            /*!< 0x00000080 */
 
-/*!< PLL_NS congiguration */
+/*!< PLL_NS configuration */
 #define CRM_PLL_PLL_NS_Pos                  (8U)
 #define CRM_PLL_PLL_NS_Msk                  (0x1FFU << CRM_PLL_PLL_NS_Pos)          /*!< 0x0001FF00 */
 #define CRM_PLL_PLL_NS                      CRM_PLL_PLL_NS_Msk                      /*!< PLL_NS[8:0] bits (PLL multiplication factor) */
@@ -1470,7 +1472,7 @@ typedef struct
 #define CRM_PLL_PLL_NS_7                    (0x080U << CRM_PLL_PLL_NS_Pos)          /*!< 0x00008000 */
 #define CRM_PLL_PLL_NS_8                    (0x100U << CRM_PLL_PLL_NS_Pos)          /*!< 0x00010000 */
 
-/*!< PLL_FREF congiguration */
+/*!< PLL_FREF configuration */
 #define CRM_PLL_PLL_FREF_Pos                (24U)
 #define CRM_PLL_PLL_FREF_Msk                (0x7U << CRM_PLL_PLL_FREF_Pos)          /*!< 0x07000000 */
 #define CRM_PLL_PLL_FREF                    CRM_PLL_PLL_FREF_Msk                    /*!< PLL_FREF[2:0] bits (PLL input clock selection) */
@@ -1503,7 +1505,7 @@ typedef struct
 #define CRM_MISC1_HICKDIV_Msk               (0x1U << CRM_MISC1_HICKDIV_Pos)         /*!< 0x02000000 */
 #define CRM_MISC1_HICKDIV                   CRM_MISC1_HICKDIV_Msk                   /*!< HICK 6 divider selection */
 
-/*!< CLKOUTDIV congiguration */
+/*!< CLKOUTDIV configuration */
 #define CRM_MISC1_CLKOUTDIV_Pos             (28U)
 #define CRM_MISC1_CLKOUTDIV_Msk             (0xFU << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0xF0000000 */
 #define CRM_MISC1_CLKOUTDIV                 CRM_MISC1_CLKOUTDIV_Msk                 /*!< CLKOUTDIV[3:0] bits (Clock output division) */
@@ -1512,7 +1514,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV_2               (0x4U << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0x40000000 */
 #define CRM_MISC1_CLKOUTDIV_3               (0x8U << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0x80000000 */
 
-#define CRM_MISC1_CLKOUTDIV_DIV1            0x00000000U                             /*!< No clock output */
+#define CRM_MISC1_CLKOUTDIV_DIV1            0x00000000U                             /*!< No clock output division */
 #define CRM_MISC1_CLKOUTDIV_DIV2            0x80000000U                             /*!< Clock output divided by 2 */
 #define CRM_MISC1_CLKOUTDIV_DIV4            0x90000000U                             /*!< Clock output divided by 4 */
 #define CRM_MISC1_CLKOUTDIV_DIV8            0xA0000000U                             /*!< Clock output divided by 8 */
@@ -1531,7 +1533,7 @@ typedef struct
 #define CRM_OTG_EXTCTRL_EP3_RMPEN           CRM_OTG_EXTCTRL_EP3_RMPEN_Msk           /*!< Endpoint 3 remap enable */
 
 /******************  Bit definition for CRM_MISC2 register  *******************/
-/*!< AUTO_STEP_EN congiguration */
+/*!< AUTO_STEP_EN configuration */
 #define CRM_MISC2_AUTO_STEP_EN_Pos          (4U)
 #define CRM_MISC2_AUTO_STEP_EN_Msk          (0x3U << CRM_MISC2_AUTO_STEP_EN_Pos)    /*!< 0x00000030 */
 #define CRM_MISC2_AUTO_STEP_EN              CRM_MISC2_AUTO_STEP_EN_Msk              /*!< AUTO_STEP_EN[1:0] bits (Auto step-by-step SCLK switch enable) */
@@ -1544,12 +1546,12 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                Flash and User System Data Registers (FLASH)                */
+/*                Flash and User System Data registers (FLASH)                */
 /*                                                                            */
 /******************************************************************************/
 
-/*******************  Bit definition for FLASH_PSR register  ******************/
-/*!< WTCYC congiguration */
+/******************  Bit definition for FLASH_PSR register  *******************/
+/*!< WTCYC configuration */
 #define FLASH_PSR_WTCYC_Pos                 (0U)
 #define FLASH_PSR_WTCYC_Msk                 (0x7U << FLASH_PSR_WTCYC_Pos)           /*!< 0x00000007 */
 #define FLASH_PSR_WTCYC                     FLASH_PSR_WTCYC_Msk                     /*!< WTCYC[2:0] bits (Wait cycle) */
@@ -1610,7 +1612,7 @@ typedef struct
 #define FLASH_CTRL_FPRGM                    FLASH_CTRL_FPRGM_Msk                    /*!< Flash program */
 #define FLASH_CTRL_SECERS_Pos               (1U)
 #define FLASH_CTRL_SECERS_Msk               (0x1U << FLASH_CTRL_SECERS_Pos)         /*!< 0x00000002 */
-#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Page erase */
+#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Sector erase */
 #define FLASH_CTRL_BANKERS_Pos              (2U)
 #define FLASH_CTRL_BANKERS_Msk              (0x1U << FLASH_CTRL_BANKERS_Pos)        /*!< 0x00000004 */
 #define FLASH_CTRL_BANKERS                  FLASH_CTRL_BANKERS_Msk                  /*!< Bank erase */
@@ -1652,7 +1654,7 @@ typedef struct
 #define FLASH_USD_FAP_Msk                   (0x1U << FLASH_USD_FAP_Pos)             /*!< 0x00000002 */
 #define FLASH_USD_FAP                       FLASH_USD_FAP_Msk                       /*!< Flash access protection */
 
-/*!< SSB congiguration */
+/*!< SSB configuration */
 #define FLASH_USD_WDT_ATO_EN_Pos            (2U)
 #define FLASH_USD_WDT_ATO_EN_Msk            (0x1U << FLASH_USD_WDT_ATO_EN_Pos)      /*!< 0x00000004 */
 #define FLASH_USD_WDT_ATO_EN                FLASH_USD_WDT_ATO_EN_Msk                /*!< nWDT_ATO_EN */
@@ -1681,7 +1683,7 @@ typedef struct
 #define FLASH_EPPS_EPPS_Msk                 (0xFFFFFFFFU << FLASH_EPPS_EPPS_Pos)    /*!< 0xFFFFFFFF */
 #define FLASH_EPPS_EPPS                     FLASH_EPPS_EPPS_Msk                     /*!< Erase/Program protection status */
 
-/*******************  Bit definition for SLIB_STS0 register *******************/
+/******************  Bit definition for SLIB_STS0 register  *******************/
 #define SLIB_STS0_BTM_AP_ENF_Pos            (0U)
 #define SLIB_STS0_BTM_AP_ENF_Msk            (0x1U << SLIB_STS0_BTM_AP_ENF_Pos)      /*!< 0x00000001 */
 #define SLIB_STS0_BTM_AP_ENF                SLIB_STS0_BTM_AP_ENF_Msk                /*!< Boot memory store application code enabled flag */
@@ -1693,25 +1695,25 @@ typedef struct
 #define SLIB_STS0_SLIB_ENF                  SLIB_STS0_SLIB_ENF_Msk                  /*!< Security library enable flag */
 #define SLIB_STS0_EM_SLIB_DAT_SS_Pos        (16U)
 #define SLIB_STS0_EM_SLIB_DAT_SS_Msk        (0xFFU << SLIB_STS0_EM_SLIB_DAT_SS_Pos) /*!< 0x00FF0000 */
-#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start page */
+#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start sector */
 
-/*******************  Bit definition for SLIB_STS1 register *******************/
+/******************  Bit definition for SLIB_STS1 register  *******************/
 #define SLIB_STS1_SLIB_SS_Pos               (0U)
 #define SLIB_STS1_SLIB_SS_Msk               (0x7FFU << SLIB_STS1_SLIB_SS_Pos)       /*!< 0x000007FF */
-#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start page */
+#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start sector */
 #define SLIB_STS1_SLIB_DAT_SS_Pos           (11U)
 #define SLIB_STS1_SLIB_DAT_SS_Msk           (0x7FFU << SLIB_STS1_SLIB_DAT_SS_Pos)   /*!< 0x003FF800 */
-#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start page */
+#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start sector */
 #define SLIB_STS1_SLIB_ES_Pos               (22U)
 #define SLIB_STS1_SLIB_ES_Msk               (0x3FFU << SLIB_STS1_SLIB_ES_Pos)       /*!< 0xFFC00000 */
-#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end page */
+#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end sector */
 
-/*****************  Bit definition for SLIB_PWD_CLR register ******************/
+/*****************  Bit definition for SLIB_PWD_CLR register  *****************/
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk      (0xFFFFFFFFU << SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos)
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL          SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk          /*!< Security library password clear value */
 
-/*****************  Bit definition for SLIB_MISC_STS register *****************/
+/****************  Bit definition for SLIB_MISC_STS register  *****************/
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Pos      (0U)                                    /*!< 0x00000001 */
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Msk      (0x1U << SLIB_MISC_STS_SLIB_PWD_ERR_Pos)
 #define SLIB_MISC_STS_SLIB_PWD_ERR          SLIB_MISC_STS_SLIB_PWD_ERR_Msk          /*!< Security library password error */
@@ -1722,54 +1724,54 @@ typedef struct
 #define SLIB_MISC_STS_SLIB_ULKF_Msk         (0x1U << SLIB_MISC_STS_SLIB_ULKF_Pos)   /*!< 0x00000004 */
 #define SLIB_MISC_STS_SLIB_ULKF             SLIB_MISC_STS_SLIB_ULKF_Msk             /*!< Security library unlock flag */
 
-/****************  Bit definition for FLASH_CRC_ADDR register *****************/
+/****************  Bit definition for FLASH_CRC_ADDR register  ****************/
 #define FLASH_CRC_ADDR_CRC_ADDR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_ADDR_CRC_ADDR_Msk         (0xFFFFFFFFU << FLASH_CRC_ADDR_CRC_ADDR_Pos)
 #define FLASH_CRC_ADDR_CRC_ADDR             FLASH_CRC_ADDR_CRC_ADDR_Msk             /*!< CRC address */
 
-/****************  Bit definition for FLASH_CRC_CTRL register *****************/
+/****************  Bit definition for FLASH_CRC_CTRL register  ****************/
 #define FLASH_CRC_CTRL_CRC_SN_Pos           (0U)
 #define FLASH_CRC_CTRL_CRC_SN_Msk           (0xFFFFU << FLASH_CRC_CTRL_CRC_SN_Pos)  /*!< 0x0000FFFF */
-#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC page number */
+#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC sector number */
 #define FLASH_CRC_CTRL_CRC_STRT_Pos         (16U)
 #define FLASH_CRC_CTRL_CRC_STRT_Msk         (0x1U << FLASH_CRC_CTRL_CRC_STRT_Pos)   /*!< 0x00010000 */
 #define FLASH_CRC_CTRL_CRC_STRT             FLASH_CRC_CTRL_CRC_STRT_Msk             /*!< CRC start */
 
-/****************  Bit definition for FLASH_CRC_CHKR register *****************/
+/****************  Bit definition for FLASH_CRC_CHKR register  ****************/
 #define FLASH_CRC_CHKR_CRC_CHKR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_CHKR_CRC_CHKR_Msk         (0xFFFFFFFFU << FLASH_CRC_CHKR_CRC_CHKR_Pos)
 #define FLASH_CRC_CHKR_CRC_CHKR             FLASH_CRC_CHKR_CRC_CHKR_Msk             /*!< CRC check result */
 
-/*****************  Bit definition for SLIB_SET_PWD register ******************/
+/*****************  Bit definition for SLIB_SET_PWD register  *****************/
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Msk      (0xFFFFFFFFU << SLIB_SET_PWD_SLIB_PSET_VAL_Pos)
 #define SLIB_SET_PWD_SLIB_PSET_VAL          SLIB_SET_PWD_SLIB_PSET_VAL_Msk          /*!< Security library password setting value */
 
-/****************  Bit definition for SLIB_SET_RANGE register *****************/
+/****************  Bit definition for SLIB_SET_RANGE register  ****************/
 #define SLIB_SET_RANGE_SLIB_SS_SET_Pos      (0U)                                    /*!< 0x000007FF */
 #define SLIB_SET_RANGE_SLIB_SS_SET_Msk      (0x7FFU << SLIB_SET_RANGE_SLIB_SS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start page setting */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Msk     (0x3FF8U << SLIB_SET_RANGE_SLIB_ISS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ISS_SET         SLIB_SET_RANGE_SLIB_ISS_SET_Msk         /*!< Security library instruction start page setting */
+#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start sector setting */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_DSS_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_DSS_SET         SLIB_SET_RANGE_SLIB_DSS_SET_Msk         /*!< Security library data start sector setting */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Pos      (22U)                                   /*!< 0xFFC00000 */
-#define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0xFFCU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end page setting */
+#define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0x3FFU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end sector setting */
 
-/******************  Bit definition for EM_SLIB_SET register ******************/
+/*****************  Bit definition for EM_SLIB_SET register  ******************/
 #define EM_SLIB_SET_EM_SLIB_SET_Pos         (0U)                                    /*!< 0x0000FFFF */
 #define EM_SLIB_SET_EM_SLIB_SET_Msk         (0xFFFFU << EM_SLIB_SET_EM_SLIB_SET_Pos)
 #define EM_SLIB_SET_EM_SLIB_SET             EM_SLIB_SET_EM_SLIB_SET_Msk             /*!< Extension memory sLib setting */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_ISS_SET_Pos)
-#define EM_SLIB_SET_EM_SLIB_ISS_SET         EM_SLIB_SET_EM_SLIB_ISS_SET_Msk         /*!< Extension memory sLib instruction start page setting */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_DSS_SET_Pos)
+#define EM_SLIB_SET_EM_SLIB_DSS_SET         EM_SLIB_SET_EM_SLIB_DSS_SET_Msk         /*!< Extension memory sLib data start sector setting */
 
-/*****************  Bit definition for BTM_MODE_SET register ******************/
+/*****************  Bit definition for BTM_MODE_SET register  *****************/
 #define BTM_MODE_SET_BTM_MODE_SET_Pos       (0U)                                    /*!< 0x000000FF */
 #define BTM_MODE_SET_BTM_MODE_SET_Msk       (0xFFU << BTM_MODE_SET_BTM_MODE_SET_Pos)
 #define BTM_MODE_SET_BTM_MODE_SET           BTM_MODE_SET_BTM_MODE_SET_Msk           /*!< Boot memory mode setting */
 
-/*****************  Bit definition for SLIB_UNLOCK register ******************/
+/*****************  Bit definition for SLIB_UNLOCK register  ******************/
 #define SLIB_UNLOCK_SLIB_UKVAL_Pos          (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_UNLOCK_SLIB_UKVAL_Msk          (0xFFFFFFFFU << SLIB_UNLOCK_SLIB_UKVAL_Pos)
 #define SLIB_UNLOCK_SLIB_UKVAL              SLIB_UNLOCK_SLIB_UKVAL_Msk              /*!< Security library unlock key value */
@@ -2142,7 +2144,7 @@ typedef struct
 #define GPIO_CFGHR_IOFC15_0                 (0x1U << GPIO_CFGHR_IOFC15_Pos)         /*!< 0x40000000 */
 #define GPIO_CFGHR_IOFC15_1                 (0x2U << GPIO_CFGHR_IOFC15_Pos)         /*!< 0x80000000 */
 
-/*!<****************  Bit definition for GPIO_IDT register  *******************/
+/*******************  Bit definition for GPIO_IDT register  *******************/
 #define GPIO_IDT_IDT0_Pos                   (0U)
 #define GPIO_IDT_IDT0_Msk                   (0x1U << GPIO_IDT_IDT0_Pos)             /*!< 0x00000001 */
 #define GPIO_IDT_IDT0                       GPIO_IDT_IDT0_Msk                       /*!< GPIO x input data, pin 0 */
@@ -2548,7 +2550,7 @@ typedef struct
 #define IOMUX_REMAP_TMR1_MUX_Msk            (0x3U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x000000C0 */
 #define IOMUX_REMAP_TMR1_MUX                IOMUX_REMAP_TMR1_MUX_Msk                /*!< TMR1_MUX[1:0] bits (TMR1 IO multiplexing) */
 #define IOMUX_REMAP_TMR1_MUX_0              (0x1U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x00000040 */
-#define IOMUX_REMAP_TMR1_MUX_1              (0x2U << IOMUX_REMAP_TMR1_MUX_Pos       /*!< 0x00000080 */
+#define IOMUX_REMAP_TMR1_MUX_1              (0x2U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x00000080 */
 
 #define IOMUX_REMAP_TMR1_MUX_MUX0           0x00000000U                             /*!< EXT/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BRK/PB12, CH1C/PB13, CH2C/PB14, CH3C/PB15 */
 #define IOMUX_REMAP_TMR1_MUX_MUX1_Pos       (6U)
@@ -2605,18 +2607,18 @@ typedef struct
 #define IOMUX_REMAP_PD01_MUX                IOMUX_REMAP_PD01_MUX_Msk                /*!< PD0/PD1 mapped on HEXT_IN/HEXT_OUT */
 #define IOMUX_REMAP_TMR5CH4_MUX_Pos         (16U)
 #define IOMUX_REMAP_TMR5CH4_MUX_Msk         (0x1U << IOMUX_REMAP_TMR5CH4_MUX_Pos)   /*!< 0x00010000 */
-#define IOMUX_REMAP_TMR5CH4_MUX             IOMUX_REMAP_TMR5CH4_MUX_Msk             /*!< TMR5 channel 4 multiplexing */
+#define IOMUX_REMAP_TMR5CH4_MUX             IOMUX_REMAP_TMR5CH4_MUX_Msk             /*!< TMR5_CH4 multiplexing */
 #define IOMUX_REMAP_ADC1_ETP_MUX_Pos        (17U)
 #define IOMUX_REMAP_ADC1_ETP_MUX_Msk        (0x1U << IOMUX_REMAP_ADC1_ETP_MUX_Pos)  /*!< 0x00020000 */
 #define IOMUX_REMAP_ADC1_ETP_MUX            IOMUX_REMAP_ADC1_ETP_MUX_Msk            /*!< ADC1 external trigger preempted conversion multiplexing */
 #define IOMUX_REMAP_ADC1_ETO_MUX_Pos        (18U)
 #define IOMUX_REMAP_ADC1_ETO_MUX_Msk        (0x1U << IOMUX_REMAP_ADC1_ETO_MUX_Pos)  /*!< 0x00040000 */
-#define IOMUX_REMAP_ADC1_ETO_MUX            IOMUX_REMAP_ADC1_ETO_MUX_Msk            /*!< ADC1 external trigger regular conversion mutiplexing */
+#define IOMUX_REMAP_ADC1_ETO_MUX            IOMUX_REMAP_ADC1_ETO_MUX_Msk            /*!< ADC1 external trigger ordinary conversion multiplexing */
 
 /*!< SWJTAG_MUX configuration */
 #define IOMUX_REMAP_SWJTAG_MUX_Pos          (24U)
 #define IOMUX_REMAP_SWJTAG_MUX_Msk          (0x7U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x07000000 */
-#define IOMUX_REMAP_SWJTAG_MUX              IOMUX_REMAP_SWJTAG_MUX_Msk              /*!< SWJTAG_MUX[2:0] bits (SWD JTAG mutiplexing) */
+#define IOMUX_REMAP_SWJTAG_MUX              IOMUX_REMAP_SWJTAG_MUX_Msk              /*!< SWJTAG_MUX[2:0] bits (SWD_JTAG IO multiplexing) */
 #define IOMUX_REMAP_SWJTAG_MUX_0            (0x1U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x01000000 */
 #define IOMUX_REMAP_SWJTAG_MUX_1            (0x2U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x02000000 */
 #define IOMUX_REMAP_SWJTAG_MUX_2            (0x4U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x04000000 */
@@ -2729,7 +2731,7 @@ typedef struct
 #define IOMUX_EXINTC2_EXINT4_GPF_Msk        (0x1U << IOMUX_EXINTC2_EXINT4_GPF_Pos)  /*!< 0x00000004 */
 #define IOMUX_EXINTC2_EXINT4_GPF            IOMUX_EXINTC2_EXINT4_GPF_Msk            /*!< GPIOF pin 4 */
 
-/* EXINT5 configuration */
+/*!< EXINT5 configuration */
 #define IOMUX_EXINTC2_EXINT5_Pos            (4U)
 #define IOMUX_EXINTC2_EXINT5_Msk            (0xFU << IOMUX_EXINTC2_EXINT5_Pos)      /*!< 0x000000F0 */
 #define IOMUX_EXINTC2_EXINT5                IOMUX_EXINTC2_EXINT5_Msk                /*!< EXINT5[3:0] bits (EXINT5 input source configuration) */
@@ -2864,7 +2866,7 @@ typedef struct
 #define IOMUX_EXINTC3_EXINT11_GPF           IOMUX_EXINTC3_EXINT11_GPF_Msk           /*!< GPIOF pin 11 */
 
 /****************  Bit definition for IOMUX_EXINTC4 register  *****************/
-/* EXINT12 configuration */
+/*!< EXINT12 configuration */
 #define IOMUX_EXINTC4_EXINT12_Pos           (0U)
 #define IOMUX_EXINTC4_EXINT12_Msk           (0xFU << IOMUX_EXINTC4_EXINT12_Pos)     /*!< 0x0000000F */
 #define IOMUX_EXINTC4_EXINT12               IOMUX_EXINTC4_EXINT12_Msk               /*!< EXINT12[3:0] bits (EXINT12 input source configuration) */
@@ -2883,7 +2885,7 @@ typedef struct
 #define IOMUX_EXINTC4_EXINT12_GPF_Msk       (0x1U << IOMUX_EXINTC4_EXINT12_GPF_Pos) /*!< 0x00000004 */
 #define IOMUX_EXINTC4_EXINT12_GPF           IOMUX_EXINTC4_EXINT12_GPF_Msk           /*!< GPIOF pin 12 */
 
-/* EXINT13 configuration */
+/*!< EXINT13 configuration */
 #define IOMUX_EXINTC4_EXINT13_Pos           (4U)
 #define IOMUX_EXINTC4_EXINT13_Msk           (0xFU << IOMUX_EXINTC4_EXINT13_Pos)     /*!< 0x000000F0 */
 #define IOMUX_EXINTC4_EXINT13               IOMUX_EXINTC4_EXINT13_Msk               /*!< EXINT13[3:0] bits (EXINT13 input source configuration) */
@@ -3046,9 +3048,12 @@ typedef struct
 #define IOMUX_REMAP4_TMR3_GMUX_3            (0x8U << IOMUX_REMAP4_TMR3_GMUX_Pos)    /*!< 0x00000800 */
 
 #define IOMUX_REMAP4_TMR3_GMUX_MUX0         0x00000000U                             /*!< CH1/PA6, CH2/PA7, CH3/PB0, CH4/PB1 */
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1_Pos     (8U)                                    /*!< 0x00000100 */
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1_Msk     (0x1U << IOMUX_REMAP4_TMR3_GMUX_MUX1_Pos)
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1         IOMUX_REMAP4_TMR3_GMUX_MUX1_Msk         /*!< CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2_Pos     (9U)                                    /*!< 0x00000200 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2_Msk     (0x1U << IOMUX_REMAP4_TMR3_GMUX_MUX2_Pos)
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2         IOMUX_REMAP4_TMR3_GMUX_MUX2_Msk         /*!< CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3_Pos     (8U)                                    /*!< 0x00000300 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3_Msk     (0x3U << IOMUX_REMAP4_TMR3_GMUX_MUX3_Pos)
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3         IOMUX_REMAP4_TMR3_GMUX_MUX3_Msk         /*!< CH1/PC6, CH2/PC7, CH3/PC8, CH4/PC9 */
 
 /*!< TMR5_GMUX configuration */
 #define IOMUX_REMAP4_TMR5_GMUX_Pos          (16U)
@@ -3065,7 +3070,7 @@ typedef struct
 
 #define IOMUX_REMAP4_TMR5CH4_GMUX_Pos       (19U)
 #define IOMUX_REMAP4_TMR5CH4_GMUX_Msk       (0x1U << IOMUX_REMAP4_TMR5CH4_GMUX_Pos) /*!< 0x00080000 */
-#define IOMUX_REMAP4_TMR5CH4_GMUX           IOMUX_REMAP4_TMR5CH4_GMUX_Msk           /*!< TMR5 channel 4 general multiplexing */
+#define IOMUX_REMAP4_TMR5CH4_GMUX           IOMUX_REMAP4_TMR5CH4_GMUX_Msk           /*!< TMR5_CH4 general multiplexing */
 
 /*****************  Bit definition for IOMUX_REMAP5 register  *****************/
 /*!< I2C1_GMUX configuration */
@@ -3188,15 +3193,15 @@ typedef struct
 /*****************  Bit definition for IOMUX_REMAP7 register  *****************/
 #define IOMUX_REMAP7_ADC1_ETP_GMUX_Pos      (4U)                                    /*!< 0x00000010 */
 #define IOMUX_REMAP7_ADC1_ETP_GMUX_Msk      (0x1U << IOMUX_REMAP7_ADC1_ETP_GMUX_Pos)
-#define IOMUX_REMAP7_ADC1_ETP_GMUX          IOMUX_REMAP7_ADC1_ETP_GMUX_Msk          /*!< ADC1 External trigger preempted conversion general multiplexing */
+#define IOMUX_REMAP7_ADC1_ETP_GMUX          IOMUX_REMAP7_ADC1_ETP_GMUX_Msk          /*!< ADC1 external trigger preempted conversion general multiplexing */
 #define IOMUX_REMAP7_ADC1_ETO_GMUX_Pos      (5U)                                    /*!< 0x00000020 */
 #define IOMUX_REMAP7_ADC1_ETO_GMUX_Msk      (0x1U << IOMUX_REMAP7_ADC1_ETO_GMUX_Pos)
-#define IOMUX_REMAP7_ADC1_ETO_GMUX          IOMUX_REMAP7_ADC1_ETO_GMUX_Msk          /*!< ADC1 external trigger regular conversion general multiplexing */
+#define IOMUX_REMAP7_ADC1_ETO_GMUX          IOMUX_REMAP7_ADC1_ETO_GMUX_Msk          /*!< ADC1 external trigger ordinary conversion general multiplexing */
 
 /*!< SWJTAG_GMUX configuration */
 #define IOMUX_REMAP7_SWJTAG_GMUX_Pos        (16U)
 #define IOMUX_REMAP7_SWJTAG_GMUX_Msk        (0x7U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00070000 */
-#define IOMUX_REMAP7_SWJTAG_GMUX            IOMUX_REMAP7_SWJTAG_GMUX_Msk            /*!< SWJTAG_GMUX[2:0] bits (SWD JTAG IO general mutiplexing) */
+#define IOMUX_REMAP7_SWJTAG_GMUX            IOMUX_REMAP7_SWJTAG_GMUX_Msk            /*!< SWJTAG_GMUX[2:0] bits (SWD_JTAG IO general multiplexing) */
 #define IOMUX_REMAP7_SWJTAG_GMUX_0          (0x1U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00010000 */
 #define IOMUX_REMAP7_SWJTAG_GMUX_1          (0x2U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00020000 */
 #define IOMUX_REMAP7_SWJTAG_GMUX_2          (0x4U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00040000 */
@@ -3354,7 +3359,7 @@ typedef struct
 #define EXINT_INTEN_INTEN22_Msk             (0x1U << EXINT_INTEN_INTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTEN_INTEN22                 EXINT_INTEN_INTEN22_Msk                 /*!< Interrupt enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTEN_INT0                    EXINT_INTEN_INTEN0
 #define EXINT_INTEN_INT1                    EXINT_INTEN_INTEN1
 #define EXINT_INTEN_INT2                    EXINT_INTEN_INTEN2
@@ -3451,7 +3456,7 @@ typedef struct
 #define EXINT_EVTEN_EVTEN22_Msk             (0x1U << EXINT_EVTEN_EVTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_EVTEN_EVTEN22                 EXINT_EVTEN_EVTEN22_Msk                 /*!< Event enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_EVTEN_EVT0                    EXINT_EVTEN_EVTEN0
 #define EXINT_EVTEN_EVT1                    EXINT_EVTEN_EVTEN1
 #define EXINT_EVTEN_EVT2                    EXINT_EVTEN_EVTEN2
@@ -3547,7 +3552,7 @@ typedef struct
 #define EXINT_POLCFG1_RP22_Msk              (0x1U << EXINT_POLCFG1_RP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG1_RP22                  EXINT_POLCFG1_RP22_Msk                  /*!< Rising edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG1_POL0                  EXINT_POLCFG1_RP0
 #define EXINT_POLCFG1_POL1                  EXINT_POLCFG1_RP1
 #define EXINT_POLCFG1_POL2                  EXINT_POLCFG1_RP2
@@ -3643,7 +3648,7 @@ typedef struct
 #define EXINT_POLCFG2_FP22_Msk              (0x1U << EXINT_POLCFG2_FP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG2_FP22                  EXINT_POLCFG2_FP22_Msk                  /*!< Falling edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG2_POL0                  EXINT_POLCFG2_FP0
 #define EXINT_POLCFG2_POL1                  EXINT_POLCFG2_FP1
 #define EXINT_POLCFG2_POL2                  EXINT_POLCFG2_FP2
@@ -3739,7 +3744,7 @@ typedef struct
 #define EXINT_SWTRG_SWT22_Msk               (0x1U << EXINT_SWTRG_SWT22_Pos)         /*!< 0x00400000 */
 #define EXINT_SWTRG_SWT22                   EXINT_SWTRG_SWT22_Msk                   /*!< Software trigger on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_SWTRG_SW0                     EXINT_SWTRG_SWT0
 #define EXINT_SWTRG_SW1                     EXINT_SWTRG_SWT1
 #define EXINT_SWTRG_SW2                     EXINT_SWTRG_SWT2
@@ -3835,7 +3840,7 @@ typedef struct
 #define EXINT_INTSTS_LINE22_Msk             (0x1U << EXINT_INTSTS_LINE22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTSTS_LINE22                 EXINT_INTSTS_LINE22_Msk                 /*!< Status bit for line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTSTS_INT0                   EXINT_INTSTS_LINE0
 #define EXINT_INTSTS_INT1                   EXINT_INTSTS_LINE1
 #define EXINT_INTSTS_INT2                   EXINT_INTSTS_LINE2
@@ -4285,8 +4290,8 @@ typedef struct
 
 /******************  Bit definition for I2C_OADDR1 register  ******************/
 /*!< ADDR1 configuration */
-#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface Address */
-#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface Address */
+#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface address */
+#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface address */
 
 #define I2C_OADDR1_ADDR1_0_Pos              (0U)
 #define I2C_OADDR1_ADDR1_0_Msk              (0x1U << I2C_OADDR1_ADDR1_0_Pos)        /*!< 0x00000001 */
@@ -4649,7 +4654,7 @@ typedef struct
 #define SPI_CTRL1_NTC                       SPI_CTRL1_NTC_Msk                       /*!< Transmit CRC next */
 #define SPI_CTRL1_CCEN_Pos                  (13U)
 #define SPI_CTRL1_CCEN_Msk                  (0x1U << SPI_CTRL1_CCEN_Pos)            /*!< 0x00002000 */
-#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< RC calculation enable */
+#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< CRC calculation enable */
 #define SPI_CTRL1_SLBTD_Pos                 (14U)
 #define SPI_CTRL1_SLBTD_Msk                 (0x1U << SPI_CTRL1_SLBTD_Pos)           /*!< 0x00004000 */
 #define SPI_CTRL1_SLBTD                     SPI_CTRL1_SLBTD_Msk                     /*!< Single line bidirectional half-duplex transmission direction */
@@ -4711,7 +4716,7 @@ typedef struct
 #define SPI_DT_DT_Msk                       (0xFFFFU << SPI_DT_DT_Pos)              /*!< 0x0000FFFF */
 #define SPI_DT_DT                           SPI_DT_DT_Msk                           /*!< Data value */
 
-/*******************  Bit definition for SPI_CPOLY register  ******************/
+/******************  Bit definition for SPI_CPOLY register  *******************/
 #define SPI_CPOLY_CPOLY_Pos                 (0U)
 #define SPI_CPOLY_CPOLY_Msk                 (0xFFFFU << SPI_CPOLY_CPOLY_Pos)        /*!< 0x0000FFFF */
 #define SPI_CPOLY_CPOLY                     SPI_CPOLY_CPOLY_Msk                     /*!< CRC polynomial */
@@ -5934,12 +5939,12 @@ typedef struct
 #define ADC_PCDTO4_PCDTO4_Msk               (0xFFFU << ADC_PCDTO4_PCDTO4_Pos)       /*!< 0x00000FFF */
 #define ADC_PCDTO4_PCDTO4                   ADC_PCDTO4_PCDTO4_Msk                   /*!< Data offset for Preempted channel 4 */
 
-/*******************  Bit definition for ADC_VMHB register  ********************/
+/*******************  Bit definition for ADC_VMHB register  *******************/
 #define ADC_VMHB_VMHB_Pos                   (0U)
 #define ADC_VMHB_VMHB_Msk                   (0xFFFU << ADC_VMHB_VMHB_Pos)           /*!< 0x00000FFF */
 #define ADC_VMHB_VMHB                       ADC_VMHB_VMHB_Msk                       /*!< Voltage monitoring high boundary */
 
-/*******************  Bit definition for ADC_VMLB register  ********************/
+/*******************  Bit definition for ADC_VMLB register  *******************/
 #define ADC_VMLB_VMLB_Pos                   (0U)
 #define ADC_VMLB_VMLB_Msk                   (0xFFFU << ADC_VMLB_VMLB_Pos)           /*!< 0x00000FFF */
 #define ADC_VMLB_VMLB                       ADC_VMLB_VMLB_Msk                       /*!< Voltage monitoring low boundary */
@@ -6307,7 +6312,7 @@ typedef struct
 #define CAN_TSTS_TMNR_Msk                   (0x3U << CAN_TSTS_TMNR_Pos)             /*!< 0x03000000 */
 #define CAN_TSTS_TMNR                       CAN_TSTS_TMNR_Msk                       /*!< TMNR[1:0] bits (Transmit mailbox number record) */
 
-/*!< TMEF congiguration */
+/*!< TMEF configuration */
 #define CAN_TSTS_TMEF_Pos                   (26U)
 #define CAN_TSTS_TMEF_Msk                   (0x7U << CAN_TSTS_TMEF_Pos)             /*!< 0x1C000000 */
 #define CAN_TSTS_TMEF                       CAN_TSTS_TMEF_Msk                       /*!< TMEF[2:0] bits (Transmit mailbox empty flag) */
@@ -6321,7 +6326,7 @@ typedef struct
 #define CAN_TSTS_TM2EF_Msk                  (0x1U << CAN_TSTS_TM2EF_Pos)            /*!< 0x10000000 */
 #define CAN_TSTS_TM2EF                      CAN_TSTS_TM2EF_Msk                      /*!< Transmit mailbox 2 empty flag */
 
-/*!< TMLPF congiguration */
+/*!< TMLPF configuration */
 #define CAN_TSTS_TMLPF_Pos                  (29U)
 #define CAN_TSTS_TMLPF_Msk                  (0x7U << CAN_TSTS_TMLPF_Pos)            /*!< 0xE0000000 */
 #define CAN_TSTS_TMLPF                      CAN_TSTS_TMLPF_Msk                      /*!< TMLPF[2:0] bits (Transmit mailbox lowest priority flag) */
@@ -6418,7 +6423,7 @@ typedef struct
 #define CAN_ESTS_BOF_Msk                    (0x1U << CAN_ESTS_BOF_Pos)              /*!< 0x00000004 */
 #define CAN_ESTS_BOF                        CAN_ESTS_BOF_Msk                        /*!< Bus-off flag */
 
-/*!< ETR congiguration */
+/*!< ETR configuration */
 #define CAN_ESTS_ETR_Pos                    (4U)
 #define CAN_ESTS_ETR_Msk                    (0x7U << CAN_ESTS_ETR_Pos)              /*!< 0x00000070 */
 #define CAN_ESTS_ETR                        CAN_ESTS_ETR_Msk                        /*!< ETR[2:0] bits (Error type record) */
@@ -6438,7 +6443,7 @@ typedef struct
 #define CAN_BTMG_BRDIV_Msk                  (0xFFFU << CAN_BTMG_BRDIV_Pos)          /*!< 0x00000FFF */
 #define CAN_BTMG_BRDIV                      CAN_BTMG_BRDIV_Msk                      /*!< Baud rate division */
 
-/*!< BTS1 congiguration */
+/*!< BTS1 configuration */
 #define CAN_BTMG_BTS1_Pos                   (16U)
 #define CAN_BTMG_BTS1_Msk                   (0xFU << CAN_BTMG_BTS1_Pos)             /*!< 0x000F0000 */
 #define CAN_BTMG_BTS1                       CAN_BTMG_BTS1_Msk                       /*!< BTS1[3:0] bits (Bit time segment 1) */
@@ -6447,7 +6452,7 @@ typedef struct
 #define CAN_BTMG_BTS1_2                     (0x4U << CAN_BTMG_BTS1_Pos)             /*!< 0x00040000 */
 #define CAN_BTMG_BTS1_3                     (0x8U << CAN_BTMG_BTS1_Pos)             /*!< 0x00080000 */
 
-/*!< BTS2 congiguration */
+/*!< BTS2 configuration */
 #define CAN_BTMG_BTS2_Pos                   (20U)
 #define CAN_BTMG_BTS2_Msk                   (0x7U << CAN_BTMG_BTS2_Pos)             /*!< 0x00700000 */
 #define CAN_BTMG_BTS2                       CAN_BTMG_BTS2_Msk                       /*!< BTS2[2:0] bits (Bit time segment 2) */
@@ -6455,7 +6460,7 @@ typedef struct
 #define CAN_BTMG_BTS2_1                     (0x2U << CAN_BTMG_BTS2_Pos)             /*!< 0x00200000 */
 #define CAN_BTMG_BTS2_2                     (0x4U << CAN_BTMG_BTS2_Pos)             /*!< 0x00400000 */
 
-/*!< RSAW congiguration */
+/*!< RSAW configuration */
 #define CAN_BTMG_RSAW_Pos                   (24U)
 #define CAN_BTMG_RSAW_Msk                   (0x3U << CAN_BTMG_RSAW_Pos)             /*!< 0x03000000 */
 #define CAN_BTMG_RSAW                       CAN_BTMG_RSAW_Msk                       /*!< RSAW[1:0] bits (Resynchronization width) */
@@ -9689,7 +9694,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for SDIO_PWRCTRL register  *****************/
-/*!< PS congiguration */
+/*!< PS configuration */
 #define SDIO_PWRCTRL_PS_Pos                 (0U)
 #define SDIO_PWRCTRL_PS_Msk                 (0x3U << SDIO_PWRCTRL_PS_Pos)           /*!< 0x00000003 */
 #define SDIO_PWRCTRL_PS                     SDIO_PWRCTRL_PS_Msk                     /*!< PS[1:0] bits (Power switch) */
@@ -9709,7 +9714,7 @@ typedef struct
 #define SDIO_CLKCTRL_BYPSEN_Msk             (0x1U << SDIO_CLKCTRL_BYPSEN_Pos)       /*!< 0x00000400 */
 #define SDIO_CLKCTRL_BYPSEN                 SDIO_CLKCTRL_BYPSEN_Msk                 /*!< Clock divider bypass enable bit */
 
-/*!< BUSWS congiguration */
+/*!< BUSWS configuration */
 #define SDIO_CLKCTRL_BUSWS_Pos              (11U)
 #define SDIO_CLKCTRL_BUSWS_Msk              (0x3U << SDIO_CLKCTRL_BUSWS_Pos)        /*!< 0x00001800 */
 #define SDIO_CLKCTRL_BUSWS                  SDIO_CLKCTRL_BUSWS_Msk                  /*!< BUSWS[1:0] bits (Bus width selection) */
@@ -9733,7 +9738,7 @@ typedef struct
 #define SDIO_CMD_CMDIDX_Msk                 (0x3FU << SDIO_CMD_CMDIDX_Pos)          /*!< 0x0000003F */
 #define SDIO_CMD_CMDIDX                     SDIO_CMD_CMDIDX_Msk                     /*!< Command index */
 
-/*!< RSPWT congiguration */
+/*!< RSPWT configuration */
 #define SDIO_CMD_RSPWT_Pos                  (6U)
 #define SDIO_CMD_RSPWT_Msk                  (0x3U << SDIO_CMD_RSPWT_Pos)            /*!< 0x000000C0 */
 #define SDIO_CMD_RSPWT                      SDIO_CMD_RSPWT_Msk                      /*!< RSPWT[1:0] bits (Wait for response bits) */
@@ -9802,7 +9807,7 @@ typedef struct
 #define SDIO_DTCTRL_DMAEN_Msk               (0x1U << SDIO_DTCTRL_DMAEN_Pos)         /*!< 0x00000008 */
 #define SDIO_DTCTRL_DMAEN                   SDIO_DTCTRL_DMAEN_Msk                   /*!< DMA enable bit */
 
-/*!< BLKSIZE congiguration */
+/*!< BLKSIZE configuration */
 #define SDIO_DTCTRL_BLKSIZE_Pos             (4U)
 #define SDIO_DTCTRL_BLKSIZE_Msk             (0xFU << SDIO_DTCTRL_BLKSIZE_Pos)       /*!< 0x000000F0 */
 #define SDIO_DTCTRL_BLKSIZE                 SDIO_DTCTRL_BLKSIZE_Msk                 /*!< BLKSIZE[3:0] bits (Data block size) */
@@ -10009,7 +10014,7 @@ typedef struct
 #define SDIO_INTEN_IOIFIEN_Msk              (0x1U << SDIO_INTEN_IOIFIEN_Pos)        /*!< 0x00400000 */
 #define SDIO_INTEN_IOIFIEN                  SDIO_INTEN_IOIFIEN_Msk                  /*!< SD I/O mode received interrupt enable */
 
-/*****************  Bit definition for SDIO_BUFCNTR register  ******************/
+/*****************  Bit definition for SDIO_BUFCNTR register  *****************/
 #define SDIO_BUFCNTR_CNT_Pos                (0U)
 #define SDIO_BUFCNTR_CNT_Msk                (0xFFFFFFU << SDIO_BUFCNTR_CNT_Pos)     /*!< 0x00FFFFFF */
 #define SDIO_BUFCNTR_CNT                    SDIO_BUFCNTR_CNT_Msk                    /*!< Number of words to be written to or read from the BUF */
@@ -10021,7 +10026,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Comparator (COMP)                              */
+/*                              Comparator (CMP)                              */
 /*                                                                            */
 /******************************************************************************/
 
@@ -10036,7 +10041,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1SSEL_Msk           (0x1U << CMP_CTRLSTS1_CMP1SSEL_Pos)     /*!< 0x00000004 */
 #define CMP_CTRLSTS1_CMP1SSEL               CMP_CTRLSTS1_CMP1SSEL_Msk               /*!< Comparator 1 speed selection */
 
-/*!< CMP1INVSEL congiguration */
+/*!< CMP1INVSEL configuration */
 #define CMP_CTRLSTS1_CMP1INVSEL_Pos         (4U)
 #define CMP_CTRLSTS1_CMP1INVSEL_Msk         (0x7U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000070 */
 #define CMP_CTRLSTS1_CMP1INVSEL             CMP_CTRLSTS1_CMP1INVSEL_Msk             /*!< CMP1INVSEL[2:0] bits (Comparator 1 inverting selection) */
@@ -10044,7 +10049,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1INVSEL_1           (0x2U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000020 */
 #define CMP_CTRLSTS1_CMP1INVSEL_2           (0x4U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000040 */
 
-/*!< CMP1TAG congiguration */
+/*!< CMP1TAG configuration */
 #define CMP_CTRLSTS1_CMP1TAG_Pos            (8U)
 #define CMP_CTRLSTS1_CMP1TAG_Msk            (0x7U << CMP_CTRLSTS1_CMP1TAG_Pos)      /*!< 0x00000700 */
 #define CMP_CTRLSTS1_CMP1TAG                CMP_CTRLSTS1_CMP1TAG_Msk                /*!< CMP1TAG[2:0] bits (Comparator 1 output target) */
@@ -10056,7 +10061,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1P_Msk              (0x1U << CMP_CTRLSTS1_CMP1P_Pos)        /*!< 0x00000800 */
 #define CMP_CTRLSTS1_CMP1P                  CMP_CTRLSTS1_CMP1P_Msk                  /*!< Comparator 1 polarity */
 
-/*!< CMP1HYST congiguration */
+/*!< CMP1HYST configuration */
 #define CMP_CTRLSTS1_CMP1HYST_Pos           (12U)
 #define CMP_CTRLSTS1_CMP1HYST_Msk           (0x3U << CMP_CTRLSTS1_CMP1HYST_Pos)     /*!< 0x00003000 */
 #define CMP_CTRLSTS1_CMP1HYST               CMP_CTRLSTS1_CMP1HYST_Msk               /*!< CMP1HYST[1:0] bits (Comparator 1 hysteresis) */
@@ -10076,7 +10081,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2SSEL_Msk           (0x1U << CMP_CTRLSTS1_CMP2SSEL_Pos)     /*!< 0x00040000 */
 #define CMP_CTRLSTS1_CMP2SSEL               CMP_CTRLSTS1_CMP2SSEL_Msk               /*!< Comparator 2 speed selection */
 
-/*!< CMP2INVSEL congiguration */
+/*!< CMP2INVSEL configuration */
 #define CMP_CTRLSTS1_CMP2INVSEL_Pos         (20U)
 #define CMP_CTRLSTS1_CMP2INVSEL_Msk         (0x7U << CMP_CTRLSTS1_CMP2INVSEL_Pos)   /*!< 0x00700000 */
 #define CMP_CTRLSTS1_CMP2INVSEL             CMP_CTRLSTS1_CMP2INVSEL_Msk             /*!< CMP2INVSEL[2:0] bits (Comparator 2 inverting selection) */
@@ -10088,7 +10093,7 @@ typedef struct
 #define CMP_CTRLSTS1_DCMPEN_Msk             (0x1U << CMP_CTRLSTS1_DCMPEN_Pos)       /*!< 0x00800000 */
 #define CMP_CTRLSTS1_DCMPEN                 CMP_CTRLSTS1_DCMPEN_Msk                 /*!< Double comparator mode enable */
 
-/*!< CMP2TAG congiguration */
+/*!< CMP2TAG configuration */
 #define CMP_CTRLSTS1_CMP2TAG_Pos            (24U)
 #define CMP_CTRLSTS1_CMP2TAG_Msk            (0x7U << CMP_CTRLSTS1_CMP2TAG_Pos)      /*!< 0x07000000 */
 #define CMP_CTRLSTS1_CMP2TAG                CMP_CTRLSTS1_CMP2TAG_Msk                /*!< CMP2TAG[2:0] bits (Comparator 2 output target) */
@@ -10100,7 +10105,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2P_Msk              (0x1U << CMP_CTRLSTS1_CMP2P_Pos)        /*!< 0x08000000 */
 #define CMP_CTRLSTS1_CMP2P                  CMP_CTRLSTS1_CMP2P_Msk                  /*!< Comparator 2 polarity */
 
-/*!< CMP2HYST congiguration */
+/*!< CMP2HYST configuration */
 #define CMP_CTRLSTS1_CMP2HYST_Pos           (28U)
 #define CMP_CTRLSTS1_CMP2HYST_Msk           (0x3U << CMP_CTRLSTS1_CMP2HYST_Pos)     /*!< 0x30000000 */
 #define CMP_CTRLSTS1_CMP2HYST               CMP_CTRLSTS1_CMP2HYST_Msk               /*!< CMP2HYST[1:0] bits (Comparator 2 hysteresis) */
@@ -10115,14 +10120,14 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2WP                 CMP_CTRLSTS1_CMP2WP_Msk                 /*!< Comparator 2 write protect */
 
 /*****************  Bit definition for CMP_CTRLSTS2 register  *****************/
-/*!< CMP1NINVSEL congiguration */
+/*!< CMP1NINVSEL configuration */
 #define CMP_CTRLSTS2_CMP1NINVSEL_Pos        (0U)
 #define CMP_CTRLSTS2_CMP1NINVSEL_Msk        (0x3U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000003 */
 #define CMP_CTRLSTS2_CMP1NINVSEL            CMP_CTRLSTS2_CMP1NINVSEL_Msk            /*!< CMP1NINVSEL[1:0] bits (Comparator 1 non-inverting input selection) */
 #define CMP_CTRLSTS2_CMP1NINVSEL_0          (0x1U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000001 */
 #define CMP_CTRLSTS2_CMP1NINVSEL_1          (0x2U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000002 */
 
-/*!< CMP2NINVSEL congiguration */
+/*!< CMP2NINVSEL configuration */
 #define CMP_CTRLSTS2_CMP2NINVSEL_Pos        (16U)
 #define CMP_CTRLSTS2_CMP2NINVSEL_Msk        (0x3U << CMP_CTRLSTS2_CMP2NINVSEL_Pos)  /*!< 0x00030000 */
 #define CMP_CTRLSTS2_CMP2NINVSEL            CMP_CTRLSTS2_CMP2NINVSEL_Msk            /*!< CMP2NINVSEL[1:0] bits (Comparator 2 non-inverting input selection) */
@@ -10136,7 +10141,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for DEBUG_IDCODE register  *****************/
-/*!< PID congiguration */
+/*!< PID configuration */
 #define DEBUG_IDCODE_PID_Pos                (0U)
 #define DEBUG_IDCODE_PID_Msk                (0xFFFFFFFFU << DEBUG_IDCODE_PID_Pos)   /*!< 0xFFFFFFFF */
 #define DEBUG_IDCODE_PID                    DEBUG_IDCODE_PID_Msk                    /*!< PID[31:0] bits (PID information) */
@@ -10187,7 +10192,7 @@ typedef struct
 #define DEBUG_CTRL_TRACE_IOEN_Msk           (0x1U << DEBUG_CTRL_TRACE_IOEN_Pos)     /*!< 0x00000020 */
 #define DEBUG_CTRL_TRACE_IOEN               DEBUG_CTRL_TRACE_IOEN_Msk               /*!< Trace pin assignment enable */
 
-/*!< TRACE_MODE congiguration */
+/*!< TRACE_MODE configuration */
 #define DEBUG_CTRL_TRACE_MODE_Pos           (6U)
 #define DEBUG_CTRL_TRACE_MODE_Msk           (0x3U << DEBUG_CTRL_TRACE_MODE_Pos)     /*!< 0x000000C0 */
 #define DEBUG_CTRL_TRACE_MODE               DEBUG_CTRL_TRACE_MODE_Msk               /*!< TRACE_MODE[1:0] bits (Trace pin assignment control) */

--- a/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415rx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F415/at32f415rx.h
@@ -2,8 +2,8 @@
   **************************************************************************
   * @file    at32f415rx.h
   * @author  Artery Technology & HorrorTroll & Zhaqian
-  * @version v2.1.6
-  * @date    13-Dec-2024
+  * @version v2.1.8
+  * @date    24-Nov-2025
   * @brief   AT32F415Rx header file.
   *
   **************************************************************************
@@ -42,11 +42,11 @@
 #endif
 
 /**
-  * @brief CMSIS Device version number V2.1.6
+  * @brief CMSIS Device version number V2.1.8
   */
 #define __AT32F415_LIBRARY_VERSION_MAJOR   (0x02) /*!< [31:24] major version */
 #define __AT32F415_LIBRARY_VERSION_MIDDLE  (0x01) /*!< [23:16] middle version */
-#define __AT32F415_LIBRARY_VERSION_MINOR   (0x06) /*!< [15:8]  minor version */
+#define __AT32F415_LIBRARY_VERSION_MINOR   (0x08) /*!< [15:8]  minor version */
 #define __AT32F415_LIBRARY_VERSION_RC      (0x00) /*!< [7:0]   release candidate */
 #define __AT32F415_LIBRARY_VERSION         ((__AT32F415_LIBRARY_VERSION_MAJOR  << 24)\
                                            |(__AT32F415_LIBRARY_VERSION_MIDDLE << 16)\
@@ -99,7 +99,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                   */
 
 /******  AT32 specific Interrupt Numbers **********************************************************/
-  WWDT_IRQn                   = 0,      /*!< Window WatchDog Timer Interrupt                      */
+  WWDT_IRQn                   = 0,      /*!< Window WATCHDOG Timer Interrupt                      */
   PVM_IRQn                    = 1,      /*!< PVM Interrupt linked to EXINT16                      */
   TAMPER_IRQn                 = 2,      /*!< Tamper Interrupt linked to EXINT21                   */
   ERTC_WKUP_IRQn              = 3,      /*!< ERTC Wake Up Interrupt linked to EXINT22             */
@@ -245,8 +245,8 @@ typedef struct
   __IO uint32_t ESTS;                                /*!< CAN error status register,                   Address offset: 0x018         */
   __IO uint32_t BTMG;                                /*!< CAN bit timing register,                     Address offset: 0x01C         */
   uint32_t      RESERVED0[88];                       /*!< Reserved,                                    Address offset: 0x020 ~ 0x17C */
-  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX Mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
-  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO Mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
+  CAN_TxMailBox_TypeDef sTxMailBox[3];               /*!< CAN TX mailbox registers,                    Address offset: 0x180 ~ 0x1AC */
+  CAN_FIFOMailBox_TypeDef sFIFOMailBox[2];           /*!< CAN FIFO mailbox registers,                  Address offset: 0x1B0 ~ 0x1CC */
   uint32_t      RESERVED1[12];                       /*!< Reserved,                                    Address offset: 0x1D0 ~ 0x1FC */
   __IO uint32_t FCTRL;                               /*!< CAN filter control register,                 Address offset: 0x200         */
   __IO uint32_t FMCFG;                               /*!< CAN filter mode configuration register,      Address offset: 0x204         */
@@ -276,12 +276,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t DT;          /*!< CRC Data register,                           Address offset: 0x00 */
-  __IO uint32_t CDT;         /*!< CRC Common data register,                    Address offset: 0x04 */
-  __IO uint32_t CTRL;        /*!< CRC Control register,                        Address offset: 0x08 */
+  __IO uint32_t DT;          /*!< CRC data register,                           Address offset: 0x00 */
+  __IO uint32_t CDT;         /*!< CRC common data register,                    Address offset: 0x04 */
+  __IO uint32_t CTRL;        /*!< CRC control register,                        Address offset: 0x08 */
   uint32_t      RESERVED;    /*!< Reserved,                                    Address offset: 0x0C */
-  __IO uint32_t IDT;         /*!< CRC Initialization register,                 Address offset: 0x10 */
-  __IO uint32_t POLY;        /*!< CRC Polynomial register,                     Address offset: 0x14 */
+  __IO uint32_t IDT;         /*!< CRC initialization register,                 Address offset: 0x10 */
+  __IO uint32_t POLY;        /*!< CRC polynomial register,                     Address offset: 0x14 */
 } CRC_TypeDef;
 
 /**
@@ -290,23 +290,23 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;            /*!< CRM Clock control register,                  Address offset: 0x00        */
-  __IO uint32_t CFG;             /*!< CRM Clock configuration register,            Address offset: 0x04        */
-  __IO uint32_t CLKINT;          /*!< CRM Clock interrupt register,                Address offset: 0x08        */
+  __IO uint32_t CTRL;            /*!< CRM clock control register,                  Address offset: 0x00        */
+  __IO uint32_t CFG;             /*!< CRM clock configuration register,            Address offset: 0x04        */
+  __IO uint32_t CLKINT;          /*!< CRM clock interrupt register,                Address offset: 0x08        */
   __IO uint32_t APB2RST;         /*!< CRM APB2 peripheral reset register,          Address offset: 0x0C        */
   __IO uint32_t APB1RST;         /*!< CRM APB1 peripheral reset register,          Address offset: 0x10        */
-  __IO uint32_t AHBEN;           /*!< CRM APB peripheral clock enable register,    Address offset: 0x14        */
+  __IO uint32_t AHBEN;           /*!< CRM AHB peripheral clock enable register,    Address offset: 0x14        */
   __IO uint32_t APB2EN;          /*!< CRM APB2 peripheral clock enable register,   Address offset: 0x18        */
   __IO uint32_t APB1EN;          /*!< CRM APB1 peripheral clock enable register,   Address offset: 0x1C        */
-  __IO uint32_t BPDC;            /*!< CRM Battery powered domain control register, Address offset: 0x20        */
-  __IO uint32_t CTRLSTS;         /*!< CRM Control/status register,                 Address offset: 0x24        */
-  __IO uint32_t AHBRST;          /*!< CRM APB peripheral reset register,           Address offset: 0x28        */
+  __IO uint32_t BPDC;            /*!< CRM battery powered domain control register, Address offset: 0x20        */
+  __IO uint32_t CTRLSTS;         /*!< CRM control/status register,                 Address offset: 0x24        */
+  __IO uint32_t AHBRST;          /*!< CRM AHB peripheral reset register,           Address offset: 0x28        */
   __IO uint32_t PLL;             /*!< CRM PLL configuration register,              Address offset: 0x2C        */
-  __IO uint32_t MISC1;           /*!< CRM Additional register 1,                   Address offset: 0x30        */
+  __IO uint32_t MISC1;           /*!< CRM additional register 1,                   Address offset: 0x30        */
   uint32_t      RESERVED0[4];    /*!< Reserved,                                    Address offset: 0x34 ~ 0x40 */
   __IO uint32_t OTG_EXTCTRL;     /*!< CRM OTG_FS extended control register,        Address offset: 0x44        */
   uint32_t      RESERVED1[3];    /*!< Reserved,                                    Address offset: 0x48 - 0x50 */
-  __IO uint32_t MISC2;           /*!< CRM Additional register 2,                   Address offset: 0x54        */
+  __IO uint32_t MISC2;           /*!< CRM additional register 2,                   Address offset: 0x54        */
 } CRM_TypeDef;
 
 /**
@@ -336,8 +336,8 @@ typedef struct
   __IO uint32_t STS;             /*!< DMA interrupt status register,               Address offset: 0x00        */
   __IO uint32_t CLR;             /*!< DMA interrupt flag clear register,           Address offset: 0x04        */
   uint32_t      RESERVED[38];    /*!< Reserved,                                    Address offset: 0x08 ~ 0x9C */
-  __IO uint32_t SRC_SEL0;        /*!< DMA Channel source register 0,               Address offset: 0xA0        */
-  __IO uint32_t SRC_SEL1;        /*!< DMA Channel source register 1,               Address offset: 0xA4        */
+  __IO uint32_t SRC_SEL0;        /*!< DMA channel source register 0,               Address offset: 0xA0        */
+  __IO uint32_t SRC_SEL1;        /*!< DMA channel source register 1,               Address offset: 0xA4        */
 } DMA_TypeDef;
 
 /**
@@ -394,12 +394,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t INTEN;      /*!< EXINT Interrupt enable register,             Address offset: 0x00 */
-  __IO uint32_t EVTEN;      /*!< EXINT Event enable register,                 Address offset: 0x04 */
-  __IO uint32_t POLCFG1;    /*!< EXINT Polarity configuration register 1,     Address offset: 0x08 */
-  __IO uint32_t POLCFG2;    /*!< EXINT Polarity configuration register 2,     Address offset: 0x0C */
-  __IO uint32_t SWTRG;      /*!< EXINT Software trigger register,             Address offset: 0x10 */
-  __IO uint32_t INTSTS;     /*!< EXINT Interrupt status register,             Address offset: 0x14 */
+  __IO uint32_t INTEN;      /*!< EXINT interrupt enable register,             Address offset: 0x00 */
+  __IO uint32_t EVTEN;      /*!< EXINT event enable register,                 Address offset: 0x04 */
+  __IO uint32_t POLCFG1;    /*!< EXINT polarity configuration register 1,     Address offset: 0x08 */
+  __IO uint32_t POLCFG2;    /*!< EXINT polarity configuration register 2,     Address offset: 0x0C */
+  __IO uint32_t SWTRG;      /*!< EXINT software trigger register,             Address offset: 0x10 */
+  __IO uint32_t INTSTS;     /*!< EXINT interrupt status register,             Address offset: 0x14 */
 } EXINT_TypeDef;
 
 /**
@@ -415,7 +415,7 @@ typedef struct
   __IO uint32_t CTRL;              /*!< FLASH control register,                      Address offset: 0x10         */
   __IO uint32_t ADDR;              /*!< FLASH address register,                      Address offset: 0x14         */
   uint32_t      RESERVED0;         /*!< Reserved,                                    Address offset: 0x18         */
-  __IO uint32_t USD;               /*!< FLASH user system data register,             Address offset: 0x1C         */
+  __IO uint32_t FUSD;              /*!< FLASH user system data register,             Address offset: 0x1C         */
   __IO uint32_t EPPS;              /*!< FLASH erase/program protection status reg,   Address offset: 0x20         */
   uint32_t      RESERVED1[20];     /*!< Reserved,                                    Address offset: 0x24 ~ 0x70  */
   __IO uint32_t SLIB_STS0;         /*!< FLASH security library status register 0,    Address offset: 0x74         */
@@ -439,15 +439,15 @@ typedef struct
 
 typedef struct
 {
-  __IO uint16_t FAP;               /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
-  __IO uint16_t SSB;               /*!< USD System configuration byte,               Address offset: 0x1FFF_F802               */
-  __IO uint16_t DATA0;             /*!< USD User data 0,                             Address offset: 0x1FFF_F804               */
-  __IO uint16_t DATA1;             /*!< USD User data 1,                             Address offset: 0x1FFF_F806               */
-  __IO uint16_t EPP0;              /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
-  __IO uint16_t EPP1;              /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
-  __IO uint16_t EPP2;              /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
-  __IO uint16_t EPP3;              /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
-  __IO uint16_t DATA[504];         /*!< USD User data 2 ~ 505,                       Address offset: 0x1FFF_F810 ~ 0x1FFF_FBFC */
+  __IO uint16_t FAP;          /*!< USD memory access protection,                Address offset: 0x1FFF_F800               */
+  __IO uint16_t SSB;          /*!< USD system configuration byte,               Address offset: 0x1FFF_F802               */
+  __IO uint16_t DATA0;        /*!< USD user data 0,                             Address offset: 0x1FFF_F804               */
+  __IO uint16_t DATA1;        /*!< USD user data 1,                             Address offset: 0x1FFF_F806               */
+  __IO uint16_t EPP0;         /*!< USD erase/write protection byte 0,           Address offset: 0x1FFF_F808               */
+  __IO uint16_t EPP1;         /*!< USD erase/write protection byte 1,           Address offset: 0x1FFF_F80A               */
+  __IO uint16_t EPP2;         /*!< USD erase/write protection byte 2,           Address offset: 0x1FFF_F80C               */
+  __IO uint16_t EPP3;         /*!< USD erase/write protection byte 3,           Address offset: 0x1FFF_F80E               */
+  __IO uint16_t DATA[504];    /*!< USD user data 2 ~ 505,                       Address offset: 0x1FFF_F810 ~ 0x1FFF_FBFC */
 } USD_TypeDef;
 
 /**
@@ -471,7 +471,7 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t EVTOUT;       /*!< IOMUX Event output control register,         Address offset: 0x00        */
+  __IO uint32_t EVTOUT;       /*!< IOMUX event output control register,         Address offset: 0x00        */
   __IO uint32_t REMAP;        /*!< IOMUX remap register 1,                      Address offset: 0x04        */
   __IO uint32_t EXINTC[4];    /*!< IOMUX external interrupt config register x,  Address offset: 0x08 ~ 0x14 */
   uint32_t      RESERVED;     /*!< Reserved,                                    Address offset: 0x18        */
@@ -490,14 +490,14 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL1;      /*!< I2C Control register 1,                      Address offset: 0x00 */
-  __IO uint32_t CTRL2;      /*!< I2C Control register 2,                      Address offset: 0x04 */
-  __IO uint32_t OADDR1;     /*!< I2C Own address register 1,                  Address offset: 0x08 */
-  __IO uint32_t OADDR2;     /*!< I2C Own address register 2,                  Address offset: 0x0C */
-  __IO uint32_t DT;         /*!< I2C Data register,                           Address offset: 0x10 */
-  __IO uint32_t STS1;       /*!< I2C Status register 1,                       Address offset: 0x14 */
-  __IO uint32_t STS2;       /*!< I2C Status register 2,                       Address offset: 0x18 */
-  __IO uint32_t CLKCTRL;    /*!< I2C Clock control register,                  Address offset: 0x1C */
+  __IO uint32_t CTRL1;      /*!< I2C control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CTRL2;      /*!< I2C control register 2,                      Address offset: 0x04 */
+  __IO uint32_t OADDR1;     /*!< I2C own address register 1,                  Address offset: 0x08 */
+  __IO uint32_t OADDR2;     /*!< I2C own address register 2,                  Address offset: 0x0C */
+  __IO uint32_t DT;         /*!< I2C data register,                           Address offset: 0x10 */
+  __IO uint32_t STS1;       /*!< I2C status register 1,                       Address offset: 0x14 */
+  __IO uint32_t STS2;       /*!< I2C status register 2,                       Address offset: 0x18 */
+  __IO uint32_t CLKCTRL;    /*!< I2C clock control register,                  Address offset: 0x1C */
   __IO uint32_t TMRISE;     /*!< I2C timer rise time register,                Address offset: 0x20 */
 } I2C_TypeDef;
 
@@ -507,8 +507,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;       /*!< PWC Power control register,                  Address offset: 0x00 */
-  __IO uint32_t CTRLSTS;    /*!< PWC Power control/status register,           Address offset: 0x04 */
+  __IO uint32_t CTRL;       /*!< PWC power control register,                  Address offset: 0x00 */
+  __IO uint32_t CTRLSTS;    /*!< PWC power control/status register,           Address offset: 0x04 */
 } PWC_TypeDef;
 
 /**
@@ -579,7 +579,7 @@ typedef struct
   __IO uint32_t C2DT;       /*!< TMR channel 2 data register,                 Address offset: 0x38 */
   __IO uint32_t C3DT;       /*!< TMR channel 3 data register,                 Address offset: 0x3C */
   __IO uint32_t C4DT;       /*!< TMR channel 4 data register,                 Address offset: 0x40 */
-  __IO uint32_t BRK;        /*!< TMR break register,                          Address offset: 0x44 */
+  __IO uint32_t BRK;        /*!< TMR brake register,                          Address offset: 0x44 */
   __IO uint32_t DMACTRL;    /*!< TMR DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMADT;      /*!< TMR DMA data register,                       Address offset: 0x4C */
 } TMR_TypeDef;
@@ -605,10 +605,10 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CMD;    /*!< WDT Command register,                        Address offset: 0x00 */
-  __IO uint32_t DIV;    /*!< WDT Divider register,                        Address offset: 0x04 */
-  __IO uint32_t RLD;    /*!< WDT Reload register,                         Address offset: 0x08 */
-  __IO uint32_t STS;    /*!< WDT Status register,                         Address offset: 0x0C */
+  __IO uint32_t CMD;    /*!< WDT command register,                        Address offset: 0x00 */
+  __IO uint32_t DIV;    /*!< WDT divider register,                        Address offset: 0x04 */
+  __IO uint32_t RLD;    /*!< WDT reload register,                         Address offset: 0x08 */
+  __IO uint32_t STS;    /*!< WDT status register,                         Address offset: 0x0C */
 } WDT_TypeDef;
 
 /**
@@ -617,9 +617,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CTRL;    /*!< WWDT Control register,                       Address offset: 0x00 */
-  __IO uint32_t CFG;     /*!< WWDT Configuration register,                 Address offset: 0x04 */
-  __IO uint32_t STS;     /*!< WWDT Status register,                        Address offset: 0x08 */
+  __IO uint32_t CTRL;    /*!< WWDT control register,                       Address offset: 0x00 */
+  __IO uint32_t CFG;     /*!< WWDT configuration register,                 Address offset: 0x04 */
+  __IO uint32_t STS;     /*!< WWDT status register,                        Address offset: 0x08 */
 } WWDT_TypeDef;
 
 /**
@@ -686,6 +686,7 @@ typedef struct
 #define DMA1_Channel5_BASE           (AHBPERIPH_BASE + 0x00000058U)  /*!< DMA1 Channel 5 base address                    */
 #define DMA1_Channel6_BASE           (AHBPERIPH_BASE + 0x0000006CU)  /*!< DMA1 Channel 6 base address                    */
 #define DMA1_Channel7_BASE           (AHBPERIPH_BASE + 0x00000080U)  /*!< DMA1 Channel 7 base address                    */
+
 #define DMA2_BASE                    (AHBPERIPH_BASE + 0x00000400U)  /*!< DMA2 base address                              */
 #define DMA2_Channel1_BASE           (AHBPERIPH_BASE + 0x00000408U)  /*!< DMA2 Channel 1 base address                    */
 #define DMA2_Channel2_BASE           (AHBPERIPH_BASE + 0x0000041CU)  /*!< DMA2 Channel 2 base address                    */
@@ -694,6 +695,7 @@ typedef struct
 #define DMA2_Channel5_BASE           (AHBPERIPH_BASE + 0x00000458U)  /*!< DMA2 Channel 5 base address                    */
 #define DMA2_Channel6_BASE           (AHBPERIPH_BASE + 0x0000046CU)  /*!< DMA2 Channel 6 base address                    */
 #define DMA2_Channel7_BASE           (AHBPERIPH_BASE + 0x00000480U)  /*!< DMA2 Channel 7 base address                    */
+
 #define CRM_BASE                     (AHBPERIPH_BASE + 0x00001000U)  /*!< CRM base address                               */
 #define CRC_BASE                     (AHBPERIPH_BASE + 0x00003000U)  /*!< CRC base address                               */
 
@@ -800,7 +802,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Power Control (PWC)                            */
+/*                             Power control (PWC)                            */
 /*                                                                            */
 /******************************************************************************/
 
@@ -973,7 +975,7 @@ typedef struct
 #define CRM_CFG_APB2DIV_DIV16               0x00003800U                             /*!< HCLK is divided by 16 */
 
 /*!< ADCDIV configuration */
-#define CRM_CFG_ADCDIV_Msk                  ((0x3U << 14) | (0x1U << 28))           /*!< 0x0100C000 */
+#define CRM_CFG_ADCDIV_Msk                  ((0x3U << 14) | (0x1U << 28))           /*!< 0x1000C000 */
 #define CRM_CFG_ADCDIV                      CRM_CFG_ADCDIV_Msk                      /*!< ADCDIV[2:0] bits (ADC division) */
 #define CRM_CFG_ADCDIV_0                    (0x1U << 14)                            /*!< 0x00004000 */
 #define CRM_CFG_ADCDIV_1                    (0x2U << 14)                            /*!< 0x00008000 */
@@ -983,8 +985,8 @@ typedef struct
 #define CRM_CFG_ADCDIV_DIV4                 0x00004000U                             /*!< PCLK/4 */
 #define CRM_CFG_ADCDIV_DIV6                 0x00008000U                             /*!< PCLK/6 */
 #define CRM_CFG_ADCDIV_DIV8                 0x0000C000U                             /*!< PCLK/8 */
-#define CRM_CFG_ADCDIV_DIV12                0x10004000U                             /*!< PCLK2/12 */
-#define CRM_CFG_ADCDIV_DIV16                0x1000C000U                             /*!< PCLK2/16 */
+#define CRM_CFG_ADCDIV_DIV12                0x10004000U                             /*!< PCLK/12 */
+#define CRM_CFG_ADCDIV_DIV16                0x1000C000U                             /*!< PCLK/16 */
 
 #define CRM_CFG_PLLRCS_Pos                  (16U)
 #define CRM_CFG_PLLRCS_Msk                  (0x1U << CRM_CFG_PLLRCS_Pos)            /*!< 0x00010000 */
@@ -1146,7 +1148,7 @@ typedef struct
 #define CRM_MISC1_CLKSEL_USB                CRM_MISC1_CLKOUT_SEL_USB
 #define CRM_MISC1_CLKSEL_ADC                CRM_MISC1_CLKOUT_SEL_ADC
 
-/*!<***************  Bit definition for CRM_CLKINT register  ******************/
+/******************  Bit definition for CRM_CLKINT register  ******************/
 #define CRM_CLKINT_LICKSTBLF_Pos            (0U)
 #define CRM_CLKINT_LICKSTBLF_Msk            (0x1U << CRM_CLKINT_LICKSTBLF_Pos)      /*!< 0x00000001 */
 #define CRM_CLKINT_LICKSTBLF                CRM_CLKINT_LICKSTBLF_Msk                /*!< LICK stable interrupt flag */
@@ -1412,7 +1414,7 @@ typedef struct
 #define CRM_BPDC_LEXTBYPS_Msk               (0x1U << CRM_BPDC_LEXTBYPS_Pos)         /*!< 0x00000004 */
 #define CRM_BPDC_LEXTBYPS                   CRM_BPDC_LEXTBYPS_Msk                   /*!< External low-speed crystal bypass */
 
-/*!< ERTCSEL congiguration */
+/*!< ERTCSEL configuration */
 #define CRM_BPDC_ERTCSEL_Pos                (8U)
 #define CRM_BPDC_ERTCSEL_Msk                (0x3U << CRM_BPDC_ERTCSEL_Pos)          /*!< 0x00000300 */
 #define CRM_BPDC_ERTCSEL                    CRM_BPDC_ERTCSEL_Msk                    /*!< ERTCSEL[1:0] bits (ERTC clock selection) */
@@ -1466,7 +1468,7 @@ typedef struct
 #define CRM_AHBRST_OTGFSRST                 CRM_AHBRST_OTGFSRST_Msk                 /*!< OTGFS reset */
 
 /*******************  Bit definition for CRM_PLL register  ********************/
-/*!< PLL_FR congiguration */
+/*!< PLL_FR configuration */
 #define CRM_PLL_PLL_FR_Pos                  (0U)
 #define CRM_PLL_PLL_FR_Msk                  (0x7U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000007 */
 #define CRM_PLL_PLL_FR                      CRM_PLL_PLL_FR_Msk                      /*!< PLL_FR[2:0] bits (PLL post-division factor) */
@@ -1474,7 +1476,7 @@ typedef struct
 #define CRM_PLL_PLL_FR_1                    (0x2U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000002 */
 #define CRM_PLL_PLL_FR_2                    (0x4U << CRM_PLL_PLL_FR_Pos)            /*!< 0x00000004 */
 
-/*!< PLL_MS congiguration */
+/*!< PLL_MS configuration */
 #define CRM_PLL_PLL_MS_Pos                  (4U)
 #define CRM_PLL_PLL_MS_Msk                  (0xFU << CRM_PLL_PLL_MS_Pos)            /*!< 0x000000F0 */
 #define CRM_PLL_PLL_MS                      CRM_PLL_PLL_MS_Msk                      /*!< PLL_MS[3:0] bits (PLL pre-division) */
@@ -1483,7 +1485,7 @@ typedef struct
 #define CRM_PLL_PLL_MS_2                    (0x4U << CRM_PLL_PLL_MS_Pos)            /*!< 0x00000040 */
 #define CRM_PLL_PLL_MS_3                    (0x8U << CRM_PLL_PLL_MS_Pos)            /*!< 0x00000080 */
 
-/*!< PLL_NS congiguration */
+/*!< PLL_NS configuration */
 #define CRM_PLL_PLL_NS_Pos                  (8U)
 #define CRM_PLL_PLL_NS_Msk                  (0x1FFU << CRM_PLL_PLL_NS_Pos)          /*!< 0x0001FF00 */
 #define CRM_PLL_PLL_NS                      CRM_PLL_PLL_NS_Msk                      /*!< PLL_NS[8:0] bits (PLL multiplication factor) */
@@ -1497,7 +1499,7 @@ typedef struct
 #define CRM_PLL_PLL_NS_7                    (0x080U << CRM_PLL_PLL_NS_Pos)          /*!< 0x00008000 */
 #define CRM_PLL_PLL_NS_8                    (0x100U << CRM_PLL_PLL_NS_Pos)          /*!< 0x00010000 */
 
-/*!< PLL_FREF congiguration */
+/*!< PLL_FREF configuration */
 #define CRM_PLL_PLL_FREF_Pos                (24U)
 #define CRM_PLL_PLL_FREF_Msk                (0x7U << CRM_PLL_PLL_FREF_Pos)          /*!< 0x07000000 */
 #define CRM_PLL_PLL_FREF                    CRM_PLL_PLL_FREF_Msk                    /*!< PLL_FREF[2:0] bits (PLL input clock selection) */
@@ -1530,7 +1532,7 @@ typedef struct
 #define CRM_MISC1_HICKDIV_Msk               (0x1U << CRM_MISC1_HICKDIV_Pos)         /*!< 0x02000000 */
 #define CRM_MISC1_HICKDIV                   CRM_MISC1_HICKDIV_Msk                   /*!< HICK 6 divider selection */
 
-/*!< CLKOUTDIV congiguration */
+/*!< CLKOUTDIV configuration */
 #define CRM_MISC1_CLKOUTDIV_Pos             (28U)
 #define CRM_MISC1_CLKOUTDIV_Msk             (0xFU << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0xF0000000 */
 #define CRM_MISC1_CLKOUTDIV                 CRM_MISC1_CLKOUTDIV_Msk                 /*!< CLKOUTDIV[3:0] bits (Clock output division) */
@@ -1539,7 +1541,7 @@ typedef struct
 #define CRM_MISC1_CLKOUTDIV_2               (0x4U << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0x40000000 */
 #define CRM_MISC1_CLKOUTDIV_3               (0x8U << CRM_MISC1_CLKOUTDIV_Pos)       /*!< 0x80000000 */
 
-#define CRM_MISC1_CLKOUTDIV_DIV1            0x00000000U                             /*!< No clock output */
+#define CRM_MISC1_CLKOUTDIV_DIV1            0x00000000U                             /*!< No clock output division */
 #define CRM_MISC1_CLKOUTDIV_DIV2            0x80000000U                             /*!< Clock output divided by 2 */
 #define CRM_MISC1_CLKOUTDIV_DIV4            0x90000000U                             /*!< Clock output divided by 4 */
 #define CRM_MISC1_CLKOUTDIV_DIV8            0xA0000000U                             /*!< Clock output divided by 8 */
@@ -1558,7 +1560,7 @@ typedef struct
 #define CRM_OTG_EXTCTRL_EP3_RMPEN           CRM_OTG_EXTCTRL_EP3_RMPEN_Msk           /*!< Endpoint 3 remap enable */
 
 /******************  Bit definition for CRM_MISC2 register  *******************/
-/*!< AUTO_STEP_EN congiguration */
+/*!< AUTO_STEP_EN configuration */
 #define CRM_MISC2_AUTO_STEP_EN_Pos          (4U)
 #define CRM_MISC2_AUTO_STEP_EN_Msk          (0x3U << CRM_MISC2_AUTO_STEP_EN_Pos)    /*!< 0x00000030 */
 #define CRM_MISC2_AUTO_STEP_EN              CRM_MISC2_AUTO_STEP_EN_Msk              /*!< AUTO_STEP_EN[1:0] bits (Auto step-by-step SCLK switch enable) */
@@ -1571,12 +1573,12 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                Flash and User System Data Registers (FLASH)                */
+/*                Flash and User System Data registers (FLASH)                */
 /*                                                                            */
 /******************************************************************************/
 
-/*******************  Bit definition for FLASH_PSR register  ******************/
-/*!< WTCYC congiguration */
+/******************  Bit definition for FLASH_PSR register  *******************/
+/*!< WTCYC configuration */
 #define FLASH_PSR_WTCYC_Pos                 (0U)
 #define FLASH_PSR_WTCYC_Msk                 (0x7U << FLASH_PSR_WTCYC_Pos)           /*!< 0x00000007 */
 #define FLASH_PSR_WTCYC                     FLASH_PSR_WTCYC_Msk                     /*!< WTCYC[2:0] bits (Wait cycle) */
@@ -1637,7 +1639,7 @@ typedef struct
 #define FLASH_CTRL_FPRGM                    FLASH_CTRL_FPRGM_Msk                    /*!< Flash program */
 #define FLASH_CTRL_SECERS_Pos               (1U)
 #define FLASH_CTRL_SECERS_Msk               (0x1U << FLASH_CTRL_SECERS_Pos)         /*!< 0x00000002 */
-#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Page erase */
+#define FLASH_CTRL_SECERS                   FLASH_CTRL_SECERS_Msk                   /*!< Sector erase */
 #define FLASH_CTRL_BANKERS_Pos              (2U)
 #define FLASH_CTRL_BANKERS_Msk              (0x1U << FLASH_CTRL_BANKERS_Pos)        /*!< 0x00000004 */
 #define FLASH_CTRL_BANKERS                  FLASH_CTRL_BANKERS_Msk                  /*!< Bank erase */
@@ -1679,7 +1681,7 @@ typedef struct
 #define FLASH_USD_FAP_Msk                   (0x1U << FLASH_USD_FAP_Pos)             /*!< 0x00000002 */
 #define FLASH_USD_FAP                       FLASH_USD_FAP_Msk                       /*!< Flash access protection */
 
-/*!< SSB congiguration */
+/*!< SSB configuration */
 #define FLASH_USD_WDT_ATO_EN_Pos            (2U)
 #define FLASH_USD_WDT_ATO_EN_Msk            (0x1U << FLASH_USD_WDT_ATO_EN_Pos)      /*!< 0x00000004 */
 #define FLASH_USD_WDT_ATO_EN                FLASH_USD_WDT_ATO_EN_Msk                /*!< nWDT_ATO_EN */
@@ -1708,7 +1710,7 @@ typedef struct
 #define FLASH_EPPS_EPPS_Msk                 (0xFFFFFFFFU << FLASH_EPPS_EPPS_Pos)    /*!< 0xFFFFFFFF */
 #define FLASH_EPPS_EPPS                     FLASH_EPPS_EPPS_Msk                     /*!< Erase/Program protection status */
 
-/*******************  Bit definition for SLIB_STS0 register *******************/
+/******************  Bit definition for SLIB_STS0 register  *******************/
 #define SLIB_STS0_BTM_AP_ENF_Pos            (0U)
 #define SLIB_STS0_BTM_AP_ENF_Msk            (0x1U << SLIB_STS0_BTM_AP_ENF_Pos)      /*!< 0x00000001 */
 #define SLIB_STS0_BTM_AP_ENF                SLIB_STS0_BTM_AP_ENF_Msk                /*!< Boot memory store application code enabled flag */
@@ -1720,25 +1722,25 @@ typedef struct
 #define SLIB_STS0_SLIB_ENF                  SLIB_STS0_SLIB_ENF_Msk                  /*!< Security library enable flag */
 #define SLIB_STS0_EM_SLIB_DAT_SS_Pos        (16U)
 #define SLIB_STS0_EM_SLIB_DAT_SS_Msk        (0xFFU << SLIB_STS0_EM_SLIB_DAT_SS_Pos) /*!< 0x00FF0000 */
-#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start page */
+#define SLIB_STS0_EM_SLIB_DAT_SS            SLIB_STS0_EM_SLIB_DAT_SS_Msk            /*!< Extension memory sLib data start sector */
 
-/*******************  Bit definition for SLIB_STS1 register *******************/
+/******************  Bit definition for SLIB_STS1 register  *******************/
 #define SLIB_STS1_SLIB_SS_Pos               (0U)
 #define SLIB_STS1_SLIB_SS_Msk               (0x7FFU << SLIB_STS1_SLIB_SS_Pos)       /*!< 0x000007FF */
-#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start page */
+#define SLIB_STS1_SLIB_SS                   SLIB_STS1_SLIB_SS_Msk                   /*!< Security library start sector */
 #define SLIB_STS1_SLIB_DAT_SS_Pos           (11U)
 #define SLIB_STS1_SLIB_DAT_SS_Msk           (0x7FFU << SLIB_STS1_SLIB_DAT_SS_Pos)   /*!< 0x003FF800 */
-#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start page */
+#define SLIB_STS1_SLIB_DAT_SS               SLIB_STS1_SLIB_DAT_SS_Msk               /*!< Security library data start sector */
 #define SLIB_STS1_SLIB_ES_Pos               (22U)
 #define SLIB_STS1_SLIB_ES_Msk               (0x3FFU << SLIB_STS1_SLIB_ES_Pos)       /*!< 0xFFC00000 */
-#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end page */
+#define SLIB_STS1_SLIB_ES                   SLIB_STS1_SLIB_ES_Msk                   /*!< Security library end sector */
 
-/*****************  Bit definition for SLIB_PWD_CLR register ******************/
+/*****************  Bit definition for SLIB_PWD_CLR register  *****************/
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk      (0xFFFFFFFFU << SLIB_PWD_CLR_SLIB_PCLR_VAL_Pos)
 #define SLIB_PWD_CLR_SLIB_PCLR_VAL          SLIB_PWD_CLR_SLIB_PCLR_VAL_Msk          /*!< Security library password clear value */
 
-/*****************  Bit definition for SLIB_MISC_STS register *****************/
+/****************  Bit definition for SLIB_MISC_STS register  *****************/
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Pos      (0U)                                    /*!< 0x00000001 */
 #define SLIB_MISC_STS_SLIB_PWD_ERR_Msk      (0x1U << SLIB_MISC_STS_SLIB_PWD_ERR_Pos)
 #define SLIB_MISC_STS_SLIB_PWD_ERR          SLIB_MISC_STS_SLIB_PWD_ERR_Msk          /*!< Security library password error */
@@ -1749,54 +1751,54 @@ typedef struct
 #define SLIB_MISC_STS_SLIB_ULKF_Msk         (0x1U << SLIB_MISC_STS_SLIB_ULKF_Pos)   /*!< 0x00000004 */
 #define SLIB_MISC_STS_SLIB_ULKF             SLIB_MISC_STS_SLIB_ULKF_Msk             /*!< Security library unlock flag */
 
-/****************  Bit definition for FLASH_CRC_ADDR register *****************/
+/****************  Bit definition for FLASH_CRC_ADDR register  ****************/
 #define FLASH_CRC_ADDR_CRC_ADDR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_ADDR_CRC_ADDR_Msk         (0xFFFFFFFFU << FLASH_CRC_ADDR_CRC_ADDR_Pos)
 #define FLASH_CRC_ADDR_CRC_ADDR             FLASH_CRC_ADDR_CRC_ADDR_Msk             /*!< CRC address */
 
-/****************  Bit definition for FLASH_CRC_CTRL register *****************/
+/****************  Bit definition for FLASH_CRC_CTRL register  ****************/
 #define FLASH_CRC_CTRL_CRC_SN_Pos           (0U)
 #define FLASH_CRC_CTRL_CRC_SN_Msk           (0xFFFFU << FLASH_CRC_CTRL_CRC_SN_Pos)  /*!< 0x0000FFFF */
-#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC page number */
+#define FLASH_CRC_CTRL_CRC_SN               FLASH_CRC_CTRL_CRC_SN_Msk               /*!< CRC sector number */
 #define FLASH_CRC_CTRL_CRC_STRT_Pos         (16U)
 #define FLASH_CRC_CTRL_CRC_STRT_Msk         (0x1U << FLASH_CRC_CTRL_CRC_STRT_Pos)   /*!< 0x00010000 */
 #define FLASH_CRC_CTRL_CRC_STRT             FLASH_CRC_CTRL_CRC_STRT_Msk             /*!< CRC start */
 
-/****************  Bit definition for FLASH_CRC_CHKR register *****************/
+/****************  Bit definition for FLASH_CRC_CHKR register  ****************/
 #define FLASH_CRC_CHKR_CRC_CHKR_Pos         (0U)                                    /*!< 0xFFFFFFFF */
 #define FLASH_CRC_CHKR_CRC_CHKR_Msk         (0xFFFFFFFFU << FLASH_CRC_CHKR_CRC_CHKR_Pos)
 #define FLASH_CRC_CHKR_CRC_CHKR             FLASH_CRC_CHKR_CRC_CHKR_Msk             /*!< CRC check result */
 
-/*****************  Bit definition for SLIB_SET_PWD register ******************/
+/*****************  Bit definition for SLIB_SET_PWD register  *****************/
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Pos      (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_SET_PWD_SLIB_PSET_VAL_Msk      (0xFFFFFFFFU << SLIB_SET_PWD_SLIB_PSET_VAL_Pos)
 #define SLIB_SET_PWD_SLIB_PSET_VAL          SLIB_SET_PWD_SLIB_PSET_VAL_Msk          /*!< Security library password setting value */
 
-/****************  Bit definition for SLIB_SET_RANGE register *****************/
+/****************  Bit definition for SLIB_SET_RANGE register  ****************/
 #define SLIB_SET_RANGE_SLIB_SS_SET_Pos      (0U)                                    /*!< 0x000007FF */
 #define SLIB_SET_RANGE_SLIB_SS_SET_Msk      (0x7FFU << SLIB_SET_RANGE_SLIB_SS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start page setting */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
-#define SLIB_SET_RANGE_SLIB_ISS_SET_Msk     (0x3FF8U << SLIB_SET_RANGE_SLIB_ISS_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ISS_SET         SLIB_SET_RANGE_SLIB_ISS_SET_Msk         /*!< Security library instruction start page setting */
+#define SLIB_SET_RANGE_SLIB_SS_SET          SLIB_SET_RANGE_SLIB_SS_SET_Msk          /*!< Security library start sector setting */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Pos     (11U)                                   /*!< 0x003FF800 */
+#define SLIB_SET_RANGE_SLIB_DSS_SET_Msk     (0x7FFU << SLIB_SET_RANGE_SLIB_DSS_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_DSS_SET         SLIB_SET_RANGE_SLIB_DSS_SET_Msk         /*!< Security library data start sector setting */
 #define SLIB_SET_RANGE_SLIB_ES_SET_Pos      (22U)                                   /*!< 0xFFC00000 */
-#define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0xFFCU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
-#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end page setting */
+#define SLIB_SET_RANGE_SLIB_ES_SET_Msk      (0x3FFU << SLIB_SET_RANGE_SLIB_ES_SET_Pos)
+#define SLIB_SET_RANGE_SLIB_ES_SET          SLIB_SET_RANGE_SLIB_ES_SET_Msk          /*!< Security library end sector setting */
 
-/******************  Bit definition for EM_SLIB_SET register ******************/
+/*****************  Bit definition for EM_SLIB_SET register  ******************/
 #define EM_SLIB_SET_EM_SLIB_SET_Pos         (0U)                                    /*!< 0x0000FFFF */
 #define EM_SLIB_SET_EM_SLIB_SET_Msk         (0xFFFFU << EM_SLIB_SET_EM_SLIB_SET_Pos)
 #define EM_SLIB_SET_EM_SLIB_SET             EM_SLIB_SET_EM_SLIB_SET_Msk             /*!< Extension memory sLib setting */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
-#define EM_SLIB_SET_EM_SLIB_ISS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_ISS_SET_Pos)
-#define EM_SLIB_SET_EM_SLIB_ISS_SET         EM_SLIB_SET_EM_SLIB_ISS_SET_Msk         /*!< Extension memory sLib instruction start page setting */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Pos     (16U)                                   /*!< 0x00FF0000 */
+#define EM_SLIB_SET_EM_SLIB_DSS_SET_Msk     (0xFFU << EM_SLIB_SET_EM_SLIB_DSS_SET_Pos)
+#define EM_SLIB_SET_EM_SLIB_DSS_SET         EM_SLIB_SET_EM_SLIB_DSS_SET_Msk         /*!< Extension memory sLib data start sector setting */
 
-/*****************  Bit definition for BTM_MODE_SET register ******************/
+/*****************  Bit definition for BTM_MODE_SET register  *****************/
 #define BTM_MODE_SET_BTM_MODE_SET_Pos       (0U)                                    /*!< 0x000000FF */
 #define BTM_MODE_SET_BTM_MODE_SET_Msk       (0xFFU << BTM_MODE_SET_BTM_MODE_SET_Pos)
 #define BTM_MODE_SET_BTM_MODE_SET           BTM_MODE_SET_BTM_MODE_SET_Msk           /*!< Boot memory mode setting */
 
-/*****************  Bit definition for SLIB_UNLOCK register ******************/
+/*****************  Bit definition for SLIB_UNLOCK register  ******************/
 #define SLIB_UNLOCK_SLIB_UKVAL_Pos          (0U)                                    /*!< 0xFFFFFFFF */
 #define SLIB_UNLOCK_SLIB_UKVAL_Msk          (0xFFFFFFFFU << SLIB_UNLOCK_SLIB_UKVAL_Pos)
 #define SLIB_UNLOCK_SLIB_UKVAL              SLIB_UNLOCK_SLIB_UKVAL_Msk              /*!< Security library unlock key value */
@@ -2169,7 +2171,7 @@ typedef struct
 #define GPIO_CFGHR_IOFC15_0                 (0x1U << GPIO_CFGHR_IOFC15_Pos)         /*!< 0x40000000 */
 #define GPIO_CFGHR_IOFC15_1                 (0x2U << GPIO_CFGHR_IOFC15_Pos)         /*!< 0x80000000 */
 
-/*!<****************  Bit definition for GPIO_IDT register  *******************/
+/*******************  Bit definition for GPIO_IDT register  *******************/
 #define GPIO_IDT_IDT0_Pos                   (0U)
 #define GPIO_IDT_IDT0_Msk                   (0x1U << GPIO_IDT_IDT0_Pos)             /*!< 0x00000001 */
 #define GPIO_IDT_IDT0                       GPIO_IDT_IDT0_Msk                       /*!< GPIO x input data, pin 0 */
@@ -2590,7 +2592,7 @@ typedef struct
 #define IOMUX_REMAP_TMR1_MUX_Msk            (0x3U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x000000C0 */
 #define IOMUX_REMAP_TMR1_MUX                IOMUX_REMAP_TMR1_MUX_Msk                /*!< TMR1_MUX[1:0] bits (TMR1 IO multiplexing) */
 #define IOMUX_REMAP_TMR1_MUX_0              (0x1U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x00000040 */
-#define IOMUX_REMAP_TMR1_MUX_1              (0x2U << IOMUX_REMAP_TMR1_MUX_Pos       /*!< 0x00000080 */
+#define IOMUX_REMAP_TMR1_MUX_1              (0x2U << IOMUX_REMAP_TMR1_MUX_Pos)      /*!< 0x00000080 */
 
 #define IOMUX_REMAP_TMR1_MUX_MUX0           0x00000000U                             /*!< EXT/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BRK/PB12, CH1C/PB13, CH2C/PB14, CH3C/PB15 */
 #define IOMUX_REMAP_TMR1_MUX_MUX1_Pos       (6U)
@@ -2647,18 +2649,18 @@ typedef struct
 #define IOMUX_REMAP_PD01_MUX                IOMUX_REMAP_PD01_MUX_Msk                /*!< PD0/PD1 mapped on HEXT_IN/HEXT_OUT */
 #define IOMUX_REMAP_TMR5CH4_MUX_Pos         (16U)
 #define IOMUX_REMAP_TMR5CH4_MUX_Msk         (0x1U << IOMUX_REMAP_TMR5CH4_MUX_Pos)   /*!< 0x00010000 */
-#define IOMUX_REMAP_TMR5CH4_MUX             IOMUX_REMAP_TMR5CH4_MUX_Msk             /*!< TMR5 channel 4 multiplexing */
+#define IOMUX_REMAP_TMR5CH4_MUX             IOMUX_REMAP_TMR5CH4_MUX_Msk             /*!< TMR5_CH4 multiplexing */
 #define IOMUX_REMAP_ADC1_ETP_MUX_Pos        (17U)
 #define IOMUX_REMAP_ADC1_ETP_MUX_Msk        (0x1U << IOMUX_REMAP_ADC1_ETP_MUX_Pos)  /*!< 0x00020000 */
 #define IOMUX_REMAP_ADC1_ETP_MUX            IOMUX_REMAP_ADC1_ETP_MUX_Msk            /*!< ADC1 external trigger preempted conversion multiplexing */
 #define IOMUX_REMAP_ADC1_ETO_MUX_Pos        (18U)
 #define IOMUX_REMAP_ADC1_ETO_MUX_Msk        (0x1U << IOMUX_REMAP_ADC1_ETO_MUX_Pos)  /*!< 0x00040000 */
-#define IOMUX_REMAP_ADC1_ETO_MUX            IOMUX_REMAP_ADC1_ETO_MUX_Msk            /*!< ADC1 external trigger regular conversion mutiplexing */
+#define IOMUX_REMAP_ADC1_ETO_MUX            IOMUX_REMAP_ADC1_ETO_MUX_Msk            /*!< ADC1 external trigger ordinary conversion multiplexing */
 
 /*!< SWJTAG_MUX configuration */
 #define IOMUX_REMAP_SWJTAG_MUX_Pos          (24U)
 #define IOMUX_REMAP_SWJTAG_MUX_Msk          (0x7U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x07000000 */
-#define IOMUX_REMAP_SWJTAG_MUX              IOMUX_REMAP_SWJTAG_MUX_Msk              /*!< SWJTAG_MUX[2:0] bits (SWD JTAG mutiplexing) */
+#define IOMUX_REMAP_SWJTAG_MUX              IOMUX_REMAP_SWJTAG_MUX_Msk              /*!< SWJTAG_MUX[2:0] bits (SWD_JTAG IO multiplexing) */
 #define IOMUX_REMAP_SWJTAG_MUX_0            (0x1U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x01000000 */
 #define IOMUX_REMAP_SWJTAG_MUX_1            (0x2U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x02000000 */
 #define IOMUX_REMAP_SWJTAG_MUX_2            (0x4U << IOMUX_REMAP_SWJTAG_MUX_Pos)    /*!< 0x04000000 */
@@ -2771,7 +2773,7 @@ typedef struct
 #define IOMUX_EXINTC2_EXINT4_GPF_Msk        (0x1U << IOMUX_EXINTC2_EXINT4_GPF_Pos)  /*!< 0x00000004 */
 #define IOMUX_EXINTC2_EXINT4_GPF            IOMUX_EXINTC2_EXINT4_GPF_Msk            /*!< GPIOF pin 4 */
 
-/* EXINT5 configuration */
+/*!< EXINT5 configuration */
 #define IOMUX_EXINTC2_EXINT5_Pos            (4U)
 #define IOMUX_EXINTC2_EXINT5_Msk            (0xFU << IOMUX_EXINTC2_EXINT5_Pos)      /*!< 0x000000F0 */
 #define IOMUX_EXINTC2_EXINT5                IOMUX_EXINTC2_EXINT5_Msk                /*!< EXINT5[3:0] bits (EXINT5 input source configuration) */
@@ -2906,7 +2908,7 @@ typedef struct
 #define IOMUX_EXINTC3_EXINT11_GPF           IOMUX_EXINTC3_EXINT11_GPF_Msk           /*!< GPIOF pin 11 */
 
 /****************  Bit definition for IOMUX_EXINTC4 register  *****************/
-/* EXINT12 configuration */
+/*!< EXINT12 configuration */
 #define IOMUX_EXINTC4_EXINT12_Pos           (0U)
 #define IOMUX_EXINTC4_EXINT12_Msk           (0xFU << IOMUX_EXINTC4_EXINT12_Pos)     /*!< 0x0000000F */
 #define IOMUX_EXINTC4_EXINT12               IOMUX_EXINTC4_EXINT12_Msk               /*!< EXINT12[3:0] bits (EXINT12 input source configuration) */
@@ -2925,7 +2927,7 @@ typedef struct
 #define IOMUX_EXINTC4_EXINT12_GPF_Msk       (0x1U << IOMUX_EXINTC4_EXINT12_GPF_Pos) /*!< 0x00000004 */
 #define IOMUX_EXINTC4_EXINT12_GPF           IOMUX_EXINTC4_EXINT12_GPF_Msk           /*!< GPIOF pin 12 */
 
-/* EXINT13 configuration */
+/*!< EXINT13 configuration */
 #define IOMUX_EXINTC4_EXINT13_Pos           (4U)
 #define IOMUX_EXINTC4_EXINT13_Msk           (0xFU << IOMUX_EXINTC4_EXINT13_Pos)     /*!< 0x000000F0 */
 #define IOMUX_EXINTC4_EXINT13               IOMUX_EXINTC4_EXINT13_Msk               /*!< EXINT13[3:0] bits (EXINT13 input source configuration) */
@@ -3088,9 +3090,12 @@ typedef struct
 #define IOMUX_REMAP4_TMR3_GMUX_3            (0x8U << IOMUX_REMAP4_TMR3_GMUX_Pos)    /*!< 0x00000800 */
 
 #define IOMUX_REMAP4_TMR3_GMUX_MUX0         0x00000000U                             /*!< CH1/PA6, CH2/PA7, CH3/PB0, CH4/PB1 */
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1_Pos     (8U)                                    /*!< 0x00000100 */
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1_Msk     (0x1U << IOMUX_REMAP4_TMR3_GMUX_MUX1_Pos)
-#define IOMUX_REMAP4_TMR3_GMUX_MUX1         IOMUX_REMAP4_TMR3_GMUX_MUX1_Msk         /*!< CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2_Pos     (9U)                                    /*!< 0x00000200 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2_Msk     (0x1U << IOMUX_REMAP4_TMR3_GMUX_MUX2_Pos)
+#define IOMUX_REMAP4_TMR3_GMUX_MUX2         IOMUX_REMAP4_TMR3_GMUX_MUX2_Msk         /*!< CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3_Pos     (8U)                                    /*!< 0x00000300 */
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3_Msk     (0x3U << IOMUX_REMAP4_TMR3_GMUX_MUX3_Pos)
+#define IOMUX_REMAP4_TMR3_GMUX_MUX3         IOMUX_REMAP4_TMR3_GMUX_MUX3_Msk         /*!< CH1/PC6, CH2/PC7, CH3/PC8, CH4/PC9 */
 
 /*!< TMR5_GMUX configuration */
 #define IOMUX_REMAP4_TMR5_GMUX_Pos          (16U)
@@ -3107,7 +3112,7 @@ typedef struct
 
 #define IOMUX_REMAP4_TMR5CH4_GMUX_Pos       (19U)
 #define IOMUX_REMAP4_TMR5CH4_GMUX_Msk       (0x1U << IOMUX_REMAP4_TMR5CH4_GMUX_Pos) /*!< 0x00080000 */
-#define IOMUX_REMAP4_TMR5CH4_GMUX           IOMUX_REMAP4_TMR5CH4_GMUX_Msk           /*!< TMR5 channel 4 general multiplexing */
+#define IOMUX_REMAP4_TMR5CH4_GMUX           IOMUX_REMAP4_TMR5CH4_GMUX_Msk           /*!< TMR5_CH4 general multiplexing */
 
 /*****************  Bit definition for IOMUX_REMAP5 register  *****************/
 /*!< I2C1_GMUX configuration */
@@ -3261,15 +3266,15 @@ typedef struct
 /*****************  Bit definition for IOMUX_REMAP7 register  *****************/
 #define IOMUX_REMAP7_ADC1_ETP_GMUX_Pos      (4U)                                    /*!< 0x00000010 */
 #define IOMUX_REMAP7_ADC1_ETP_GMUX_Msk      (0x1U << IOMUX_REMAP7_ADC1_ETP_GMUX_Pos)
-#define IOMUX_REMAP7_ADC1_ETP_GMUX          IOMUX_REMAP7_ADC1_ETP_GMUX_Msk          /*!< ADC1 External trigger preempted conversion general multiplexing */
+#define IOMUX_REMAP7_ADC1_ETP_GMUX          IOMUX_REMAP7_ADC1_ETP_GMUX_Msk          /*!< ADC1 external trigger preempted conversion general multiplexing */
 #define IOMUX_REMAP7_ADC1_ETO_GMUX_Pos      (5U)                                    /*!< 0x00000020 */
 #define IOMUX_REMAP7_ADC1_ETO_GMUX_Msk      (0x1U << IOMUX_REMAP7_ADC1_ETO_GMUX_Pos)
-#define IOMUX_REMAP7_ADC1_ETO_GMUX          IOMUX_REMAP7_ADC1_ETO_GMUX_Msk          /*!< ADC1 external trigger regular conversion general multiplexing */
+#define IOMUX_REMAP7_ADC1_ETO_GMUX          IOMUX_REMAP7_ADC1_ETO_GMUX_Msk          /*!< ADC1 external trigger ordinary conversion general multiplexing */
 
 /*!< SWJTAG_GMUX configuration */
 #define IOMUX_REMAP7_SWJTAG_GMUX_Pos        (16U)
 #define IOMUX_REMAP7_SWJTAG_GMUX_Msk        (0x7U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00070000 */
-#define IOMUX_REMAP7_SWJTAG_GMUX            IOMUX_REMAP7_SWJTAG_GMUX_Msk            /*!< SWJTAG_GMUX[2:0] bits (SWD JTAG IO general mutiplexing) */
+#define IOMUX_REMAP7_SWJTAG_GMUX            IOMUX_REMAP7_SWJTAG_GMUX_Msk            /*!< SWJTAG_GMUX[2:0] bits (SWD_JTAG IO general multiplexing) */
 #define IOMUX_REMAP7_SWJTAG_GMUX_0          (0x1U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00010000 */
 #define IOMUX_REMAP7_SWJTAG_GMUX_1          (0x2U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00020000 */
 #define IOMUX_REMAP7_SWJTAG_GMUX_2          (0x4U << IOMUX_REMAP7_SWJTAG_GMUX_Pos)  /*!< 0x00040000 */
@@ -3427,7 +3432,7 @@ typedef struct
 #define EXINT_INTEN_INTEN22_Msk             (0x1U << EXINT_INTEN_INTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTEN_INTEN22                 EXINT_INTEN_INTEN22_Msk                 /*!< Interrupt enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTEN_INT0                    EXINT_INTEN_INTEN0
 #define EXINT_INTEN_INT1                    EXINT_INTEN_INTEN1
 #define EXINT_INTEN_INT2                    EXINT_INTEN_INTEN2
@@ -3524,7 +3529,7 @@ typedef struct
 #define EXINT_EVTEN_EVTEN22_Msk             (0x1U << EXINT_EVTEN_EVTEN22_Pos)       /*!< 0x00400000 */
 #define EXINT_EVTEN_EVTEN22                 EXINT_EVTEN_EVTEN22_Msk                 /*!< Event enable or disable on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_EVTEN_EVT0                    EXINT_EVTEN_EVTEN0
 #define EXINT_EVTEN_EVT1                    EXINT_EVTEN_EVTEN1
 #define EXINT_EVTEN_EVT2                    EXINT_EVTEN_EVTEN2
@@ -3620,7 +3625,7 @@ typedef struct
 #define EXINT_POLCFG1_RP22_Msk              (0x1U << EXINT_POLCFG1_RP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG1_RP22                  EXINT_POLCFG1_RP22_Msk                  /*!< Rising edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG1_POL0                  EXINT_POLCFG1_RP0
 #define EXINT_POLCFG1_POL1                  EXINT_POLCFG1_RP1
 #define EXINT_POLCFG1_POL2                  EXINT_POLCFG1_RP2
@@ -3716,7 +3721,7 @@ typedef struct
 #define EXINT_POLCFG2_FP22_Msk              (0x1U << EXINT_POLCFG2_FP22_Pos)        /*!< 0x00400000 */
 #define EXINT_POLCFG2_FP22                  EXINT_POLCFG2_FP22_Msk                  /*!< Falling edge event configuration bit on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_POLCFG2_POL0                  EXINT_POLCFG2_FP0
 #define EXINT_POLCFG2_POL1                  EXINT_POLCFG2_FP1
 #define EXINT_POLCFG2_POL2                  EXINT_POLCFG2_FP2
@@ -3812,7 +3817,7 @@ typedef struct
 #define EXINT_SWTRG_SWT22_Msk               (0x1U << EXINT_SWTRG_SWT22_Pos)         /*!< 0x00400000 */
 #define EXINT_SWTRG_SWT22                   EXINT_SWTRG_SWT22_Msk                   /*!< Software trigger on line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_SWTRG_SW0                     EXINT_SWTRG_SWT0
 #define EXINT_SWTRG_SW1                     EXINT_SWTRG_SWT1
 #define EXINT_SWTRG_SW2                     EXINT_SWTRG_SWT2
@@ -3908,7 +3913,7 @@ typedef struct
 #define EXINT_INTSTS_LINE22_Msk             (0x1U << EXINT_INTSTS_LINE22_Pos)       /*!< 0x00400000 */
 #define EXINT_INTSTS_LINE22                 EXINT_INTSTS_LINE22_Msk                 /*!< Status bit for line 22 */
 
-/* References Defines */
+/* References defines */
 #define EXINT_INTSTS_INT0                   EXINT_INTSTS_LINE0
 #define EXINT_INTSTS_INT1                   EXINT_INTSTS_LINE1
 #define EXINT_INTSTS_INT2                   EXINT_INTSTS_LINE2
@@ -4358,8 +4363,8 @@ typedef struct
 
 /******************  Bit definition for I2C_OADDR1 register  ******************/
 /*!< ADDR1 configuration */
-#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface Address */
-#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface Address */
+#define I2C_OADDR1_ADDR1_1_7                0x000000FEU                             /*!< Interface address */
+#define I2C_OADDR1_ADDR1_8_9                0x00000300U                             /*!< Interface address */
 
 #define I2C_OADDR1_ADDR1_0_Pos              (0U)
 #define I2C_OADDR1_ADDR1_0_Msk              (0x1U << I2C_OADDR1_ADDR1_0_Pos)        /*!< 0x00000001 */
@@ -4722,7 +4727,7 @@ typedef struct
 #define SPI_CTRL1_NTC                       SPI_CTRL1_NTC_Msk                       /*!< Transmit CRC next */
 #define SPI_CTRL1_CCEN_Pos                  (13U)
 #define SPI_CTRL1_CCEN_Msk                  (0x1U << SPI_CTRL1_CCEN_Pos)            /*!< 0x00002000 */
-#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< RC calculation enable */
+#define SPI_CTRL1_CCEN                      SPI_CTRL1_CCEN_Msk                      /*!< CRC calculation enable */
 #define SPI_CTRL1_SLBTD_Pos                 (14U)
 #define SPI_CTRL1_SLBTD_Msk                 (0x1U << SPI_CTRL1_SLBTD_Pos)           /*!< 0x00004000 */
 #define SPI_CTRL1_SLBTD                     SPI_CTRL1_SLBTD_Msk                     /*!< Single line bidirectional half-duplex transmission direction */
@@ -4784,7 +4789,7 @@ typedef struct
 #define SPI_DT_DT_Msk                       (0xFFFFU << SPI_DT_DT_Pos)              /*!< 0x0000FFFF */
 #define SPI_DT_DT                           SPI_DT_DT_Msk                           /*!< Data value */
 
-/*******************  Bit definition for SPI_CPOLY register  ******************/
+/******************  Bit definition for SPI_CPOLY register  *******************/
 #define SPI_CPOLY_CPOLY_Pos                 (0U)
 #define SPI_CPOLY_CPOLY_Msk                 (0xFFFFU << SPI_CPOLY_CPOLY_Pos)        /*!< 0x0000FFFF */
 #define SPI_CPOLY_CPOLY                     SPI_CPOLY_CPOLY_Msk                     /*!< CRC polynomial */
@@ -6007,12 +6012,12 @@ typedef struct
 #define ADC_PCDTO4_PCDTO4_Msk               (0xFFFU << ADC_PCDTO4_PCDTO4_Pos)       /*!< 0x00000FFF */
 #define ADC_PCDTO4_PCDTO4                   ADC_PCDTO4_PCDTO4_Msk                   /*!< Data offset for Preempted channel 4 */
 
-/*******************  Bit definition for ADC_VMHB register  ********************/
+/*******************  Bit definition for ADC_VMHB register  *******************/
 #define ADC_VMHB_VMHB_Pos                   (0U)
 #define ADC_VMHB_VMHB_Msk                   (0xFFFU << ADC_VMHB_VMHB_Pos)           /*!< 0x00000FFF */
 #define ADC_VMHB_VMHB                       ADC_VMHB_VMHB_Msk                       /*!< Voltage monitoring high boundary */
 
-/*******************  Bit definition for ADC_VMLB register  ********************/
+/*******************  Bit definition for ADC_VMLB register  *******************/
 #define ADC_VMLB_VMLB_Pos                   (0U)
 #define ADC_VMLB_VMLB_Msk                   (0xFFFU << ADC_VMLB_VMLB_Pos)           /*!< 0x00000FFF */
 #define ADC_VMLB_VMLB                       ADC_VMLB_VMLB_Msk                       /*!< Voltage monitoring low boundary */
@@ -6380,7 +6385,7 @@ typedef struct
 #define CAN_TSTS_TMNR_Msk                   (0x3U << CAN_TSTS_TMNR_Pos)             /*!< 0x03000000 */
 #define CAN_TSTS_TMNR                       CAN_TSTS_TMNR_Msk                       /*!< TMNR[1:0] bits (Transmit mailbox number record) */
 
-/*!< TMEF congiguration */
+/*!< TMEF configuration */
 #define CAN_TSTS_TMEF_Pos                   (26U)
 #define CAN_TSTS_TMEF_Msk                   (0x7U << CAN_TSTS_TMEF_Pos)             /*!< 0x1C000000 */
 #define CAN_TSTS_TMEF                       CAN_TSTS_TMEF_Msk                       /*!< TMEF[2:0] bits (Transmit mailbox empty flag) */
@@ -6394,7 +6399,7 @@ typedef struct
 #define CAN_TSTS_TM2EF_Msk                  (0x1U << CAN_TSTS_TM2EF_Pos)            /*!< 0x10000000 */
 #define CAN_TSTS_TM2EF                      CAN_TSTS_TM2EF_Msk                      /*!< Transmit mailbox 2 empty flag */
 
-/*!< TMLPF congiguration */
+/*!< TMLPF configuration */
 #define CAN_TSTS_TMLPF_Pos                  (29U)
 #define CAN_TSTS_TMLPF_Msk                  (0x7U << CAN_TSTS_TMLPF_Pos)            /*!< 0xE0000000 */
 #define CAN_TSTS_TMLPF                      CAN_TSTS_TMLPF_Msk                      /*!< TMLPF[2:0] bits (Transmit mailbox lowest priority flag) */
@@ -6491,7 +6496,7 @@ typedef struct
 #define CAN_ESTS_BOF_Msk                    (0x1U << CAN_ESTS_BOF_Pos)              /*!< 0x00000004 */
 #define CAN_ESTS_BOF                        CAN_ESTS_BOF_Msk                        /*!< Bus-off flag */
 
-/*!< ETR congiguration */
+/*!< ETR configuration */
 #define CAN_ESTS_ETR_Pos                    (4U)
 #define CAN_ESTS_ETR_Msk                    (0x7U << CAN_ESTS_ETR_Pos)              /*!< 0x00000070 */
 #define CAN_ESTS_ETR                        CAN_ESTS_ETR_Msk                        /*!< ETR[2:0] bits (Error type record) */
@@ -6511,7 +6516,7 @@ typedef struct
 #define CAN_BTMG_BRDIV_Msk                  (0xFFFU << CAN_BTMG_BRDIV_Pos)          /*!< 0x00000FFF */
 #define CAN_BTMG_BRDIV                      CAN_BTMG_BRDIV_Msk                      /*!< Baud rate division */
 
-/*!< BTS1 congiguration */
+/*!< BTS1 configuration */
 #define CAN_BTMG_BTS1_Pos                   (16U)
 #define CAN_BTMG_BTS1_Msk                   (0xFU << CAN_BTMG_BTS1_Pos)             /*!< 0x000F0000 */
 #define CAN_BTMG_BTS1                       CAN_BTMG_BTS1_Msk                       /*!< BTS1[3:0] bits (Bit time segment 1) */
@@ -6520,7 +6525,7 @@ typedef struct
 #define CAN_BTMG_BTS1_2                     (0x4U << CAN_BTMG_BTS1_Pos)             /*!< 0x00040000 */
 #define CAN_BTMG_BTS1_3                     (0x8U << CAN_BTMG_BTS1_Pos)             /*!< 0x00080000 */
 
-/*!< BTS2 congiguration */
+/*!< BTS2 configuration */
 #define CAN_BTMG_BTS2_Pos                   (20U)
 #define CAN_BTMG_BTS2_Msk                   (0x7U << CAN_BTMG_BTS2_Pos)             /*!< 0x00700000 */
 #define CAN_BTMG_BTS2                       CAN_BTMG_BTS2_Msk                       /*!< BTS2[2:0] bits (Bit time segment 2) */
@@ -6528,7 +6533,7 @@ typedef struct
 #define CAN_BTMG_BTS2_1                     (0x2U << CAN_BTMG_BTS2_Pos)             /*!< 0x00200000 */
 #define CAN_BTMG_BTS2_2                     (0x4U << CAN_BTMG_BTS2_Pos)             /*!< 0x00400000 */
 
-/*!< RSAW congiguration */
+/*!< RSAW configuration */
 #define CAN_BTMG_RSAW_Pos                   (24U)
 #define CAN_BTMG_RSAW_Msk                   (0x3U << CAN_BTMG_RSAW_Pos)             /*!< 0x03000000 */
 #define CAN_BTMG_RSAW                       CAN_BTMG_RSAW_Msk                       /*!< RSAW[1:0] bits (Resynchronization width) */
@@ -9762,7 +9767,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for SDIO_PWRCTRL register  *****************/
-/*!< PS congiguration */
+/*!< PS configuration */
 #define SDIO_PWRCTRL_PS_Pos                 (0U)
 #define SDIO_PWRCTRL_PS_Msk                 (0x3U << SDIO_PWRCTRL_PS_Pos)           /*!< 0x00000003 */
 #define SDIO_PWRCTRL_PS                     SDIO_PWRCTRL_PS_Msk                     /*!< PS[1:0] bits (Power switch) */
@@ -9782,7 +9787,7 @@ typedef struct
 #define SDIO_CLKCTRL_BYPSEN_Msk             (0x1U << SDIO_CLKCTRL_BYPSEN_Pos)       /*!< 0x00000400 */
 #define SDIO_CLKCTRL_BYPSEN                 SDIO_CLKCTRL_BYPSEN_Msk                 /*!< Clock divider bypass enable bit */
 
-/*!< BUSWS congiguration */
+/*!< BUSWS configuration */
 #define SDIO_CLKCTRL_BUSWS_Pos              (11U)
 #define SDIO_CLKCTRL_BUSWS_Msk              (0x3U << SDIO_CLKCTRL_BUSWS_Pos)        /*!< 0x00001800 */
 #define SDIO_CLKCTRL_BUSWS                  SDIO_CLKCTRL_BUSWS_Msk                  /*!< BUSWS[1:0] bits (Bus width selection) */
@@ -9806,7 +9811,7 @@ typedef struct
 #define SDIO_CMD_CMDIDX_Msk                 (0x3FU << SDIO_CMD_CMDIDX_Pos)          /*!< 0x0000003F */
 #define SDIO_CMD_CMDIDX                     SDIO_CMD_CMDIDX_Msk                     /*!< Command index */
 
-/*!< RSPWT congiguration */
+/*!< RSPWT configuration */
 #define SDIO_CMD_RSPWT_Pos                  (6U)
 #define SDIO_CMD_RSPWT_Msk                  (0x3U << SDIO_CMD_RSPWT_Pos)            /*!< 0x000000C0 */
 #define SDIO_CMD_RSPWT                      SDIO_CMD_RSPWT_Msk                      /*!< RSPWT[1:0] bits (Wait for response bits) */
@@ -9875,7 +9880,7 @@ typedef struct
 #define SDIO_DTCTRL_DMAEN_Msk               (0x1U << SDIO_DTCTRL_DMAEN_Pos)         /*!< 0x00000008 */
 #define SDIO_DTCTRL_DMAEN                   SDIO_DTCTRL_DMAEN_Msk                   /*!< DMA enable bit */
 
-/*!< BLKSIZE congiguration */
+/*!< BLKSIZE configuration */
 #define SDIO_DTCTRL_BLKSIZE_Pos             (4U)
 #define SDIO_DTCTRL_BLKSIZE_Msk             (0xFU << SDIO_DTCTRL_BLKSIZE_Pos)       /*!< 0x000000F0 */
 #define SDIO_DTCTRL_BLKSIZE                 SDIO_DTCTRL_BLKSIZE_Msk                 /*!< BLKSIZE[3:0] bits (Data block size) */
@@ -10082,7 +10087,7 @@ typedef struct
 #define SDIO_INTEN_IOIFIEN_Msk              (0x1U << SDIO_INTEN_IOIFIEN_Pos)        /*!< 0x00400000 */
 #define SDIO_INTEN_IOIFIEN                  SDIO_INTEN_IOIFIEN_Msk                  /*!< SD I/O mode received interrupt enable */
 
-/*****************  Bit definition for SDIO_BUFCNTR register  ******************/
+/*****************  Bit definition for SDIO_BUFCNTR register  *****************/
 #define SDIO_BUFCNTR_CNT_Pos                (0U)
 #define SDIO_BUFCNTR_CNT_Msk                (0xFFFFFFU << SDIO_BUFCNTR_CNT_Pos)     /*!< 0x00FFFFFF */
 #define SDIO_BUFCNTR_CNT                    SDIO_BUFCNTR_CNT_Msk                    /*!< Number of words to be written to or read from the BUF */
@@ -10094,7 +10099,7 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                             Comparator (COMP)                              */
+/*                              Comparator (CMP)                              */
 /*                                                                            */
 /******************************************************************************/
 
@@ -10109,7 +10114,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1SSEL_Msk           (0x1U << CMP_CTRLSTS1_CMP1SSEL_Pos)     /*!< 0x00000004 */
 #define CMP_CTRLSTS1_CMP1SSEL               CMP_CTRLSTS1_CMP1SSEL_Msk               /*!< Comparator 1 speed selection */
 
-/*!< CMP1INVSEL congiguration */
+/*!< CMP1INVSEL configuration */
 #define CMP_CTRLSTS1_CMP1INVSEL_Pos         (4U)
 #define CMP_CTRLSTS1_CMP1INVSEL_Msk         (0x7U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000070 */
 #define CMP_CTRLSTS1_CMP1INVSEL             CMP_CTRLSTS1_CMP1INVSEL_Msk             /*!< CMP1INVSEL[2:0] bits (Comparator 1 inverting selection) */
@@ -10117,7 +10122,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1INVSEL_1           (0x2U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000020 */
 #define CMP_CTRLSTS1_CMP1INVSEL_2           (0x4U << CMP_CTRLSTS1_CMP1INVSEL_Pos)   /*!< 0x00000040 */
 
-/*!< CMP1TAG congiguration */
+/*!< CMP1TAG configuration */
 #define CMP_CTRLSTS1_CMP1TAG_Pos            (8U)
 #define CMP_CTRLSTS1_CMP1TAG_Msk            (0x7U << CMP_CTRLSTS1_CMP1TAG_Pos)      /*!< 0x00000700 */
 #define CMP_CTRLSTS1_CMP1TAG                CMP_CTRLSTS1_CMP1TAG_Msk                /*!< CMP1TAG[2:0] bits (Comparator 1 output target) */
@@ -10129,7 +10134,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP1P_Msk              (0x1U << CMP_CTRLSTS1_CMP1P_Pos)        /*!< 0x00000800 */
 #define CMP_CTRLSTS1_CMP1P                  CMP_CTRLSTS1_CMP1P_Msk                  /*!< Comparator 1 polarity */
 
-/*!< CMP1HYST congiguration */
+/*!< CMP1HYST configuration */
 #define CMP_CTRLSTS1_CMP1HYST_Pos           (12U)
 #define CMP_CTRLSTS1_CMP1HYST_Msk           (0x3U << CMP_CTRLSTS1_CMP1HYST_Pos)     /*!< 0x00003000 */
 #define CMP_CTRLSTS1_CMP1HYST               CMP_CTRLSTS1_CMP1HYST_Msk               /*!< CMP1HYST[1:0] bits (Comparator 1 hysteresis) */
@@ -10149,7 +10154,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2SSEL_Msk           (0x1U << CMP_CTRLSTS1_CMP2SSEL_Pos)     /*!< 0x00040000 */
 #define CMP_CTRLSTS1_CMP2SSEL               CMP_CTRLSTS1_CMP2SSEL_Msk               /*!< Comparator 2 speed selection */
 
-/*!< CMP2INVSEL congiguration */
+/*!< CMP2INVSEL configuration */
 #define CMP_CTRLSTS1_CMP2INVSEL_Pos         (20U)
 #define CMP_CTRLSTS1_CMP2INVSEL_Msk         (0x7U << CMP_CTRLSTS1_CMP2INVSEL_Pos)   /*!< 0x00700000 */
 #define CMP_CTRLSTS1_CMP2INVSEL             CMP_CTRLSTS1_CMP2INVSEL_Msk             /*!< CMP2INVSEL[2:0] bits (Comparator 2 inverting selection) */
@@ -10161,7 +10166,7 @@ typedef struct
 #define CMP_CTRLSTS1_DCMPEN_Msk             (0x1U << CMP_CTRLSTS1_DCMPEN_Pos)       /*!< 0x00800000 */
 #define CMP_CTRLSTS1_DCMPEN                 CMP_CTRLSTS1_DCMPEN_Msk                 /*!< Double comparator mode enable */
 
-/*!< CMP2TAG congiguration */
+/*!< CMP2TAG configuration */
 #define CMP_CTRLSTS1_CMP2TAG_Pos            (24U)
 #define CMP_CTRLSTS1_CMP2TAG_Msk            (0x7U << CMP_CTRLSTS1_CMP2TAG_Pos)      /*!< 0x07000000 */
 #define CMP_CTRLSTS1_CMP2TAG                CMP_CTRLSTS1_CMP2TAG_Msk                /*!< CMP2TAG[2:0] bits (Comparator 2 output target) */
@@ -10173,7 +10178,7 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2P_Msk              (0x1U << CMP_CTRLSTS1_CMP2P_Pos)        /*!< 0x08000000 */
 #define CMP_CTRLSTS1_CMP2P                  CMP_CTRLSTS1_CMP2P_Msk                  /*!< Comparator 2 polarity */
 
-/*!< CMP2HYST congiguration */
+/*!< CMP2HYST configuration */
 #define CMP_CTRLSTS1_CMP2HYST_Pos           (28U)
 #define CMP_CTRLSTS1_CMP2HYST_Msk           (0x3U << CMP_CTRLSTS1_CMP2HYST_Pos)     /*!< 0x30000000 */
 #define CMP_CTRLSTS1_CMP2HYST               CMP_CTRLSTS1_CMP2HYST_Msk               /*!< CMP2HYST[1:0] bits (Comparator 2 hysteresis) */
@@ -10188,14 +10193,14 @@ typedef struct
 #define CMP_CTRLSTS1_CMP2WP                 CMP_CTRLSTS1_CMP2WP_Msk                 /*!< Comparator 2 write protect */
 
 /*****************  Bit definition for CMP_CTRLSTS2 register  *****************/
-/*!< CMP1NINVSEL congiguration */
+/*!< CMP1NINVSEL configuration */
 #define CMP_CTRLSTS2_CMP1NINVSEL_Pos        (0U)
 #define CMP_CTRLSTS2_CMP1NINVSEL_Msk        (0x3U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000003 */
 #define CMP_CTRLSTS2_CMP1NINVSEL            CMP_CTRLSTS2_CMP1NINVSEL_Msk            /*!< CMP1NINVSEL[1:0] bits (Comparator 1 non-inverting input selection) */
 #define CMP_CTRLSTS2_CMP1NINVSEL_0          (0x1U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000001 */
 #define CMP_CTRLSTS2_CMP1NINVSEL_1          (0x2U << CMP_CTRLSTS2_CMP1NINVSEL_Pos)  /*!< 0x00000002 */
 
-/*!< CMP2NINVSEL congiguration */
+/*!< CMP2NINVSEL configuration */
 #define CMP_CTRLSTS2_CMP2NINVSEL_Pos        (16U)
 #define CMP_CTRLSTS2_CMP2NINVSEL_Msk        (0x3U << CMP_CTRLSTS2_CMP2NINVSEL_Pos)  /*!< 0x00030000 */
 #define CMP_CTRLSTS2_CMP2NINVSEL            CMP_CTRLSTS2_CMP2NINVSEL_Msk            /*!< CMP2NINVSEL[1:0] bits (Comparator 2 non-inverting input selection) */
@@ -10209,7 +10214,7 @@ typedef struct
 /******************************************************************************/
 
 /*****************  Bit definition for DEBUG_IDCODE register  *****************/
-/*!< PID congiguration */
+/*!< PID configuration */
 #define DEBUG_IDCODE_PID_Pos                (0U)
 #define DEBUG_IDCODE_PID_Msk                (0xFFFFFFFFU << DEBUG_IDCODE_PID_Pos)   /*!< 0xFFFFFFFF */
 #define DEBUG_IDCODE_PID                    DEBUG_IDCODE_PID_Msk                    /*!< PID[31:0] bits (PID information) */
@@ -10260,7 +10265,7 @@ typedef struct
 #define DEBUG_CTRL_TRACE_IOEN_Msk           (0x1U << DEBUG_CTRL_TRACE_IOEN_Pos)     /*!< 0x00000020 */
 #define DEBUG_CTRL_TRACE_IOEN               DEBUG_CTRL_TRACE_IOEN_Msk               /*!< Trace pin assignment enable */
 
-/*!< TRACE_MODE congiguration */
+/*!< TRACE_MODE configuration */
 #define DEBUG_CTRL_TRACE_MODE_Pos           (6U)
 #define DEBUG_CTRL_TRACE_MODE_Msk           (0x3U << DEBUG_CTRL_TRACE_MODE_Pos)     /*!< 0x000000C0 */
 #define DEBUG_CTRL_TRACE_MODE               DEBUG_CTRL_TRACE_MODE_Msk               /*!< TRACE_MODE[1:0] bits (Trace pin assignment control) */

--- a/os/hal/boards/AT_START_F402/board.c
+++ b/os/hal/boards/AT_START_F402/board.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2020 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -147,6 +147,9 @@ static void at32_gpio_init(void) {
 void __early_init(void) {
   at32_gpio_init();
   at32_clock_init();
+#if HAL_USE_USB || defined(__DOXYGEN__)
+  at32_reduce_power_consumption();
+#endif /* HAL_USE_USB */
 }
 
 /**

--- a/os/hal/boards/AT_START_F405/board.c
+++ b/os/hal/boards/AT_START_F405/board.c
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2020 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -148,6 +148,9 @@ static void at32_gpio_init(void) {
 void __early_init(void) {
   at32_gpio_init();
   at32_clock_init();
+#if (HAL_USE_USB && AT32_USB_USE_OTG1) || defined(__DOXYGEN__)
+  at32_reduce_power_consumption();
+#endif /* HAL_USE_USB */
 }
 
 /**

--- a/os/hal/ports/AT32/AT32F402_405/at32_crm.h
+++ b/os/hal/ports/AT32/AT32F402_405/at32_crm.h
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -271,7 +271,7 @@
 /** @} */
 
 /**
- * @name    ADC peripherals specific CRM operations
+ * @name    ADC peripheral specific CRM operations
  * @{
  */
 /**
@@ -327,7 +327,7 @@
 /** @} */
 
 /**
- * @name    CAN peripherals specific CRM operations
+ * @name    CAN peripheral specific CRM operations
  * @{
  */
 /**
@@ -531,7 +531,7 @@
 /** @} */
 
 /**
- * @name    QUADSPI peripherals specific CRM operations
+ * @name    QUADSPI peripheral specific CRM operations
  * @{
  */
 /**
@@ -1080,7 +1080,7 @@
 /** @} */
 
 /**
- * @name    ACC peripherals specific CRM operations
+ * @name    ACC peripheral specific CRM operations
  * @{
  */
 /**
@@ -1108,7 +1108,7 @@
 /** @} */
 
 /**
- * @name    CRC peripherals specific CRM operations
+ * @name    CRC peripheral specific CRM operations
  * @{
  */
 /**

--- a/os/hal/ports/AT32/AT32F402_405/at32_isr.h
+++ b/os/hal/ports/AT32/AT32F402_405/at32_isr.h
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -226,6 +226,11 @@
 #define AT32_TMR13_HANDLER           VectorF0
 #define AT32_TMR14_HANDLER           VectorF4
 
+/* Aliases.*/
+#define AT32_TMR9_HANDLER            AT32_TMR1_BRK_TMR9_HANDLER
+#define AT32_TMR10_HANDLER           AT32_TMR1_OVF_TMR10_HANDLER
+#define AT32_TMR11_HANDLER           AT32_TMR1_HALL_TMR11_HANDLER
+
 #define AT32_TMR1_BRK_TMR9_NUMBER    24
 #define AT32_TMR1_OVF_TMR10_NUMBER   25
 #define AT32_TMR1_HALL_TMR11_NUMBER  26
@@ -237,6 +242,11 @@
 #define AT32_TMR7_NUMBER             55
 #define AT32_TMR13_NUMBER            44
 #define AT32_TMR14_NUMBER            45
+
+/* Aliases.*/
+#define AT32_TMR9_NUMBER             AT32_TMR1_BRK_TMR9_NUMBER
+#define AT32_TMR10_NUMBER            AT32_TMR1_OVF_TMR10_NUMBER
+#define AT32_TMR11_NUMBER            AT32_TMR1_HALL_TMR11_NUMBER
 
 /*
  * USART units.

--- a/os/hal/ports/AT32/AT32F402_405/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F402_405/at32_registry.h
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -48,10 +48,10 @@
 /* Platform capabilities.                                                    */
 /*===========================================================================*/
 
-/**
- * @name    Common capabilities
- * @{
- */
+/*===========================================================================*/
+/* Common.                                                                   */
+/*===========================================================================*/
+
 /* GPIO attributes.*/
 #if defined(AT32_HAS_GPIOD)
 #define AT32_GPIO_EN_MASK                  (CRM_AHBEN1_GPIOAEN |           \
@@ -69,13 +69,13 @@
                                             CRM_AHBEN1_GPIOBEN |           \
                                             CRM_AHBEN1_GPIOFEN)
 #endif
-/** @} */
+
+/*===========================================================================*/
+/* AT32F402KB, AT32F402KC, AT32F405KB, AT32F405KC.                           */
+/*===========================================================================*/
 
 #if defined(AT32F402_405K) || defined(__DOXYGEN__)
-/**
- * @name    AT32F402_405K capabilities
- * @{
- */
+
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
 #define AT32_ADC_SUPPORTS_PRESCALER        TRUE
@@ -253,13 +253,13 @@
 #define AT32_OTG_STEPPING                  2
 
 #define AT32_HAS_OTG1                      TRUE
-#define AT32_OTG1_ENDPOINTS                8
+#define AT32_OTG1_ENDPOINTS                7
 
 #if defined(AT32F402KB) || defined(AT32F402KC) || defined(__DOXYGEN__)
 #define AT32_HAS_OTG2                      FALSE
 #elif defined(AT32F405KB) || defined(AT32F405KC)
 #define AT32_HAS_OTG2                      TRUE
-#define AT32_OTG2_ENDPOINTS                8
+#define AT32_OTG2_ENDPOINTS                7
 #endif
 
 /* WDT attributes.*/
@@ -275,14 +275,15 @@
 #else
 #define STM32_CRC_USE_CRC1                 FALSE
 #endif
-/** @} */
+
 #endif /* defined(AT32F402_405K) */
 
+/*===========================================================================*/
+/* AT32F402CB, AT32F402CC, AT32F405CB, AT32F405CC.                           */
+/*===========================================================================*/
+
 #if defined(AT32F402_405C) || defined(__DOXYGEN__)
-/**
- * @name    AT32F402_405C capabilities
- * @{
- */
+
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
 #define AT32_ADC_SUPPORTS_PRESCALER        TRUE
@@ -463,13 +464,13 @@
 #define AT32_OTG_STEPPING                  2
 
 #define AT32_HAS_OTG1                      TRUE
-#define AT32_OTG1_ENDPOINTS                8
+#define AT32_OTG1_ENDPOINTS                7
 
 #if defined(AT32F402CB) || defined(AT32F402CC) || defined(__DOXYGEN__)
 #define AT32_HAS_OTG2                      FALSE
 #elif defined(AT32F405CB) || defined(AT32F405CC)
 #define AT32_HAS_OTG2                      TRUE
-#define AT32_OTG2_ENDPOINTS                8
+#define AT32_OTG2_ENDPOINTS                7
 #endif
 
 /* WDT attributes.*/
@@ -485,14 +486,15 @@
 #else
 #define STM32_CRC_USE_CRC1                 FALSE
 #endif
-/** @} */
+
 #endif /* defined(AT32F402_405C) */
 
+/*===========================================================================*/
+/* AT32F402RB, AT32F402RC, AT32F405RB, AT32F405RC.                           */
+/*===========================================================================*/
+
 #if defined(AT32F402_405R) || defined(__DOXYGEN__)
-/**
- * @name    AT32F402_405R capabilities
- * @{
- */
+
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
 #define AT32_ADC_SUPPORTS_PRESCALER        TRUE
@@ -673,13 +675,13 @@
 #define AT32_OTG_STEPPING                  2
 
 #define AT32_HAS_OTG1                      TRUE
-#define AT32_OTG1_ENDPOINTS                8
+#define AT32_OTG1_ENDPOINTS                7
 
 #if defined(AT32F402RB) || defined(AT32F402RC) || defined(__DOXYGEN__)
 #define AT32_HAS_OTG2                      FALSE
 #elif defined(AT32F405RB) || defined(AT32F405RC)
 #define AT32_HAS_OTG2                      TRUE
-#define AT32_OTG2_ENDPOINTS                8
+#define AT32_OTG2_ENDPOINTS                7
 #endif
 
 /* WDT attributes.*/
@@ -695,7 +697,7 @@
 #else
 #define STM32_CRC_USE_CRC1                 FALSE
 #endif
-/** @} */
+
 #endif /* defined(AT32F402_405R) */
 
 #endif /* AT32_REGISTRY_H */

--- a/os/hal/ports/AT32/AT32F402_405/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F402_405/at32_registry.h
@@ -28,20 +28,34 @@
 #ifndef AT32_REGISTRY_H
 #define AT32_REGISTRY_H
 
-#if defined(AT32F402KB) || defined(AT32F402KC) ||                           \
+/* Define by package size */
+#if defined(AT32F402KB) || defined(AT32F402KC) ||                          \
     defined(AT32F405KB) || defined(AT32F405KC)
-#define AT32F402_405K
+#define AT32F402_405Kx
 
-#elif defined(AT32F402CB) || defined(AT32F402CC) ||                         \
+#elif defined(AT32F402CB) || defined(AT32F402CC) ||                        \
       defined(AT32F405CB) || defined(AT32F405CC)
-#define AT32F402_405C
+#define AT32F402_405Cx
 
-#elif defined(AT32F402RB) || defined(AT32F402RC) ||                         \
+#elif defined(AT32F402RB) || defined(AT32F402RC) ||                        \
       defined(AT32F405RB) || defined(AT32F405RC)
-#define AT32F402_405R
+#define AT32F402_405Rx
 
 #else
-#error "unsupported or unrecognized AT32F402 or AT32F405 member"
+#error "unsupported or unrecognized AT32F402 or AT32F405 package size"
+#endif
+
+/* Define by flash size */
+#if defined(AT32F402KB) || defined(AT32F402CB) || defined(AT32F402RB) ||   \
+    defined(AT32F405KB) || defined(AT32F405CB) || defined(AT32F405RB)
+#define AT32F402_405xB
+
+#elif defined(AT32F402KC) || defined(AT32F402CC) || defined(AT32F402RC) || \
+      defined(AT32F405KC) || defined(AT32F405CC) || defined(AT32F405RC)
+#define AT32F402_405xC
+
+#else
+#error "unsupported or unrecognized AT32F402 or AT32F405 flash size"
 #endif
 
 /*===========================================================================*/
@@ -51,6 +65,19 @@
 /*===========================================================================*/
 /* Common.                                                                   */
 /*===========================================================================*/
+
+/* FLASH attributes.*/
+#define AT32_FLASH_NUMBER_OF_BANKS         1
+
+#if defined(AT32F402_405xB) || defined(__DOXYGEN__)
+#define AT32_FLASH_SECTOR_SIZE             1024U
+#elif defined(AT32F402_405xC)
+#define AT32_FLASH_SECTOR_SIZE             2048U
+#endif
+
+#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
+#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
+#endif
 
 /* GPIO attributes.*/
 #if defined(AT32_HAS_GPIOD)
@@ -74,7 +101,7 @@
 /* AT32F402KB, AT32F402KC, AT32F405KB, AT32F405KC.                           */
 /*===========================================================================*/
 
-#if defined(AT32F402_405K) || defined(__DOXYGEN__)
+#if defined(AT32F402_405Kx) || defined(__DOXYGEN__)
 
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
@@ -99,19 +126,8 @@
 #elif defined(AT32F405KB) || defined(AT32F405KC)
 #define AT32_EXINT_NUM_LINES               22
 #endif
+
 #define AT32_EXINT_INTEN_MASK              0x00000000U
-
-/* FLASH attributes.*/
-#define AT32_FLASH_NUMBER_OF_BANKS         1
-#if defined(AT32F402KB) || defined(AT32F405KB) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTOR_SIZE             1024U
-#elif defined(AT32F402KC) || defined(AT32F405KC)
-#define AT32_FLASH_SECTOR_SIZE             2048U
-#endif
-
-#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
-#endif
 
 /* GPIO attributes.*/
 #define AT32_HAS_GPIOA                     TRUE
@@ -282,7 +298,7 @@
 /* AT32F402CB, AT32F402CC, AT32F405CB, AT32F405CC.                           */
 /*===========================================================================*/
 
-#if defined(AT32F402_405C) || defined(__DOXYGEN__)
+#if defined(AT32F402_405Cx) || defined(__DOXYGEN__)
 
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
@@ -307,19 +323,8 @@
 #elif defined(AT32F405CB) || defined(AT32F405CC)
 #define AT32_EXINT_NUM_LINES               22
 #endif
+
 #define AT32_EXINT_INTEN_MASK              0x00000000U
-
-/* FLASH attributes.*/
-#define AT32_FLASH_NUMBER_OF_BANKS         1
-#if defined(AT32F402CB) || defined(AT32F405CB) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTOR_SIZE             1024U
-#elif defined(AT32F402CC) || defined(AT32F405CC)
-#define AT32_FLASH_SECTOR_SIZE             2048U
-#endif
-
-#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
-#endif
 
 /* GPIO attributes.*/
 #define AT32_HAS_GPIOA                     TRUE
@@ -493,7 +498,7 @@
 /* AT32F402RB, AT32F402RC, AT32F405RB, AT32F405RC.                           */
 /*===========================================================================*/
 
-#if defined(AT32F402_405R) || defined(__DOXYGEN__)
+#if defined(AT32F402_405Rx) || defined(__DOXYGEN__)
 
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
@@ -518,19 +523,8 @@
 #elif defined(AT32F405RB) || defined(AT32F405RC)
 #define AT32_EXINT_NUM_LINES               22
 #endif
+
 #define AT32_EXINT_INTEN_MASK              0x00000000U
-
-/* FLASH attributes.*/
-#define AT32_FLASH_NUMBER_OF_BANKS         1
-#if defined(AT32F402RB) || defined(AT32F405RB) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTOR_SIZE             1024U
-#elif defined(AT32F402RC) || defined(AT32F405RC)
-#define AT32_FLASH_SECTOR_SIZE             2048U
-#endif
-
-#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
-#endif
 
 /* GPIO attributes.*/
 #define AT32_HAS_GPIOA                     TRUE

--- a/os/hal/ports/AT32/AT32F402_405/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F402_405/at32_registry.h
@@ -62,6 +62,24 @@
 /* Platform capabilities.                                                    */
 /*===========================================================================*/
 
+/**
+ * @name    AT32F402_405 capabilities
+ * @{
+ */
+
+/* DEBUG helpers.*/
+#define AT32_DEBUG_TMR1_STOP()             DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR1_PAUSE
+#define AT32_DEBUG_TMR2_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR2_PAUSE
+#define AT32_DEBUG_TMR3_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR3_PAUSE
+#define AT32_DEBUG_TMR4_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR4_PAUSE
+#define AT32_DEBUG_TMR6_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR6_PAUSE
+#define AT32_DEBUG_TMR7_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR7_PAUSE
+#define AT32_DEBUG_TMR9_STOP()             DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR9_PAUSE
+#define AT32_DEBUG_TMR10_STOP()            DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR10_PAUSE
+#define AT32_DEBUG_TMR11_STOP()            DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR11_PAUSE
+#define AT32_DEBUG_TMR13_STOP()            DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR13_PAUSE
+#define AT32_DEBUG_TMR14_STOP()            DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR14_PAUSE
+
 /*===========================================================================*/
 /* Common.                                                                   */
 /*===========================================================================*/

--- a/os/hal/ports/AT32/AT32F402_405/hal_efl_lld.c
+++ b/os/hal/ports/AT32/AT32F402_405/hal_efl_lld.c
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
 
-#define AT32_FLASH_LINE_SIZE               2U
+#define AT32_FLASH_LINE_SIZE               4U
 #define AT32_FLASH_LINE_MASK               (AT32_FLASH_LINE_SIZE - 1U)
 
 /*===========================================================================*/
@@ -274,18 +274,18 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
 
   /* Actual program implementation.*/
   while (n > 0U) {
-    volatile uint16_t *address;
+    volatile uint32_t *address;
 
     union {
-      uint16_t  hw[AT32_FLASH_LINE_SIZE / sizeof (uint16_t)];
+      uint32_t  w[AT32_FLASH_LINE_SIZE / sizeof (uint32_t)];
       uint8_t   b[AT32_FLASH_LINE_SIZE / sizeof (uint8_t)];
     } line;
 
     /* Unwritten bytes are initialized to all ones.*/
-    line.hw[0] = 0xFFFFU;
+    line.w[0] = 0xFFFFFFFFU;
 
     /* Programming address aligned to flash lines.*/
-    address = (volatile uint16_t *)(efl_lld_descriptor.address +
+    address = (volatile uint32_t *)(efl_lld_descriptor.address +
                                     (offset & ~AT32_FLASH_LINE_MASK));
 
     /* Copying data inside the prepared line.*/
@@ -298,16 +298,17 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
     while ((n > 0U) & ((offset & AT32_FLASH_LINE_MASK) != 0U));
 
     /* Programming line.*/
-    address[0] = line.hw[0];
+    address[0] = line.w[0];
     at32_flash_wait_busy(devp);
 
     err = at32_flash_check_errors(devp);
+
     if (err != FLASH_NO_ERROR) {
       break;
     }
 
     /* Check for flash error.*/
-    if (address[0] != line.hw[0]) {
+    if (address[0] != line.w[0]) {
       err = FLASH_ERROR_PROGRAM;
       break;
     }

--- a/os/hal/ports/AT32/AT32F402_405/hal_lld.c
+++ b/os/hal/ports/AT32/AT32F402_405/hal_lld.c
@@ -320,4 +320,42 @@ void at32_clock_init(void) {
      among multiple drivers.*/
   crmEnableAPB2(CRM_APB2EN_SCFGEN, true);
 }
+
+#if HAL_USE_USB
+/*
+ * Reduce power consumption initialize for all series using OTGFS.
+ */
+void at32_reduce_power_consumption(void) {
+  volatile uint32_t delay = 0x34BC0;
+
+  if (CRM->CTRL & CRM_CTRL_HEXTSTBL) {
+    CRM->OTGHS = 0x00;
+  } else if (CRM->CTRL & CRM_CTRL_PLLSTBL) {
+    CRM->PLLCFG |= CRM_PLLCFG_PLLU_EN;
+    while ((!(CRM->CTRL & CRM_CTRL_PLLSTBL)) || (!(CRM->CTRL & CRM_CTRL_PLLUSTBL)))
+      ;
+    CRM->OTGHS = 0x10;
+  } else {
+    /* PLL or HEXT need to be enable.*/
+    return;
+  }
+
+  CRM->AHBEN1 |= CRM_AHBEN1_OTGHSEN;
+  OTG_HS->GCCFG = GCCFG_PWRDOWN | GCCFG_VBUSIG;
+  OTG_HS->GUSBCFG |= GUSBCFG_FDEVMODE;
+  OTG_HS->DCTL &= ~DCTL_SFTDISCON;
+
+  while (delay --) {
+    if (OTG_HS->DSTS & DSTS_SUSPSTS) {
+      break;
+    }
+  }
+
+  OTG_HS->GCCFG |= GCCFG_WAIT_CLK_RCV;
+  OTG_HS->PCGCCTL |= PCGCCTL_STOPPCLK;
+  OTG_HS->GCCFG &= ~GCCFG_PWRDOWN;
+
+  return;
+}
+#endif /* HAL_USE_USB */
 /** @} */

--- a/os/hal/ports/AT32/AT32F402_405/hal_lld.c
+++ b/os/hal/ports/AT32/AT32F402_405/hal_lld.c
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -64,10 +64,11 @@ static void hal_lld_battery_powered_domain_init(void) {
     /* Battery powered domain reset.*/
     CRM->BPDC = CRM_BPDC_BPDRST;
 
-    /* Errata 1.2.1: Read/write ERTC occupies APB1 for 15 ERTC clock cycles.*/
+    /* Errata 1.2.1: Read/write ERTC occupies APB1 for 15 ERTC clock cycles
+       (one more clock cycle at the end for stable).*/
     {
       __NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();
-      __NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();
+      __NOP();__NOP();__NOP();__NOP();__NOP();__NOP();
     }
 
     CRM->BPDC = 0;
@@ -122,7 +123,7 @@ void hal_lld_init(void) {
   crmResetAPB1(~CRM_APB1RST_PWCRST);
   crmResetAPB2(~0);
 
-  /* Initializes the backup domain.*/
+  /* Initializes the battery powered domain.*/
   hal_lld_battery_powered_domain_init();
 
   /* DMA subsystems initialization.*/
@@ -140,7 +141,7 @@ void hal_lld_init(void) {
 }
 
 /*
- * HICK divider selection for all sub-families.
+ * HICK divider selection for all series.
  */
 static void at32_hick_divider(uint32_t div)
 {
@@ -167,7 +168,7 @@ static void at32_hick_divider(uint32_t div)
 }
 
 /*
- * HICK to SCLK selection for all sub-families.
+ * HICK to SCLK selection for all series.
  */
 static void at32_hick_to_sclk(uint32_t value)
 {
@@ -224,12 +225,12 @@ void at32_clock_init(void) {
 
   /* HICK is selected as new source without touching the other fields in
      CFGR. Clearing the register has to be postponed after HICK is the
-     new source. */
+     new source.*/
   CRM->CFG &= ~CRM_CFG_SCLKSEL;             /* Reset SCLKSEL, selecting HICK. */
   while ((CRM->CFG & CRM_CFG_SCLKSTS) != CRM_CFG_SCLKSTS_HICK)
     ;                                       /* Waits until HICK is selected.  */
 
-  /* Registers finally cleared to reset values. */
+  /* Registers finally cleared to reset values.*/
   CRM->CTRL &= ~(0x010D0000);               /* CTRL reset value.              */
   CRM->CFG = (0x40000000);                  /* CFG reset value.               */
   CRM->PLLCFG = 0x000007C1;                 /* PLLCFG reset value.            */
@@ -248,7 +249,7 @@ void at32_clock_init(void) {
   /* HEXT Bypass.*/
   CRM->CTRL |= CRM_CTRL_HEXTEN | CRM_CTRL_HEXTBYPS;
 #endif
-  /* HEXT activation. */
+  /* HEXT activation.*/
   CRM->CTRL |= CRM_CTRL_HEXTEN;
   while (!(CRM->CTRL & CRM_CTRL_HEXTSTBL))
     ;                                       /* Waits until HEXT is stable.    */

--- a/os/hal/ports/AT32/AT32F402_405/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F402_405/hal_lld.h
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -1193,6 +1193,7 @@ extern "C" {
 #endif
   void hal_lld_init(void);
   void at32_clock_init(void);
+  void at32_reduce_power_consumption(void);
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/ports/AT32/AT32F415/at32_crm.h
+++ b/os/hal/ports/AT32/AT32F415/at32_crm.h
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@
 /** @} */
 
 /**
- * @name    ADC peripherals specific CRM operations
+ * @name    ADC peripheral specific CRM operations
  * @{
  */
 /**
@@ -230,7 +230,7 @@
 /** @} */
 
 /**
- * @name    CAN peripherals specific CRM operations
+ * @name    CAN peripheral specific CRM operations
  * @{
  */
 /**
@@ -367,7 +367,7 @@
 /** @} */
 
 /**
- * @name    OTG peripherals specific CRM operations
+ * @name    OTG peripheral specific CRM operations
  * @{
  */
 /**
@@ -396,7 +396,7 @@
 /** @} */
 
 /**
- * @name    SDIO peripherals specific CRM operations
+ * @name    SDIO peripheral specific CRM operations
  * @{
  */
 /**
@@ -801,7 +801,7 @@
 /** @} */
 
 /**
- * @name    CRC peripherals specific CRM operations
+ * @name    CRC peripheral specific CRM operations
  * @{
  */
 /**

--- a/os/hal/ports/AT32/AT32F415/at32_isr.h
+++ b/os/hal/ports/AT32/AT32F415/at32_isr.h
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -208,6 +208,11 @@
 #define AT32_TMR4_HANDLER            VectorB8
 #define AT32_TMR5_HANDLER            Vector108
 
+/* Aliases.*/
+#define AT32_TMR9_HANDLER            AT32_TMR1_BRK_TMR9_HANDLER
+#define AT32_TMR10_HANDLER           AT32_TMR1_OVF_TMR10_HANDLER
+#define AT32_TMR11_HANDLER           AT32_TMR1_HALL_TMR11_HANDLER
+
 #define AT32_TMR1_BRK_TMR9_NUMBER    24
 #define AT32_TMR1_OVF_TMR10_NUMBER   25
 #define AT32_TMR1_HALL_TMR11_NUMBER  26
@@ -216,6 +221,11 @@
 #define AT32_TMR3_NUMBER             29
 #define AT32_TMR4_NUMBER             30
 #define AT32_TMR5_NUMBER             50
+
+/* Aliases.*/
+#define AT32_TMR9_NUMBER             AT32_TMR1_BRK_TMR9_NUMBER
+#define AT32_TMR10_NUMBER            AT32_TMR1_OVF_TMR10_NUMBER
+#define AT32_TMR11_NUMBER            AT32_TMR1_HALL_TMR11_NUMBER
 
 /*
  * USART units.

--- a/os/hal/ports/AT32/AT32F415/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F415/at32_registry.h
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -44,11 +44,16 @@
 /* Platform capabilities.                                                    */
 /*===========================================================================*/
 
+/*===========================================================================*/
+/* Common.                                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* AT32F415KB, AT32F415KC.                                                   */
+/*===========================================================================*/
+
 #if defined(AT32F415K) || defined(__DOXYGEN__)
-/**
- * @name    AT32F415K capabilities
- * @{
- */
+
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
 #define AT32_ADC_SUPPORTS_PRESCALER        FALSE
@@ -278,14 +283,15 @@
 #else
 #define STM32_CRC_USE_CRC1                 FALSE
 #endif
-/** @} */
+
 #endif /* defined(AT32F415K) */
 
+/*===========================================================================*/
+/* AT32F415CB, AT32F415CC.                                                   */
+/*===========================================================================*/
+
 #if defined(AT32F415C) || defined(__DOXYGEN__)
-/**
- * @name    AT32F415C capabilities
- * @{
- */
+
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
 #define AT32_ADC_SUPPORTS_PRESCALER        FALSE
@@ -523,14 +529,15 @@
 #else
 #define STM32_CRC_USE_CRC1                 FALSE
 #endif
-/** @} */
+
 #endif /* defined(AT32F415C) */
 
+/*===========================================================================*/
+/* AT32F415RB, AT32F415RC.                                                   */
+/*===========================================================================*/
+
 #if defined(AT32F415R) || defined(__DOXYGEN__)
-/**
- * @name    AT32F415R capabilities
- * @{
- */
+
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
 #define AT32_ADC_SUPPORTS_PRESCALER        FALSE
@@ -787,7 +794,7 @@
 #else
 #define STM32_CRC_USE_CRC1                 FALSE
 #endif
-/** @} */
+
 #endif /* defined(AT32F415R) */
 
 #endif /* AT32_REGISTRY_H */

--- a/os/hal/ports/AT32/AT32F415/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F415/at32_registry.h
@@ -56,6 +56,21 @@
 /* Platform capabilities.                                                    */
 /*===========================================================================*/
 
+/**
+ * @name    AT32F415 capabilities
+ * @{
+ */
+
+/* DEBUG helpers.*/
+#define AT32_DEBUG_TMR1_STOP()             DEBUG->CTRL |= DEBUG_CTRL_TMR1_PAUSE
+#define AT32_DEBUG_TMR2_STOP()             DEBUG->CTRL |= DEBUG_CTRL_TMR2_PAUSE
+#define AT32_DEBUG_TMR3_STOP()             DEBUG->CTRL |= DEBUG_CTRL_TMR3_PAUSE
+#define AT32_DEBUG_TMR4_STOP()             DEBUG->CTRL |= DEBUG_CTRL_TMR4_PAUSE
+#define AT32_DEBUG_TMR5_STOP()             DEBUG->CTRL |= DEBUG_CTRL_TMR5_PAUSE
+#define AT32_DEBUG_TMR9_STOP()             DEBUG->CTRL |= DEBUG_CTRL_TMR9_PAUSE
+#define AT32_DEBUG_TMR10_STOP()            DEBUG->CTRL |= DEBUG_CTRL_TMR10_PAUSE
+#define AT32_DEBUG_TMR11_STOP()            DEBUG->CTRL |= DEBUG_CTRL_TMR11_PAUSE
+
 /*===========================================================================*/
 /* Common.                                                                   */
 /*===========================================================================*/

--- a/os/hal/ports/AT32/AT32F415/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F415/at32_registry.h
@@ -27,17 +27,29 @@
 #ifndef AT32_REGISTRY_H
 #define AT32_REGISTRY_H
 
+/* Define by package size */
 #if defined(AT32F415KB) || defined(AT32F415KC)
-#define AT32F415K
+#define AT32F415Kx
 
 #elif defined(AT32F415CB) || defined(AT32F415CC)
-#define AT32F415C
+#define AT32F415Cx
 
 #elif defined(AT32F415RB) ||  defined(AT32F415RC)
-#define AT32F415R
+#define AT32F415Rx
 
 #else
-#error "unsupported or unrecognized AT32F415 member"
+#error "unsupported or unrecognized AT32F415 package size"
+#endif
+
+/* Define by flash size */
+#if defined(AT32F415KB) || defined(AT32F415CB) || defined(AT32F415RB)
+#define AT32F415xB
+
+#elif defined(AT32F415KC) || defined(AT32F415CC) || defined(AT32F415RC)
+#define AT32F415xC
+
+#else
+#error "unsupported or unrecognized AT32F415 flash size"
 #endif
 
 /*===========================================================================*/
@@ -48,11 +60,24 @@
 /* Common.                                                                   */
 /*===========================================================================*/
 
+/* FLASH attributes.*/
+#define AT32_FLASH_NUMBER_OF_BANKS         1
+
+#if defined(AT32F415xB) || defined(__DOXYGEN__)
+#define AT32_FLASH_SECTOR_SIZE             1024U
+#elif defined(AT32F415xC)
+#define AT32_FLASH_SECTOR_SIZE             2048U
+#endif
+
+#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
+#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
+#endif
+
 /*===========================================================================*/
 /* AT32F415KB, AT32F415KC.                                                   */
 /*===========================================================================*/
 
-#if defined(AT32F415K) || defined(__DOXYGEN__)
+#if defined(AT32F415Kx) || defined(__DOXYGEN__)
 
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
@@ -85,18 +110,6 @@
 /* EXINT attributes.*/
 #define AT32_EXINT_NUM_LINES               23
 #define AT32_EXINT_INTEN_MASK              0x00000000U
-
-/* FLASH attributes.*/
-#define AT32_FLASH_NUMBER_OF_BANKS         1
-#if defined(AT32F415KB) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTOR_SIZE             1024U
-#elif defined(AT32F415KC)
-#define AT32_FLASH_SECTOR_SIZE             2048U
-#endif
-
-#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
-#endif
 
 /* GPIO attributes.*/
 #define AT32_HAS_GPIOA                     TRUE
@@ -290,7 +303,7 @@
 /* AT32F415CB, AT32F415CC.                                                   */
 /*===========================================================================*/
 
-#if defined(AT32F415C) || defined(__DOXYGEN__)
+#if defined(AT32F415Cx) || defined(__DOXYGEN__)
 
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
@@ -323,18 +336,6 @@
 /* EXINT attributes.*/
 #define AT32_EXINT_NUM_LINES               23
 #define AT32_EXINT_INTEN_MASK              0x00000000U
-
-/* FLASH attributes.*/
-#define AT32_FLASH_NUMBER_OF_BANKS         1
-#if defined(AT32F415CB) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTOR_SIZE             1024U
-#elif defined(AT32F415CC)
-#define AT32_FLASH_SECTOR_SIZE             2048U
-#endif
-
-#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
-#endif
 
 /* GPIO attributes.*/
 #define AT32_HAS_GPIOA                     TRUE
@@ -536,7 +537,7 @@
 /* AT32F415RB, AT32F415RC.                                                   */
 /*===========================================================================*/
 
-#if defined(AT32F415R) || defined(__DOXYGEN__)
+#if defined(AT32F415Rx) || defined(__DOXYGEN__)
 
 /* ADC attributes.*/
 #define AT32_HAS_ADC1                      TRUE
@@ -569,18 +570,6 @@
 /* EXINT attributes.*/
 #define AT32_EXINT_NUM_LINES               23
 #define AT32_EXINT_INTEN_MASK              0x00000000U
-
-/* FLASH attributes.*/
-#define AT32_FLASH_NUMBER_OF_BANKS         1
-#if defined(AT32F415RB) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTOR_SIZE             1024U
-#elif defined(AT32F415RC)
-#define AT32_FLASH_SECTOR_SIZE             2048U
-#endif
-
-#if !defined(AT32_FLASH_SECTORS_PER_BANK) || defined(__DOXYGEN__)
-#define AT32_FLASH_SECTORS_PER_BANK        128 /* Maximum, can be redefined.*/
-#endif
 
 /* GPIO attributes.*/
 #define AT32_HAS_GPIOA                     TRUE

--- a/os/hal/ports/AT32/AT32F415/hal_efl_lld.c
+++ b/os/hal/ports/AT32/AT32F415/hal_efl_lld.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
 
-#define AT32_FLASH_LINE_SIZE               2U
+#define AT32_FLASH_LINE_SIZE               4U
 #define AT32_FLASH_LINE_MASK               (AT32_FLASH_LINE_SIZE - 1U)
 
 /*===========================================================================*/
@@ -273,18 +273,18 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
 
   /* Actual program implementation.*/
   while (n > 0U) {
-    volatile uint16_t *address;
+    volatile uint32_t *address;
 
     union {
-      uint16_t  hw[AT32_FLASH_LINE_SIZE / sizeof (uint16_t)];
+      uint32_t  w[AT32_FLASH_LINE_SIZE / sizeof (uint32_t)];
       uint8_t   b[AT32_FLASH_LINE_SIZE / sizeof (uint8_t)];
     } line;
 
     /* Unwritten bytes are initialized to all ones.*/
-    line.hw[0] = 0xFFFFU;
+    line.w[0] = 0xFFFFFFFFU;
 
     /* Programming address aligned to flash lines.*/
-    address = (volatile uint16_t *)(efl_lld_descriptor.address +
+    address = (volatile uint32_t *)(efl_lld_descriptor.address +
                                     (offset & ~AT32_FLASH_LINE_MASK));
 
     /* Copying data inside the prepared line.*/
@@ -297,16 +297,17 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
     while ((n > 0U) & ((offset & AT32_FLASH_LINE_MASK) != 0U));
 
     /* Programming line.*/
-    address[0] = line.hw[0];
+    address[0] = line.w[0];
     at32_flash_wait_busy(devp);
 
     err = at32_flash_check_errors(devp);
+
     if (err != FLASH_NO_ERROR) {
       break;
     }
 
     /* Check for flash error.*/
-    if (address[0] != line.hw[0]) {
+    if (address[0] != line.w[0]) {
       err = FLASH_ERROR_PROGRAM;
       break;
     }

--- a/os/hal/ports/AT32/AT32F415/hal_lld.c
+++ b/os/hal/ports/AT32/AT32F415/hal_lld.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -105,10 +105,10 @@ OSAL_IRQ_HANDLER(AT32_DMA2_CH4_5_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
-  /* Check on channel 4 of DMA2. */
+  /* Check on channel 4 of DMA2.*/
   dmaServeInterrupt(AT32_DMA2_STREAM4);
 
-  /* Check on channel 5 of DMA2. */
+  /* Check on channel 5 of DMA2.*/
   dmaServeInterrupt(AT32_DMA2_STREAM5);
 
   OSAL_IRQ_EPILOGUE();
@@ -147,14 +147,14 @@ OSAL_IRQ_HANDLER(AT32_DMA2_CH6_7_HANDLER) {
  */
 void hal_lld_init(void) {
 
-  /* Reset of all peripherals. */
+  /* Reset of all peripherals.*/
   crmResetAPB1(0xFFFFFFFF);
   crmResetAPB2(0xFFFFFFFF);
 
-  /* PWC clocks enabled. */
+  /* PWC clocks enabled.*/
   crmEnablePWCInterface(true);
 
-  /* Initializes the backup domain.*/
+  /* Initializes the battery powered domain.*/
   hal_lld_battery_powered_domain_init();
 
   /* DMA subsystems initialization.*/
@@ -193,12 +193,12 @@ void at32_clock_init(void) {
 
   /* HICK is selected as new source without touching the other fields in
      CFGR. Clearing the register has to be postponed after HICK is the
-     new source. */
+     new source.*/
   CRM->CFG &= ~CRM_CFG_SCLKSEL;             /* Reset SCLKSEL, selecting HICK. */
   while ((CRM->CFG & CRM_CFG_SCLKSTS) != CRM_CFG_SCLKSTS_HICK)
     ;                                       /* Waits until HICK is selected.  */
 
-  /* Registers finally cleared to reset values. */
+  /* Registers finally cleared to reset values.*/
   CRM->CTRL &= ~(0x010D0000);               /* CTRL reset value.              */
   CRM->CFG = 0x00000000;                    /* CFG reset value.               */
   CRM->PLL = 0x00001F10;                    /* PLL reset value.               */
@@ -217,7 +217,7 @@ void at32_clock_init(void) {
   /* HEXT Bypass.*/
   CRM->CTRL |= CRM_CTRL_HEXTEN | CRM_CTRL_HEXTBYPS;
 #endif
-  /* HEXT activation. */
+  /* HEXT activation.*/
   CRM->CTRL |= CRM_CTRL_HEXTEN;
   while (!(CRM->CTRL & CRM_CTRL_HEXTSTBL))
     ;                                       /* Waits until HEXT is stable.    */
@@ -233,13 +233,13 @@ void at32_clock_init(void) {
 #if AT32_ACTIVATE_PLL
   /* PLL activation.*/
 #if (AT32_PLLCFGEN == AT32_PLLCFGEN_SOLID)
-  /* Solid PLL config. */
+  /* Solid PLL config.*/
   CRM->CFG |= AT32_PLLMULT | AT32_PLLHEXTDIV | AT32_PLLRCS;
 #ifdef AT32_PLLCLKREF
   CRM->PLL |= AT32_PLLCLKREF;
 #endif
 #else
-  /* Flexible PLL config. */
+  /* Flexible PLL config.*/
   CRM->CFG |= AT32_PLLHEXTDIV | AT32_PLLRCS;
   CRM->PLL  = AT32_PLL_FR | AT32_PLL_MS | AT32_PLL_NS | AT32_PLLCFGEN;
 #endif

--- a/os/hal/ports/AT32/AT32F415/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F415/hal_lld.h
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -724,10 +724,10 @@
  * @brief   PLL input and output clock frequency.
  */
 #if (AT32_PLLCFGEN == AT32_PLLCFGEN_SOLID) || defined(__DOXYGEN__)
-#define AT32_PLLCLKIN              AT32_PLLRCSCLK  
+#define AT32_PLLCLKIN              AT32_PLLRCSCLK
 #define AT32_PLLCLKOUT             (AT32_PLLCLKIN * AT32_PLLMULT_VALUE)
 #elif AT32_PLLCFGEN == AT32_PLLCFGEN_FLEX
-#define AT32_PLLCLKIN              (AT32_PLLRCSCLK / AT32_PLL_MS_VALUE) 
+#define AT32_PLLCLKIN              (AT32_PLLRCSCLK / AT32_PLL_MS_VALUE)
 #define AT32_PLLFRCLK              (AT32_PLLCLKIN * AT32_PLL_NS_VALUE)
 #define AT32_PLLCLKOUT             (AT32_PLLFRCLK / AT32_PLL_FR_VALUE)
 

--- a/os/hal/ports/AT32/AT32F435_437/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F435_437/at32_registry.h
@@ -101,6 +101,29 @@
 /*===========================================================================*/
 /* Platform capabilities.                                                    */
 /*===========================================================================*/
+
+/**
+ * @name    AT32F435_437 capabilities
+ * @{
+ */
+
+/* DEBUG helpers.*/
+#define AT32_DEBUG_TMR1_STOP()             DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR1_PAUSE
+#define AT32_DEBUG_TMR2_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR2_PAUSE
+#define AT32_DEBUG_TMR3_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR3_PAUSE
+#define AT32_DEBUG_TMR4_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR4_PAUSE
+#define AT32_DEBUG_TMR5_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR5_PAUSE
+#define AT32_DEBUG_TMR6_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR6_PAUSE
+#define AT32_DEBUG_TMR7_STOP()             DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR7_PAUSE
+#define AT32_DEBUG_TMR8_STOP()             DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR8_PAUSE
+#define AT32_DEBUG_TMR9_STOP()             DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR9_PAUSE
+#define AT32_DEBUG_TMR10_STOP()            DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR10_PAUSE
+#define AT32_DEBUG_TMR11_STOP()            DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR11_PAUSE
+#define AT32_DEBUG_TMR12_STOP()            DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR12_PAUSE
+#define AT32_DEBUG_TMR13_STOP()            DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR13_PAUSE
+#define AT32_DEBUG_TMR14_STOP()            DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR14_PAUSE
+#define AT32_DEBUG_TMR20_STOP()            DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR20_PAUSE
+
 #if defined(AT32F435_437Cx) || defined(__DOXYGEN__)
 /**
  * @name    AT32F435Cx capabilities

--- a/os/hal/ports/AT32/AT32F435_437/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F435_437/at32_registry.h
@@ -1,6 +1,8 @@
 /*
-    ChibiOS - Copyright (C) 2023..2024 Zhaqian
-    ChibiOS - Copyright (C) 2024 Maxjta
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -273,10 +275,10 @@
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                   2
 #define AT32_HAS_OTG1                       TRUE
-#define AT32_OTG1_ENDPOINTS                 8
+#define AT32_OTG1_ENDPOINTS                 7
 
 #define AT32_HAS_OTG2                       TRUE
-#define AT32_OTG2_ENDPOINTS                 8
+#define AT32_OTG2_ENDPOINTS                 7
 #define AT32_OTG2_SUPPORTS_HS               FALSE
 
 #define AT32_HAS_USB                        FALSE
@@ -473,10 +475,10 @@
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                   2
 #define AT32_HAS_OTG1                       TRUE
-#define AT32_OTG1_ENDPOINTS                 8
+#define AT32_OTG1_ENDPOINTS                 7
 
 #define AT32_HAS_OTG2                       TRUE
-#define AT32_OTG2_ENDPOINTS                 8
+#define AT32_OTG2_ENDPOINTS                 7
 #define AT32_OTG2_SUPPORTS_HS               FALSE
 
 #define AT32_HAS_USB                        FALSE
@@ -674,10 +676,10 @@
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                   2
 #define AT32_HAS_OTG1                       TRUE
-#define AT32_OTG1_ENDPOINTS                 8
+#define AT32_OTG1_ENDPOINTS                 7
 
 #define AT32_HAS_OTG2                       TRUE
-#define AT32_OTG2_ENDPOINTS                 8
+#define AT32_OTG2_ENDPOINTS                 7
 #define AT32_OTG2_SUPPORTS_HS               FALSE
 
 #define AT32_HAS_USB                        FALSE
@@ -877,10 +879,10 @@
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                   2
 #define AT32_HAS_OTG1                       TRUE
-#define AT32_OTG1_ENDPOINTS                 8
+#define AT32_OTG1_ENDPOINTS                 7
 
 #define AT32_HAS_OTG2                       TRUE
-#define AT32_OTG2_ENDPOINTS                 8
+#define AT32_OTG2_ENDPOINTS                 7
 #define AT32_OTG2_SUPPORTS_HS               FALSE
 
 #define AT32_HAS_USB                        FALSE

--- a/os/hal/ports/AT32/AT32F435_437/hal_efl_lld.c
+++ b/os/hal/ports/AT32/AT32F435_437/hal_efl_lld.c
@@ -1,6 +1,8 @@
 /*
-    ChibiOS - Copyright (C) 2023..2024 Zhaqian
-    ChibiOS - Copyright (C) 2024 Maxjta
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,7 +18,7 @@
 */
 
 /**
- * @file    AT32F435_437/hal_efl_lld.c
+ * @file    hal_efl_lld.c
  * @brief   AT32F435_437 Embedded Flash subsystem low level driver source.
  *
  * @addtogroup HAL_EFL
@@ -33,7 +35,7 @@
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
 
-#define AT32_FLASH_LINE_SIZE               2U
+#define AT32_FLASH_LINE_SIZE               4U
 #define AT32_FLASH_LINE_MASK               (AT32_FLASH_LINE_SIZE - 1U)
 
 #define AT32_FLASH_GET_BANK(addr, bank)                                            \
@@ -328,18 +330,18 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
 
   /* Actual program implementation.*/
   while (n > 0U) {
-    volatile uint16_t *address;
+    volatile uint32_t *address;
 
     union {
-      uint16_t  hw[AT32_FLASH_LINE_SIZE / sizeof (uint16_t)];
+      uint32_t  w[AT32_FLASH_LINE_SIZE / sizeof (uint32_t)];
       uint8_t   b[AT32_FLASH_LINE_SIZE / sizeof (uint8_t)];
     } line;
 
     /* Unwritten bytes are initialized to all ones.*/
-    line.hw[0] = 0xFFFFU;
+    line.w[0] = 0xFFFFFFFFU;
 
     /* Programming address aligned to flash lines.*/
-    address = (volatile uint16_t *)(efl_lld_descriptor.address +
+    address = (volatile uint32_t *)(efl_lld_descriptor.address +
                                     (offset & ~AT32_FLASH_LINE_MASK));
 
     /* Copying data inside the prepared line.*/
@@ -351,7 +353,7 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
     }
     while ((n > 0U) & ((offset & AT32_FLASH_LINE_MASK) != 0U));
     /* Programming line.*/
-    address[0] = line.hw[0];
+    address[0] = line.w[0];
     at32_flash_wait_busy(devp, bank);
 
     uint32_t sts = 0;
@@ -385,7 +387,7 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
     }
 
     /* Check for flash error.*/
-    if (address[0] != line.hw[0]) {
+    if (address[0] != line.w[0]) {
       err = FLASH_ERROR_PROGRAM;
       break;
     }

--- a/os/hal/ports/AT32/LLD/ADCv1/hal_adc_lld.c
+++ b/os/hal/ports/AT32/LLD/ADCv1/hal_adc_lld.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -265,6 +265,7 @@ void adc_lld_start_conversion(ADCDriver *adcp) {
          is enabled in order to allow streaming processing.*/
       mode |= AT32_DMA_CCTRL_HDTIEN;
     }
+    ctrl2 = 0U;
   }
   dmaStreamSetMemory0(adcp->dmastp, adcp->samples);
   dmaStreamSetTransactionSize(adcp->dmastp, (uint32_t)grpp->num_channels *
@@ -286,10 +287,12 @@ void adc_lld_start_conversion(ADCDriver *adcp) {
   adcp->adc->CTRL1 = grpp->ctrl1 | ADC_CTRL1_SQEN;
 
   /* Enforcing the mandatory bits in CTRL2.*/
-  ctrl2 = grpp->ctrl2 | ADC_CTRL2_OCDMAEN | ADC_CTRL2_ADCEN;
+  ctrl2 |= grpp->ctrl2 | ADC_CTRL2_OCDMAEN | ADC_CTRL2_ADCEN;
 
-  if ((ctrl2 & (ADC_CTRL2_OCTEN | ADC_CTRL2_PCTEN)) == 0)
+  if ((ctrl2 & (ADC_CTRL2_OCTEN | ADC_CTRL2_PCTEN)) == 0) {
     ctrl2 |= ADC_CTRL2_RPEN;
+  }
+
   adcp->adc->CTRL2 = grpp->ctrl2 | ctrl2;
 
   /* ADC start by writing ADC_CTRL2_ADCEN a second time.*/

--- a/os/hal/ports/AT32/LLD/ADCv2/hal_adc_lld.c
+++ b/os/hal/ports/AT32/LLD/ADCv2/hal_adc_lld.c
@@ -1,8 +1,8 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
-    ChibiOS - Copyright (C) 2024..2025 Maxjta
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
+    ChibiOS - Copyright (C) 2024..2026 Maxjta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -273,6 +273,7 @@ void adc_lld_start_conversion(ADCDriver *adcp) {
          is enabled in order to allow streaming processing.*/
       mode |= AT32_DMA_CCTRL_HDTIEN;
     }
+    ctrl2 = 0U;
   }
   dmaStreamSetMemory0(adcp->dmastp, adcp->samples);
   dmaStreamSetTransactionSize(adcp->dmastp, (uint32_t)grpp->num_channels *
@@ -294,10 +295,12 @@ void adc_lld_start_conversion(ADCDriver *adcp) {
   adcp->adc->CTRL1 = grpp->ctrl1 | ADC_CTRL1_SQEN;
 
   /* Enforcing the mandatory bits in CTRL2.*/
-  ctrl2 = grpp->ctrl2 | ADC_CTRL2_OCDMAEN | ADC_CTRL2_ADCEN;
+  ctrl2 |= grpp->ctrl2 | ADC_CTRL2_OCDMAEN | ADC_CTRL2_ADCEN;
 
-  if ((ctrl2 & (ADC_CTRL2_OCTEN | ADC_CTRL2_PCTEN)) == 0)
+  if ((ctrl2 & (ADC_CTRL2_OCTEN | ADC_CTRL2_PCTEN)) == 0) {
     ctrl2 |= ADC_CTRL2_RPEN;
+  }
+
   adcp->adc->CTRL2 = grpp->ctrl2 | ctrl2;
 
   /* ADC start by writing ADC_CTRL2_ADCEN a second time.*/

--- a/os/hal/ports/AT32/LLD/SDIOv1/hal_sdc_lld.c
+++ b/os/hal/ports/AT32/LLD/SDIOv1/hal_sdc_lld.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -278,21 +278,21 @@ static bool sdc_lld_wait_transaction_end(SDCDriver *sdcp, uint32_t n,
     osalThreadSuspendS(&sdcp->thread);
   }
 
-  /* Stopping operations, waiting for transfer completion at DMA level, then
-     the stream is disabled and cleared.*/
-  dmaWaitCompletion(sdcp->dma);
-  sdcp->sdio->INTEN  = 0U;
-  sdcp->sdio->DTCTRL = 0U;
+  /* Mask has now been set to zero by interrupt handler. */
+  osalSysUnlock();
 
+  /* Data transfer not complete, let error cleanup stop DMA.*/
   if ((sdcp->sdio->STS & SDIO_STS_DTCMPL) == 0) {
-    osalSysUnlock();
     return HAL_FAILED;
   }
 
+  /* Waiting for transfer completion at DMA level, then the stream is disabled
+     and cleared.*/
+  dmaWaitCompletion(sdcp->dma);
+  sdcp->sdio->DTCTRL = 0U;
+
   /* Clearing status.*/
   sdcp->sdio->INTCLR = SDIO_INTCLR_ALL_FLAGS;
-
-  osalSysUnlock();
 
   /* Finalize transaction.*/
   if (n > 1U)
@@ -766,15 +766,15 @@ bool sdc_lld_read_aligned(SDCDriver *sdcp, uint32_t startblk,
                        SDIO_INTEN_DTCMPLIEN;
   sdcp->sdio->DTLEN  = blocks * MMCSD_BLOCK_SIZE;
 
+  if (sdc_lld_prepare_read(sdcp, startblk, blocks, resp) == true)
+    goto error;
+
   /* Transaction starts just after TFREN bit setting.*/
   sdcp->sdio->DTCTRL = SDIO_DTCTRL_TFRDIR |
                        SDIO_DTCTRL_BLKSIZE_3 |
                        SDIO_DTCTRL_BLKSIZE_0 |
                        SDIO_DTCTRL_DMAEN |
                        SDIO_DTCTRL_TFREN;
-
-  if (sdc_lld_prepare_read(sdcp, startblk, blocks, resp) == true)
-    goto error;
 
   if (sdc_lld_wait_transaction_end(sdcp, blocks, resp) == true)
     goto error;

--- a/os/hal/ports/AT32/LLD/SDIOv1/hal_sdc_lld.h
+++ b/os/hal/ports/AT32/LLD/SDIOv1/hal_sdc_lld.h
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -121,18 +121,6 @@
 
 #if !defined(AT32_DMA_REQUIRED)
 #define AT32_DMA_REQUIRED
-#endif
-
-/*
- * SDIO clock divider.
- */
-#if AT32_HCLK > 48000000
-#define AT32_SDIO_DIV_HS                    1
-#define AT32_SDIO_DIV_LS                    178
-#else
-
-#define AT32_SDIO_DIV_HS                    0
-#define AT32_SDIO_DIV_LS                    118
 #endif
 
 /*===========================================================================*/

--- a/os/hal/ports/AT32/LLD/SYSTICKv1/hal_st_lld.c
+++ b/os/hal/ports/AT32/LLD/SYSTICKv1/hal_st_lld.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,11 +60,7 @@
 #define ST_NUMBER                           AT32_TMR1_CH_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK2
 #define ST_ENABLE_CLOCK()                   crmEnableTMR1(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR1_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR1_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR1_STOP()
 
 #elif AT32_ST_USE_TIMER == 2
 
@@ -80,11 +76,7 @@
 #define ST_NUMBER                           AT32_TMR2_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK1
 #define ST_ENABLE_CLOCK()                   crmEnableTMR2(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR2_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR2_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR2_STOP()
 
 #elif AT32_ST_USE_TIMER == 3
 
@@ -100,11 +92,7 @@
 #define ST_NUMBER                           AT32_TMR3_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK1
 #define ST_ENABLE_CLOCK()                   crmEnableTMR3(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR3_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR3_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR3_STOP()
 
 #elif AT32_ST_USE_TIMER == 4
 
@@ -120,11 +108,7 @@
 #define ST_NUMBER                           AT32_TMR4_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK1
 #define ST_ENABLE_CLOCK()                   crmEnableTMR4(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR4_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR4_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR4_STOP()
 
 #elif AT32_ST_USE_TIMER == 5
 
@@ -140,9 +124,7 @@
 #define ST_NUMBER                           AT32_TMR5_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK1
 #define ST_ENABLE_CLOCK()                   crmEnableTMR5(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR5_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR5_STOP()
 
 #elif AT32_ST_USE_TIMER == 9
 
@@ -158,11 +140,7 @@
 #define ST_NUMBER                           AT32_TMR9_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK2
 #define ST_ENABLE_CLOCK()                   crmEnableTMR9(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR9_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR9_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR9_STOP()
 
 #elif AT32_ST_USE_TIMER == 10
 
@@ -178,11 +156,7 @@
 #define ST_NUMBER                           AT32_TMR10_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK2
 #define ST_ENABLE_CLOCK()                   crmEnableTMR10(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR10_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR10_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR10_STOP()
 
 #elif AT32_ST_USE_TIMER == 11
 
@@ -198,11 +172,7 @@
 #define ST_NUMBER                           AT32_TMR11_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK2
 #define ST_ENABLE_CLOCK()                   crmEnableTMR11(true)
-#if defined(AT32F415)
-#define ST_ENABLE_PAUSE()                   DEBUG->CTRL |= DEBUG_CTRL_TMR11_PAUSE
-#else
-#define ST_ENABLE_PAUSE()                   DEBUG->APB2_PAUSE |= DEBUG_APB2_PAUSE_TMR11_PAUSE
-#endif
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR11_STOP()
 
 #elif AT32_ST_USE_TIMER == 13
 
@@ -218,7 +188,7 @@
 #define ST_NUMBER                           AT32_TMR13_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK1
 #define ST_ENABLE_CLOCK()                   crmEnableTMR13(true)
-#define ST_ENABLE_PAUSE()                   DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR13_PAUSE
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR13_STOP()
 
 #elif AT32_ST_USE_TIMER == 14
 
@@ -234,7 +204,7 @@
 #define ST_NUMBER                           AT32_TMR14_NUMBER
 #define ST_CLOCK_SRC                        AT32_TMRCLK1
 #define ST_ENABLE_CLOCK()                   crmEnableTMR14(true)
-#define ST_ENABLE_PAUSE()                   DEBUG->APB1_PAUSE |= DEBUG_APB1_PAUSE_TMR14_PAUSE
+#define ST_ENABLE_PAUSE()                   AT32_DEBUG_TMR14_STOP()
 
 #else
 #error "AT32_ST_USE_TIMER specifies an unsupported timer"

--- a/os/hal/ports/AT32/LLD/USARTv2/hal_sio_lld.c
+++ b/os/hal/ports/AT32/LLD/USARTv2/hal_sio_lld.c
@@ -1,7 +1,7 @@
 /*
     ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-    ChibiOS - Copyright (C) 2023..2025 HorrorTroll
-    ChibiOS - Copyright (C) 2023..2025 Zhaqian
+    ChibiOS - Copyright (C) 2023..2026 HorrorTroll
+    ChibiOS - Copyright (C) 2023..2026 Zhaqian
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -553,7 +553,7 @@ sioevents_t sio_lld_get_events(SIODriver *siop) {
  * @param[in] buffer        pointer to the buffer for read frames
  * @param[in] n             maximum number of frames to be read
  * @return                  The number of frames copied from the buffer.
- * @retval 0                if the TX FIFO is full.
+ * @retval 0                if the RX FIFO is empty.
  */
 size_t sio_lld_read(SIODriver *siop, uint8_t *buffer, size_t n) {
   size_t rd;
@@ -732,7 +732,7 @@ void sio_lld_serve_interrupt(SIODriver *siop) {
     /* If there are no errors then we check for the other RX-related
        status flags.*/
     else {
-      /* Idle RX flag.*/
+      /* Idle RX flag. Note: At start the USART will produce an IDLEF interrupt.*/
       if ((sts & USART_STS_IDLEF) != 0U) {
 
         /* Interrupt source disabled.*/


### PR DESCRIPTION
### Changelog:
- Update CMSIS for AT32F402/405/415.
- Correct USB Endpoint for AT32F402/405/435/437 and update registry files.
- Change 16 to 32 bits flash programming on EFL driver for AT32 series and update registry files.
- Added timers-freeze macros to AT32 registry. Removed all device dependencies from hal_st_lld.c.
- Update platform files for AT32F402/405/F415. Decrease 1 ERTC clock cycle for AT32F402/405.
- Support reduce power consumption for OTGHS PHY when OTGHS is not used.
- Update ADC v1/2, USART v2, SDIO LLD drivers.