### PR TITLE
FSMCv1: add STM32G4 FMC register support

### DIFF
--- a/os/hal/include/hal_fsmc.h
+++ b/os/hal/include/hal_fsmc.h
@@ -43,7 +43,9 @@
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \
-     defined(STM32F779xx) || defined(STM32H743xx))
+     defined(STM32F779xx) || defined(STM32H743xx) || \
+     defined(STM32G473xx) || defined(STM32G483xx) || \
+     defined(STM32G474xx) || defined(STM32G484xx))
   #if !defined(FSMC_Bank1_R_BASE)
   #define FSMC_Bank1_R_BASE               (FMC_R_BASE + 0x0000)
   #endif
@@ -239,7 +241,9 @@ typedef struct {
 #define  FSMC_BCR_CBURSTRW        ((uint32_t)1 << 19)
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
-     defined(STM32F7) || defined(STM32H743xx))
+     defined(STM32F7) || defined(STM32H743xx) || \
+     defined(STM32G473xx) || defined(STM32G483xx) || \
+     defined(STM32G474xx) || defined(STM32G484xx))
 #define  FSMC_BCR_CCLKEN          ((uint32_t)1 << 20)
 #endif
 #if (defined(STM32F7))

--- a/os/hal/ports/STM32/LLD/FSMCv1/hal_sram_lld.c
+++ b/os/hal/ports/STM32/LLD/FSMCv1/hal_sram_lld.c
@@ -112,7 +112,9 @@ void sram_lld_stop(SRAMDriver *sramp) {
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \
-     defined(STM32F779xx))
+     defined(STM32F779xx) || defined(STM32G473xx) || \
+     defined(STM32G483xx) || defined(STM32G474xx) || \
+     defined(STM32G484xx))
     mask |= FSMC_BCR_CCLKEN;
 #endif
     sramp->sram->BCR &= ~mask;
@@ -121,4 +123,3 @@ void sram_lld_stop(SRAMDriver *sramp) {
 #endif /* STM32_SRAM_USE_SRAM */
 
 /** @} */
-


### PR DESCRIPTION
This adds STM32G4 devices with FMC to the existing FSMCv1 compatibility layer.

The change maps STM32G473/G483/G474/G484 devices through the existing FMC base-address compatibility path and includes them in the SRAM CCLKEN handling used when stopping the SRAM driver.

This also needs matching STM32G4/FMC support on the main ChibiOS side, as proposed here:
https://forum.chibios.org/viewtopic.php?t=6698

Validation:
- External SRAM access tested successfully on STM32G474-EVAL1.
