### PR TITLE
Fix header guard definition in system_fs026.h which breaks builds with gcc 15+

### DIFF
--- a/os/common/ext/CMSIS/ES32/FS026/system_fs026.h
+++ b/os/common/ext/CMSIS/ES32/FS026/system_fs026.h
@@ -32,7 +32,7 @@
 /* Define to prevent recursive inclusion -------------------------------------*/ 
 
 #ifndef __SYSTEM_FS026_H__
-#define __SYSTEM_ES32F0283_H__
+#define __SYSTEM_FS026_H__
 
 #ifdef __cplusplus
  extern "C" {


### PR DESCRIPTION
This pull request corrects a preprocessor macro definition in the `system_fs026.h` header file to ensure the correct include guard is used.

- Fixed the include guard macro from `__SYSTEM_ES32F0283_H__` to `__SYSTEM_FS026_H__` in `system_fs026.h` to prevent potential issues with recursive inclusion or incorrect header protection.

The `-Werror=header-guard` diagnostic (which promotes the mismatched #ifndef/#define guard to a hard error) was introduced/tightened in GCC 15. On GCC 14 the mismatch is silently ignored, on GCC 15 it becomes a build-breaking error.
