### PR TITLE
fix: WB32 DMA Fixes

### DIFF
--- a/os/hal/ports/WB32/LLD/DMAv1/wb32_dma.c
+++ b/os/hal/ports/WB32/LLD/DMAv1/wb32_dma.c
@@ -188,11 +188,11 @@ OSAL_IRQ_HANDLER(WB32_DMAC2_IRQ_VECTOR) {
   dmaServeInterrupt(WB32_DMA2_STREAM1);
 #endif
 
-#if WB32_DMAC2_NUM_CHANNELS > 0
+#if WB32_DMAC2_NUM_CHANNELS > 1
   dmaServeInterrupt(WB32_DMA2_STREAM2);
 #endif
 
-#if WB32_DMAC2_NUM_CHANNELS > 0
+#if WB32_DMAC2_NUM_CHANNELS > 2
   dmaServeInterrupt(WB32_DMA2_STREAM3);
 #endif
 
@@ -215,7 +215,7 @@ void dmaInit(void) {
   dma.allocated_mask = 0U;
   dma.isr_mask = 0U;
 
-#if WB32_DMAC2_NUM_CHANNELS > 0
+#if WB32_DMAC1_NUM_CHANNELS > 0
   rccResetDMAC1();
 #endif
 #if WB32_DMAC2_NUM_CHANNELS > 0

--- a/os/hal/ports/WB32/LLD/DMAv1/wb32_dma.h
+++ b/os/hal/ports/WB32/LLD/DMAv1/wb32_dma.h
@@ -291,7 +291,7 @@
   * @{
   */
 #define WB32_DMAC_DST_AUTO_RELOAD_EN                         (0x1U << 31)
-#define WB32_DMAC_DST_AUTO_RELOAD_DIS                        (0x0U << 30)
+#define WB32_DMAC_DST_AUTO_RELOAD_DIS                        (0x0U << 31)
 /**
   * @}
   */
@@ -584,8 +584,9 @@ typedef struct {
  *
  * @special
  */
-#define dmaStreamSetTransactionSize(dmastp, size) {                          \
-    (dmastp)->dmac->Ch[(dmastp)->channel].CTLH = (uint32_t)((size) & 0x1FF); \
+#define dmaStreamSetTransactionSize(dmastp, size) {                                    \
+    osalDbgAssert((size) <= 511U, "DMA BLOCK_TS max 511");                              \
+    (dmastp)->dmac->Ch[(dmastp)->channel].CTLH = (uint32_t)((size) & WB32_DMA_CHCFG_SIZE_MASK); \
   }
 
 /**
@@ -858,7 +859,7 @@ typedef struct {
  * @param[in] dmastp    pointer to a wb32_dma_stream_t structure
  */
 #define dmaWaitCompletion(dmastp) {                                         \
-    while (((dmastp)->dmac->Ch[(dmastp)->channel].CTLH & 0x00000FFFU) > 0U) \
+    while (((dmastp)->dmac->Ch[(dmastp)->channel].CTLH & WB32_DMA_CHCFG_SIZE_MASK) > 0U) \
       ;                                                                     \
     dmaStreamDisable(dmastp);                                               \
   }


### PR DESCRIPTION
* Add validation for DMA Block Transfer Size Mask and use constant instead of hard coded value
* Fix ISR channel initialisation to only initialise channels that are in use
* Fix DMAC1 reset which was guarded with wrong channel
* Fix DST_AUTO_RELOAD_DIS which was off by one