### PR TITLE
Compatibility updates with latest `ChibiOS/stable_21.11.x`.

### DIFF
--- a/os/hal/ports/AT32/AT32F402_405/hal_efl_lld.h
+++ b/os/hal/ports/AT32/AT32F402_405/hal_efl_lld.h
@@ -79,14 +79,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  FLASH_TypeDef             *flash
+  FLASH_TypeDef             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/AT32/AT32F402_405/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F402_405/hal_lld.h
@@ -1174,6 +1174,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/AT32/AT32F415/hal_efl_lld.h
+++ b/os/hal/ports/AT32/AT32F415/hal_efl_lld.h
@@ -78,14 +78,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  FLASH_TypeDef             *flash
+  FLASH_TypeDef             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/AT32/AT32F415/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F415/hal_lld.h
@@ -959,6 +959,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/AT32/AT32F435_437/hal_efl_lld.h
+++ b/os/hal/ports/AT32/AT32F435_437/hal_efl_lld.h
@@ -85,14 +85,14 @@ typedef enum {
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  FLASH_TypeDef             *flash
+  FLASH_TypeDef             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/AT32/AT32F435_437/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F435_437/hal_lld.h
@@ -1164,6 +1164,18 @@
 
 #define DEBUG_CTRL_TMR2_PAUSE DEBUG_APB1_PAUSE_TMR2_PAUSE
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /* Various helpers.*/
 #include "nvic.h"
 #include "mpu_v7m.h"

--- a/os/hal/ports/AT32/LLD/ADCv1/hal_adc_lld.h
+++ b/os/hal/ports/AT32/LLD/ADCv1/hal_adc_lld.h
@@ -185,14 +185,14 @@ typedef uint32_t adcerror_t;
   /* Pointer to associated DMA channel.*/                                   \
   const at32_dma_stream_t   *dmastp;                                        \
   /* DMA mode bit mask.*/                                                   \
-  uint32_t                  dmamode
+  uint32_t                  dmamode;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -231,7 +231,7 @@ typedef uint32_t adcerror_t;
   uint32_t                  osq2;                                           \
   /* ADC OSQ3 register initialization data.                                 \
      NOTE: Conversion group sequence 1...6.*/                               \
-  uint32_t                  osq3
+  uint32_t                  osq3;
 
 /**
  * @name    Sequences building helper macros

--- a/os/hal/ports/AT32/LLD/ADCv2/hal_adc_lld.h
+++ b/os/hal/ports/AT32/LLD/ADCv2/hal_adc_lld.h
@@ -244,14 +244,14 @@ typedef uint32_t adcerror_t;
   /* Pointer to associated DMA channel.*/                                   \
   const at32_dma_stream_t   *dmastp;                                        \
   /* DMA mode bit mask.*/                                                   \
-  uint32_t                  dmamode
+  uint32_t                  dmamode;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -290,7 +290,7 @@ typedef uint32_t adcerror_t;
   uint32_t                  osq2;                                           \
   /* ADC OSQ3 register initialization data.                                 \
      NOTE: Conversion group sequence 1...6.*/                               \
-  uint32_t                  osq3
+  uint32_t                  osq3;
 
 /**
  * @name    Sequences building helper macros

--- a/os/hal/ports/AT32/LLD/RTCv2/hal_rtc_lld.h
+++ b/os/hal/ports/AT32/LLD/RTCv2/hal_rtc_lld.h
@@ -206,7 +206,7 @@ typedef struct hal_ertc_wakeup {
   /* Pointer to the ERTC registers block.*/                                 \
   ERTC_TypeDef              *ertc;                                          \
   /* Callback pointer.*/                                                    \
-  rtccb_t                   callback
+  rtccb_t                   callback;
 
 /*===========================================================================*/
 /* Driver macros.                                                            */

--- a/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.h
+++ b/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.h
@@ -232,7 +232,7 @@
   /* Sink for discarded data.*/                                             \
   uint32_t                  rxsink;                                         \
   /* Source for default TX pattern.*/                                       \
-  uint32_t                  txsource
+  uint32_t                  txsource;
 
 /**
  * @brief   Low level fields of the SPI configuration structure.
@@ -241,7 +241,7 @@
   /* SPI CTRL1 register initialization data.*/                              \
   uint16_t                  ctrl1;                                          \
   /* SPI CTRL2 register initialization data.*/                              \
-  uint16_t                  ctrl2
+  uint16_t                  ctrl2;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/AT32/LLD/SPIv2/hal_spi_v2_lld.h
+++ b/os/hal/ports/AT32/LLD/SPIv2/hal_spi_v2_lld.h
@@ -233,7 +233,7 @@
   /* Sink for discarded data.*/                                             \
   uint32_t                  rxsink;                                         \
   /* Source for default TX pattern.*/                                       \
-  uint32_t                  txsource
+  uint32_t                  txsource;
 
 /**
  * @brief   Low level fields of the SPI configuration structure.
@@ -242,7 +242,7 @@
   /* SPI CTRL1 register initialization data.*/                              \
   uint16_t                  ctrl1;                                          \
   /* SPI CTRL2 register initialization data.*/                              \
-  uint16_t                  ctrl2
+  uint16_t                  ctrl2;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/AT32/LLD/USARTv2/hal_sio_lld.h
+++ b/os/hal/ports/AT32/LLD/USARTv2/hal_sio_lld.h
@@ -246,7 +246,7 @@
   /* Pointer to the USARTx registers block.*/                               \
   USART_TypeDef             *usart;                                         \
   /* Clock frequency for the associated USART/UART.*/                       \
-  uint32_t                  clock
+  uint32_t                  clock;
 
 /**
  * @brief   Low level fields of the SIO configuration structure.
@@ -259,7 +259,7 @@
   /* USART CTRL2 register initialization data.*/                            \
   uint32_t                  ctrl2;                                          \
   /* USART CTRL3 register initialization data.*/                            \
-  uint32_t                  ctrl3
+  uint32_t                  ctrl3;
 
 /**
  * @brief   Determines the state of the RX FIFO.

--- a/os/hal/ports/ES32/FS026/hal_lld.h
+++ b/os/hal/ports/ES32/FS026/hal_lld.h
@@ -109,6 +109,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/ES32/LLD/ADCv1/hal_adc_lld.h
+++ b/os/hal/ports/ES32/LLD/ADCv1/hal_adc_lld.h
@@ -72,14 +72,14 @@ typedef uint32_t adcerror_t;
   /* Pointer to associated DMA channel.*/                                   \
   const void  *dmastp;                                        \
   /* DMA mode bit mask.*/                                                   \
-  uint32_t                  dmamode
+  uint32_t                  dmamode;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -99,7 +99,7 @@ typedef uint32_t adcerror_t;
   /* ADC CHSELR register initialization data.                               \
      NOTE: The number of bits at logic level one in this register must      \
            be equal to the number in the @p num_channels field.*/           \
-  uint32_t                  chselr
+  uint32_t                  chselr;
 
 
 /*===========================================================================*/

--- a/os/hal/ports/GD/GD32VF103/DACv1/hal_dac_lld.h
+++ b/os/hal/ports/GD/GD32VF103/DACv1/hal_dac_lld.h
@@ -248,7 +248,7 @@ typedef enum {
   /* DAC channel parameters.*/                                              \
   const dacparams_t         *params;                                        \
   /* Associated DMA.*/                                                      \
-  const gd32_dma_stream_t  *dma
+  const gd32_dma_stream_t  *dma;
 
 /**
  * @brief   Low level fields of the DAC configuration structure.
@@ -259,7 +259,7 @@ typedef enum {
   /* DAC data holding register mode.*/                                      \
   dacdhrmode_t              datamode;                                       \
   /* DAC control register lower 16 bits.*/                                  \
-  uint32_t                  ctl
+  uint32_t                  ctl;
 
 /**
  * @brief   Low level fields of the DAC group configuration structure.
@@ -268,7 +268,7 @@ typedef enum {
   /* DAC initialization data. This field contains the (not shifted) value   \
      to be put into the TSEL field of the DAC CR register during            \
      initialization. All other fields are handled internally.*/             \
-  uint32_t                  trigger
+  uint32_t                  trigger;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/GD/GD32VF103/RTCv1/hal_rtc_lld.h
+++ b/os/hal/ports/GD/GD32VF103/RTCv1/hal_rtc_lld.h
@@ -117,7 +117,7 @@ typedef struct hal_rtc_alarm {
   /* Pointer to the RTC registers block.*/                                  \
   RTC_TypeDef               *rtc;                                           \
   /* Callback pointer.*/                                                    \
-  rtccb_t           callback
+  rtccb_t           callback;
 
 /*===========================================================================*/
 /* Driver macros.                                                            */

--- a/os/hal/ports/GD/GD32VF103/SPIv1/hal_i2s_lld.h
+++ b/os/hal/ports/GD/GD32VF103/SPIv1/hal_i2s_lld.h
@@ -225,7 +225,7 @@
   /* RX DMA mode bit mask.*/                                                \
   uint32_t                  rxdmamode;                                      \
   /* TX DMA mode bit mask.*/                                                \
-  uint32_t                  txdmamode
+  uint32_t                  txdmamode;
 
 /**
  * @brief   Low level fields of the I2S configuration structure.
@@ -243,7 +243,7 @@
   /* Configuration of the I2SPSC register.                                   \
      NOTE: See the GD32 reference manual, this register is used for        \
            the I2S clock setup.*/                                           \
-  int16_t                   i2spsc
+  int16_t                   i2spsc;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/GD/GD32VF103/SPIv1/hal_spi_lld.h
+++ b/os/hal/ports/GD/GD32VF103/SPIv1/hal_spi_lld.h
@@ -210,7 +210,7 @@
   /* RX DMA mode bit mask.*/                                                \
   uint32_t                  rxdmamode;                                      \
   /* TX DMA mode bit mask.*/                                                \
-  uint32_t                  txdmamode
+  uint32_t                  txdmamode;
 
 /**
  * @brief   Low level fields of the SPI configuration structure.
@@ -219,7 +219,7 @@
   /* SPI CR1 register initialization data.*/                                \
   uint16_t                  ctl0;                                            \
   /* SPI CR2 register initialization data.*/                                \
-  uint16_t                  ctl1
+  uint16_t                  ctl1;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/GD/GD32VF103/hal_adc_lld.h
+++ b/os/hal/ports/GD/GD32VF103/hal_adc_lld.h
@@ -162,14 +162,14 @@ typedef enum {
   /* Pointer to associated DMA channel.*/                                   \
   const gd32_dma_stream_t  *dmastp;                                        \
   /* DMA mode bit mask.*/                                                   \
-  uint32_t                  dmamode
+  uint32_t                  dmamode;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -200,7 +200,7 @@ typedef enum {
   uint32_t                  rsq1;                                           \
   /* ADC RSQ2 register initialization data.                                 \
      NOTE: Conversion group sequence 1...6.*/                               \
-  uint32_t                  rsq2
+  uint32_t                  rsq2;
 
 /**
  * @name    Sequences building helper macros

--- a/os/hal/ports/GD/GD32VF103/hal_efl_lld.h
+++ b/os/hal/ports/GD/GD32VF103/hal_efl_lld.h
@@ -77,14 +77,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  FLASH_TypeDef             *flash
+  FLASH_TypeDef             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/GD/GD32VF103/hal_lld.h
+++ b/os/hal/ports/GD/GD32VF103/hal_lld.h
@@ -954,6 +954,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/HT32/HT32F165x/hal_lld.h
+++ b/os/hal/ports/HT32/HT32F165x/hal_lld.h
@@ -148,6 +148,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/HT32/HT32F523xx/hal_lld.h
+++ b/os/hal/ports/HT32/HT32F523xx/hal_lld.h
@@ -150,6 +150,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/KINETIS/K20x/hal_lld.h
+++ b/os/hal/ports/KINETIS/K20x/hal_lld.h
@@ -282,6 +282,18 @@ typedef uint32_t halrtcnt_t;
  */
 #define hal_lld_get_counter_frequency()     0
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/KINETIS/K60x/hal_lld.h
+++ b/os/hal/ports/KINETIS/K60x/hal_lld.h
@@ -302,6 +302,18 @@ typedef uint32_t halrtcnt_t;
  */
 #define hal_lld_get_counter_frequency()     0
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/KINETIS/KL2x/hal_lld.h
+++ b/os/hal/ports/KINETIS/KL2x/hal_lld.h
@@ -296,6 +296,18 @@ typedef uint32_t halrtcnt_t;
  */
 #define hal_lld_get_counter_frequency()     0
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/KINETIS/LLD/USBHSv1/hal_usb_lld.c
+++ b/os/hal/ports/KINETIS/LLD/USBHSv1/hal_usb_lld.c
@@ -210,6 +210,8 @@ void usb_packet_receive(USBDriver *usbp, usbep_t ep, size_t n)
  * @isr
  */
 OSAL_IRQ_HANDLER(KINETIS_USB_IRQ_VECTOR) {
+  OSAL_IRQ_PROLOGUE();
+
   USBDriver *usbp = &USBD1;
 
   /* Bail out if driver is stopped or being torn down */
@@ -232,8 +234,6 @@ OSAL_IRQ_HANDLER(KINETIS_USB_IRQ_VECTOR) {
 
 
   uint8_t istat = USB0->ISTAT;
-
-  OSAL_IRQ_PROLOGUE();
 
   /* 04 - Bit2 - Start Of Frame token received */
   if(istat & USBx_ISTAT_SOFTOK) {

--- a/os/hal/ports/KINETIS/MK66F18/hal_lld.h
+++ b/os/hal/ports/KINETIS/MK66F18/hal_lld.h
@@ -302,6 +302,18 @@ typedef uint32_t halrtcnt_t;
  */
 #define hal_lld_get_counter_frequency()     0
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/LPC/LLD/SPI/hal_spi_lld.h
+++ b/os/hal/ports/LPC/LLD/SPI/hal_spi_lld.h
@@ -78,7 +78,7 @@
   size_t                                      size;                         \
   size_t                                      cnt;                          \
   void*                                       rxbuf;                        \
-  const void*                                 txbuf
+  const void*                                 txbuf;
 
 
 /**
@@ -89,7 +89,8 @@
   uint8_t                                     clock_divider;                \
   uint8_t                                     clock_prescaler;              \
   uint8_t                                     clock_rate;                   \
-  uint8_t                                     data_size
+  uint8_t                                     data_size;
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/LPC/LPC11Uxx/hal_lld.h
+++ b/os/hal/ports/LPC/LPC11Uxx/hal_lld.h
@@ -171,6 +171,18 @@ typedef struct _ROM {
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/MIMXRT1062/MIMXRT1062/hal_lld.h
+++ b/os/hal/ports/MIMXRT1062/MIMXRT1062/hal_lld.h
@@ -92,6 +92,18 @@ typedef uint32_t halrtcnt_t;
  */
 #define hal_lld_get_counter_frequency()     0
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/MIMXRT1064/MIMXRT1064/hal_lld.h
+++ b/os/hal/ports/MIMXRT1064/MIMXRT1064/hal_lld.h
@@ -92,6 +92,18 @@ typedef uint32_t halrtcnt_t;
  */
 #define hal_lld_get_counter_frequency()     0
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/MSP430X/hal_lld.h
+++ b/os/hal/ports/MSP430X/hal_lld.h
@@ -230,6 +230,18 @@
 #define DIVIDER(x) DIV_HELPER(x)
 #define DIV_HELPER(x) DIVM__ ## x
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/NRF5/LLD/ADCv1/hal_adc_lld.h
+++ b/os/hal/ports/NRF5/LLD/ADCv1/hal_adc_lld.h
@@ -111,7 +111,7 @@ typedef uint8_t adc_channels_num_t;
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 #define adc_lld_configuration_group_fields                                  \
   /**                                                                       \

--- a/os/hal/ports/NRF5/LLD/ADCv2/hal_adc_lld.h
+++ b/os/hal/ports/NRF5/LLD/ADCv2/hal_adc_lld.h
@@ -117,14 +117,14 @@ struct adc_lld_channel_config {
   /* @brief Current sample counter.*/                                       \
   size_t                   counter;                                         \
   /* @brief Current channel counter.*/                                      \
-  size_t                   ch_counter
+  size_t                   ch_counter;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -139,7 +139,7 @@ struct adc_lld_channel_config {
   /* @brief ADC SAMPLERATE register details.*/                              \
   uint32_t                  samplerate;                                     \
   /* @brief ADC channel configurations.*/                                   \
-  struct adc_lld_channel_config channels[NRF5_ADC_MAX_CHANNELS]
+  struct adc_lld_channel_config channels[NRF5_ADC_MAX_CHANNELS];
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/NRF5/NRF51822/hal_lld.h
+++ b/os/hal/ports/NRF5/NRF51822/hal_lld.h
@@ -89,6 +89,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/NRF5/NRF52832/hal_efl_lld.h
+++ b/os/hal/ports/NRF5/NRF52832/hal_efl_lld.h
@@ -93,7 +93,7 @@ typedef struct {
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/NRF5/NRF52832/hal_lld.h
+++ b/os/hal/ports/NRF5/NRF52832/hal_lld.h
@@ -102,6 +102,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/NUMICRO/LLD/FLASHv1/hal_efl_lld.h
+++ b/os/hal/ports/NUMICRO/LLD/FLASHv1/hal_efl_lld.h
@@ -124,14 +124,14 @@ typedef enum {
  */
 #define efl_lld_driver_fields                                               \
   /* The currently used bank.*/                                       \
-  nuc123_eflbank_t bank
+  nuc123_eflbank_t bank;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t dummy
+  uint32_t dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/NUMICRO/NUC123/hal_lld.h
+++ b/os/hal/ports/NUMICRO/NUC123/hal_lld.h
@@ -306,6 +306,18 @@ which need the starting address */
 /* Alias for compatibility */
 #define SystemUnlockReg() UNLOCKREG()
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/SAM/LLD/ADCv1/hal_adc_lld.h
+++ b/os/hal/ports/SAM/LLD/ADCv1/hal_adc_lld.h
@@ -100,7 +100,7 @@ typedef uint32_t adcerror_t;
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.

--- a/os/hal/ports/SAM/SAMD21A/hal_efl_lld.h
+++ b/os/hal/ports/SAM/SAMD21A/hal_efl_lld.h
@@ -75,14 +75,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Dummy field, it is not needed.*/                                       \
-  nvmctrl_registers_t       *flash
+  nvmctrl_registers_t       *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SAM/SAMD21A/hal_lld.h
+++ b/os/hal/ports/SAM/SAMD21A/hal_lld.h
@@ -145,6 +145,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/SN32/LLD/SN32F2xx/ADC/hal_adc_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/ADC/hal_adc_lld.h
@@ -194,14 +194,14 @@ typedef uint32_t adcerror_t;
   /* @brief Current position in the buffer. */                              \
   size_t                    current_index;                                  \
   /* @brief Current channel index into group channel_mask. */               \
-  size_t                    current_channel
+  size_t                    current_channel;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -216,7 +216,7 @@ typedef uint32_t adcerror_t;
   /* ADC CHS    register initialization data.                               \
      NOTE: The number of bits at logic level one in this register must      \
            be equal to the number in the @p num_channels field.*/           \
-  uint32_t                  chs
+  uint32_t                  chs;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SN32/LLD/SN32F2xx/RTC/hal_rtc_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/RTC/hal_rtc_lld.h
@@ -105,7 +105,7 @@ typedef struct hal_rtc_alarm {
   /* Pointer to the RTC registers block.*/                                  \
   RTC_TypeDef               *rtc;                                           \
   /* Callback pointer.*/                                                    \
-  rtccb_t           callback
+  rtccb_t           callback;
 
 /*===========================================================================*/
 /* Driver macros.                                                            */

--- a/os/hal/ports/SN32/SN32F240/hal_efl_lld.h
+++ b/os/hal/ports/SN32/SN32F240/hal_efl_lld.h
@@ -85,14 +85,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  SN_FLASH_Type             *flash
+  SN_FLASH_Type             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SN32/SN32F240/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F240/hal_lld.h
@@ -68,6 +68,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F240B/hal_efl_lld.h
+++ b/os/hal/ports/SN32/SN32F240B/hal_efl_lld.h
@@ -85,14 +85,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  SN_FLASH_Type             *flash
+  SN_FLASH_Type             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SN32/SN32F240B/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F240B/hal_lld.h
@@ -73,6 +73,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F240C/hal_efl_lld.h
+++ b/os/hal/ports/SN32/SN32F240C/hal_efl_lld.h
@@ -85,14 +85,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  SN_FLASH_Type             *flash
+  SN_FLASH_Type             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SN32/SN32F240C/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F240C/hal_lld.h
@@ -73,6 +73,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F260/hal_efl_lld.h
+++ b/os/hal/ports/SN32/SN32F260/hal_efl_lld.h
@@ -85,14 +85,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  SN_FLASH_Type             *flash
+  SN_FLASH_Type             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SN32/SN32F260/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F260/hal_lld.h
@@ -73,6 +73,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F290/hal_efl_lld.h
+++ b/os/hal/ports/SN32/SN32F290/hal_efl_lld.h
@@ -85,14 +85,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* Flash registers.*/                                                     \
-  SN_FLASH_Type             *flash
+  SN_FLASH_Type             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/SN32/SN32F290/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F290/hal_lld.h
@@ -73,6 +73,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/TIVA/TM4C123x/hal_lld.h
+++ b/os/hal/ports/TIVA/TM4C123x/hal_lld.h
@@ -220,6 +220,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/TIVA/TM4C129x/hal_lld.h
+++ b/os/hal/ports/TIVA/TM4C129x/hal_lld.h
@@ -190,6 +190,18 @@
 /* Driver macros.                                                            */
 /*===========================================================================*/
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/

--- a/os/hal/ports/WB32/LLD/ADCv1/hal_adc_lld.h
+++ b/os/hal/ports/WB32/LLD/ADCv1/hal_adc_lld.h
@@ -177,14 +177,14 @@ typedef enum {
   /* Pointer to associated DMA channel.*/                                   \
   const wb32_dma_stream_t   *dmastp;                                        \
   /* DMA mode bit mask.*/                                                   \
-  uint32_t                  dmamode                                         \
+  uint32_t                  dmamode;                                        \
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
  */
 #define adc_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /**
  * @brief   Low level fields of the ADC configuration structure.
@@ -215,7 +215,7 @@ typedef enum {
   uint32_t                  sqr2;                                           \
   /* ADC SQR3 register initialization data.                                 \
      NOTE: Conversion group sequence 1...6.*/                               \
-  uint32_t                  sqr3
+  uint32_t                  sqr3;
 
 /**
  * @name    Sequences building helper macros

--- a/os/hal/ports/WB32/LLD/RTCv1/hal_rtc_lld.h
+++ b/os/hal/ports/WB32/LLD/RTCv1/hal_rtc_lld.h
@@ -126,7 +126,7 @@ typedef struct hal_rtc_alarm {
   /* Pointer to the RTC registers block.*/                                  \
   RTC_TypeDef               *rtc;                                           \
   /* Callback pointer.*/                                                    \
-  rtccb_t           callback
+  rtccb_t           callback;
 
 /*===========================================================================*/
 /* Driver macros.                                                            */

--- a/os/hal/ports/WB32/LLD/SPIv1/hal_spi_lld.h
+++ b/os/hal/ports/WB32/LLD/SPIv1/hal_spi_lld.h
@@ -230,7 +230,7 @@ typedef struct {
   /* Pointer to the SPIx registers block.*/                                 \
   SPI_TypeDef               *spi ;                                          \
   spi_xfer_info_t           xfer;                                           \
-  uint16_t                  fifo_len
+  uint16_t                  fifo_len;
 
 /**
  * @brief   Low level fields of the SPI configuration structure.

--- a/os/hal/ports/WB32/WB32F3G71xx/hal_efl_lld.h
+++ b/os/hal/ports/WB32/WB32F3G71xx/hal_efl_lld.h
@@ -72,14 +72,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* FMC registers.*/                                                     \
-  FMC_TypeDef             *flash
+  FMC_TypeDef             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/WB32/WB32F3G71xx/hal_lld.h
+++ b/os/hal/ports/WB32/WB32F3G71xx/hal_lld.h
@@ -581,6 +581,18 @@
  */
 #define PWR_BackupAccessDISABLE()              (PWR->CR0 &= (~(0x1U)))
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/WB32/WB32FQ95xx/hal_efl_lld.h
+++ b/os/hal/ports/WB32/WB32FQ95xx/hal_efl_lld.h
@@ -72,14 +72,14 @@
  */
 #define efl_lld_driver_fields                                               \
   /* FMC registers.*/                                                     \
-  FMC_TypeDef             *flash
+  FMC_TypeDef             *flash;
 
 /**
  * @brief   Low level fields of the embedded flash configuration structure.
  */
 #define efl_lld_config_fields                                               \
   /* Dummy configuration, it is not needed.*/                               \
-  uint32_t                  dummy
+  uint32_t                  dummy;
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/WB32/WB32FQ95xx/hal_lld.h
+++ b/os/hal/ports/WB32/WB32FQ95xx/hal_lld.h
@@ -581,6 +581,18 @@
  */
 #define PWR_BackupAccessDISABLE()              (PWR->CR0 &= (~(0x1U)))
 
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Static implementation.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+#define hal_lld_get_clock_point(clkpt) 0U
+
 /** @} */
 
 /*===========================================================================*/


### PR DESCRIPTION
As per title.
Changes made to ChibiOS warrant the new clock point definitions as well as trailing semicolons on field defs.