### PR TITLE
fix: WB32 Timer Fixes

### DIFF
--- a/os/hal/ports/WB32/LLD/TIMv1/hal_pwm_lld.c
+++ b/os/hal/ports/WB32/LLD/TIMv1/hal_pwm_lld.c
@@ -433,11 +433,13 @@ void pwm_lld_start(PWMDriver *pwmp) {
   /* DMA-related DIER settings. */
   pwmp->tim->DIER = pwmp->config->dier & ~WB32_TIM_DIER_IRQ_MASK;
 #if WB32_PWM_USE_TIM1
+  if (&PWMD1 == pwmp) {
 #if WB32_PWM_USE_ADVANCED
-  pwmp->tim->BDTR = pwmp->config->bdtr | WB32_TIM_BDTR_MOE;
+    pwmp->tim->BDTR = pwmp->config->bdtr | WB32_TIM_BDTR_MOE;
 #else
-  pwmp->tim->BDTR = WB32_TIM_BDTR_MOE;
+    pwmp->tim->BDTR = WB32_TIM_BDTR_MOE;
 #endif
+  }
 #endif
   /* Timer configured and started.*/
   pwmp->tim->CR1 = WB32_TIM_CR1_ARPE | WB32_TIM_CR1_URS | WB32_TIM_CR1_CEN;
@@ -460,8 +462,10 @@ void pwm_lld_stop(PWMDriver *pwmp) {
     pwmp->tim->DIER = 0;
     /* Clear eventual pending IRQs.*/
     pwmp->tim->SR = 0;
-#if WB32_PWM_USE_TIM1 || WB32_PWM_USE_TIM8 || WB32_PWM_USE_TIM20
-    pwmp->tim->BDTR = 0;
+#if WB32_PWM_USE_TIM1
+    if (&PWMD1 == pwmp) {
+      pwmp->tim->BDTR = 0;
+    }
 #endif
 
 #if WB32_PWM_USE_TIM1

--- a/os/hal/ports/WB32/LLD/TIMv1/wb32_tim.h
+++ b/os/hal/ports/WB32/LLD/TIMv1/wb32_tim.h
@@ -356,7 +356,7 @@
 
 #define WB32_TIM_CCMR3_OC5M_MASK               ((7U << 4) | (1U << 16))
 #define WB32_TIM_CCMR3_OC5M(n)                 ((((n) & 7) << 4) |          \
-                                                (((n) >> 2) << 16))
+                                                (((n) >> 3) << 16))
 
 #define WB32_TIM_CCMR3_OC5CE                   (1U << 7)
 
@@ -365,7 +365,7 @@
 
 #define WB32_TIM_CCMR3_OC6M_MASK               ((7U << 12) | (1U << 24))
 #define WB32_TIM_CCMR3_OC6M(n)                 ((((n) & 7) << 12) |         \
-                                                (((n) >> 2) << 24))
+                                                (((n) >> 3) << 24))
 
 #define WB32_TIM_CCMR3_OC6CE                   (1U << 15)
 /** @} */


### PR DESCRIPTION
* Remove TIM8 and TIM20 which do not exist on this hardware
* Add guard for BDTR as only TIM1 is an Advanced Timer
* Fix off by one error OC5M and OC6M