### PR TITLE
Fix CI builds for HAL 9.1

### DIFF
--- a/demos/AT32/RT-AT-START-F402/cfg/halconf.h
+++ b/demos/AT32/RT-AT-START-F402/cfg/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/AT32/RT-AT-START-F405/cfg/halconf.h
+++ b/demos/AT32/RT-AT-START-F405/cfg/halconf.h
@@ -32,7 +32,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/AT32/RT-AT-START-F415/cfg/halconf.h
+++ b/demos/AT32/RT-AT-START-F415/cfg/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/AT32/RT-AT-START-F435/cfg/halconf.h
+++ b/demos/AT32/RT-AT-START-F435/cfg/halconf.h
@@ -32,7 +32,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/AT32/RT-AT-START-F437/cfg/halconf.h
+++ b/demos/AT32/RT-AT-START-F437/cfg/halconf.h
@@ -32,7 +32,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/ES32/ES32F0283/cfg/halconf.h
+++ b/demos/ES32/ES32F0283/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/ES32/FS026/cfg/halconf.h
+++ b/demos/ES32/FS026/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/HT32/HT32F165x_USB_DFU/cfg/halconf.h
+++ b/demos/HT32/HT32F165x_USB_DFU/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-FREEDOM-K20D50M/halconf.h
+++ b/demos/KINETIS/RT-FREEDOM-K20D50M/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-FREEDOM-KL25Z-SHELL/halconf.h
+++ b/demos/KINETIS/RT-FREEDOM-KL25Z-SHELL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-FREEDOM-KL25Z/halconf.h
+++ b/demos/KINETIS/RT-FREEDOM-KL25Z/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-MCHCK-K20-GPT/halconf.h
+++ b/demos/KINETIS/RT-MCHCK-K20-GPT/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-MCHCK-K20-SPI/halconf.h
+++ b/demos/KINETIS/RT-MCHCK-K20-SPI/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-TEENSY3/halconf.h
+++ b/demos/KINETIS/RT-TEENSY3/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/KINETIS/RT-TEENSY3_6/halconf.h
+++ b/demos/KINETIS/RT-TEENSY3_6/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/LPC/LPC_11U35_USBDFU/cfg/halconf.h
+++ b/demos/LPC/LPC_11U35_USBDFU/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/NRF51/MICROBIT/halconf.h
+++ b/demos/NRF51/MICROBIT/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/NRF51/OSHCHIP_V1.0/halconf.h
+++ b/demos/NRF51/OSHCHIP_V1.0/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/NRF51/RT-WVSHARE_BLE400/halconf.h
+++ b/demos/NRF51/RT-WVSHARE_BLE400/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/NRF52/Classic/halconf.h
+++ b/demos/NRF52/Classic/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/STM32/RT-STM32F303-DISCOVERY-PID/halconf.h
+++ b/demos/STM32/RT-STM32F303-DISCOVERY-PID/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/STM32/RT-STM32F407-DISCOVERY-fault_handlers/cfg/halconf.h
+++ b/demos/STM32/RT-STM32F407-DISCOVERY-fault_handlers/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/STM32/RT-STM32F411-DISCOVERY-blinker/cfg/halconf.h
+++ b/demos/STM32/RT-STM32F411-DISCOVERY-blinker/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/STM32/RT-STM32F429-DISCOVERY-TRIBUF/halconf.h
+++ b/demos/STM32/RT-STM32F429-DISCOVERY-TRIBUF/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/WB32/RT-WB32F3G71-RTC/Makefile
+++ b/demos/WB32/RT-WB32F3G71-RTC/Makefile
@@ -125,7 +125,7 @@ LDSCRIPT= $(STARTUPLD_CONTRIB)/WB32F3G71xC.ld
 # setting.
 CSRC = $(ALLCSRC) \
        $(TESTSRC) \
-       $(CHIBIOS)/os/various/syscalls.c \
+       $(CHIBIOS)/os/various/newlib_bindings/syscalls.c \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
        debug.c \
        main.c

--- a/demos/WB32/RT-WB32F3G71-RTC/cfg/halconf.h
+++ b/demos/WB32/RT-WB32F3G71-RTC/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/demos/WB32/RT-WB32FQ95-GENERIC/cfg/halconf.h
+++ b/demos/WB32/RT-WB32FQ95-GENERIC/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/ERTC/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/ERTC/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/ERTC/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/ERTC/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/ERTC/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/ERTC/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/I2C_HW/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/I2C_HW/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/I2C_HW/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/I2C_HW/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/I2C_HW/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/I2C_HW/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/I2C_SW/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/I2C_SW/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/I2C_SW/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/I2C_SW/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/I2C_SW/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/I2C_SW/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/PWM_ICU/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/PWM_ICU/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/PWM_ICU/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/PWM_ICU/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/PWM_ICU/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/PWM_ICU/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/SDC-FATFS/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/SDC-FATFS/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/SDC/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/SDC/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/SIO/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/SIO/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/SIO/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/SIO/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/UART/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/UART/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/UART/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/UART/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/UART/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/UART/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/USB_CDC/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/USB_CDC/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/USB_CDC/cfg/at-start-f405_usbfs/halconf.h
+++ b/testhal/AT32/multi/USB_CDC/cfg/at-start-f405_usbfs/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/USB_CDC/cfg/at-start-f405_usbhs-dma/halconf.h
+++ b/testhal/AT32/multi/USB_CDC/cfg/at-start-f405_usbhs-dma/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/USB_CDC/cfg/at-start-f405_usbhs/halconf.h
+++ b/testhal/AT32/multi/USB_CDC/cfg/at-start-f405_usbhs/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/USB_CDC/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/USB_CDC/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/WDT/cfg/at-start-f402/halconf.h
+++ b/testhal/AT32/multi/WDT/cfg/at-start-f402/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/WDT/cfg/at-start-f405/halconf.h
+++ b/testhal/AT32/multi/WDT/cfg/at-start-f405/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/AT32/multi/WDT/cfg/at-start-f415/halconf.h
+++ b/testhal/AT32/multi/WDT/cfg/at-start-f415/halconf.h
@@ -31,7 +31,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-K20D50M/I2C/halconf.h
+++ b/testhal/KINETIS/FRDM-K20D50M/I2C/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/halconf.h
+++ b/testhal/KINETIS/FRDM-K20D50M/USB_SERIAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL25Z/ADC/halconf.h
+++ b/testhal/KINETIS/FRDM-KL25Z/ADC/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL25Z/GPT/halconf.h
+++ b/testhal/KINETIS/FRDM-KL25Z/GPT/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL25Z/PWM/halconf.h
+++ b/testhal/KINETIS/FRDM-KL25Z/PWM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL25Z/USB_HID/halconf.h
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_HID/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/halconf.h
+++ b/testhal/KINETIS/FRDM-KL25Z/USB_SERIAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL26Z/I2C/halconf.h
+++ b/testhal/KINETIS/FRDM-KL26Z/I2C/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL26Z/PWM/halconf.h
+++ b/testhal/KINETIS/FRDM-KL26Z/PWM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/halconf.h
+++ b/testhal/KINETIS/FRDM-KL26Z/USB_SERIAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/KL27Z/BLINK/halconf.h
+++ b/testhal/KINETIS/KL27Z/BLINK/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/MCHCK/BOOTLOADER/halconf.h
+++ b/testhal/KINETIS/MCHCK/BOOTLOADER/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/MCHCK/PWM/halconf.h
+++ b/testhal/KINETIS/MCHCK/PWM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/MCHCK/USB_SERIAL/halconf.h
+++ b/testhal/KINETIS/MCHCK/USB_SERIAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY3_x/ADC/halconf.h
+++ b/testhal/KINETIS/TEENSY3_x/ADC/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY3_x/EEPROM_EMU/halconf.h
+++ b/testhal/KINETIS/TEENSY3_x/EEPROM_EMU/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY3_x/GPT/halconf.h
+++ b/testhal/KINETIS/TEENSY3_x/GPT/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY3_x/PWM/halconf.h
+++ b/testhal/KINETIS/TEENSY3_x/PWM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY3_x/SERIAL/halconf.h
+++ b/testhal/KINETIS/TEENSY3_x/SERIAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY3_x/USB_SERIAL/halconf.h
+++ b/testhal/KINETIS/TEENSY3_x/USB_SERIAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY_LC/BOOTLOADER/halconf.h
+++ b/testhal/KINETIS/TEENSY_LC/BOOTLOADER/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY_LC/EEPROM_EMU/halconf.h
+++ b/testhal/KINETIS/TEENSY_LC/EEPROM_EMU/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/KINETIS/TEENSY_LC/PWM/halconf.h
+++ b/testhal/KINETIS/TEENSY_LC/PWM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/ADC/halconf.h
+++ b/testhal/NRF51/NRF51822/ADC/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/GPT/halconf.h
+++ b/testhal/NRF51/NRF51822/GPT/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/I2C/halconf.h
+++ b/testhal/NRF51/NRF51822/I2C/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/PAL/halconf.h
+++ b/testhal/NRF51/NRF51822/PAL/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/PWM/halconf.h
+++ b/testhal/NRF51/NRF51822/PWM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/RNG/halconf.h
+++ b/testhal/NRF51/NRF51822/RNG/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/SPI/halconf.h
+++ b/testhal/NRF51/NRF51822/SPI/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF51/NRF51822/WDG/halconf.h
+++ b/testhal/NRF51/NRF51822/WDG/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF52/NRF52832/ADC/halconf.h
+++ b/testhal/NRF52/NRF52832/ADC/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF52/NRF52832/I2C/halconf.h
+++ b/testhal/NRF52/NRF52832/I2C/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF52/NRF52832/PWM-ICU/halconf.h
+++ b/testhal/NRF52/NRF52832/PWM-ICU/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF52/NRF52832/RADIO-ESB/Makefile
+++ b/testhal/NRF52/NRF52832/RADIO-ESB/Makefile
@@ -104,7 +104,7 @@ LDSCRIPT= $(STARTUPLD_CONTRIB)/NRF52832.ld
 # setting.
 CSRC = $(ALLCSRC) \
        $(TESTSRC) \
-       $(CHIBIOS)/os/various/syscalls.c \
+       $(CHIBIOS)/os/various/newlib_bindings/syscalls.c \
        $(CHIBIOS)/os/hal/lib/streams/memstreams.c \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
        nrf52_radio.c \

--- a/testhal/NRF52/NRF52832/RADIO-ESB/halconf.h
+++ b/testhal/NRF52/NRF52832/RADIO-ESB/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/NRF52/NRF52832/UART/Makefile
+++ b/testhal/NRF52/NRF52832/UART/Makefile
@@ -104,7 +104,7 @@ LDSCRIPT= $(STARTUPLD_CONTRIB)/NRF52832.ld
 # setting.
 CSRC = $(ALLCSRC) \
        $(TESTSRC) \
-       $(CHIBIOS)/os/various/syscalls.c \
+       $(CHIBIOS)/os/various/newlib_bindings/syscalls.c \
        $(CHIBIOS)/os/hal/lib/streams/memstreams.c \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
        main.c

--- a/testhal/NRF52/NRF52832/UART/halconf.h
+++ b/testhal/NRF52/NRF52832/UART/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/RP/RP2040/RT-RP2040-PICO-ADC/cfg/halconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-ADC/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/RP/RP2040/RT-RP2040-PICO-HID/cfg/halconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-HID/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/RP/RP2040/RT-RP2040-PICO-I2C-24AA01/cfg/halconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-I2C-24AA01/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/RP/RP2040/RT-RP2040-PICO-SERIAL/cfg/halconf.h
+++ b/testhal/RP/RP2040/RT-RP2040-PICO-SERIAL/cfg/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/SAMD21A/Blinky/cfg/halconf.h
+++ b/testhal/SAMD21A/Blinky/cfg/halconf.h
@@ -26,7 +26,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/SAMD21A/EFL-MFS/cfg/halconf.h
+++ b/testhal/SAMD21A/EFL-MFS/cfg/halconf.h
@@ -26,7 +26,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/SAMD21A/SIO/cfg/halconf.h
+++ b/testhal/SAMD21A/SIO/cfg/halconf.h
@@ -26,7 +26,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F0xx/crc/halconf.h
+++ b/testhal/STM32/STM32F0xx/crc/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F0xx/onewire/halconf.h
+++ b/testhal/STM32/STM32F0xx/onewire/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F0xx/qei/halconf.h
+++ b/testhal/STM32/STM32F0xx/qei/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F1xx/onewire/halconf.h
+++ b/testhal/STM32/STM32F1xx/onewire/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F1xx/qei/halconf.h
+++ b/testhal/STM32/STM32F1xx/qei/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F3xx/COMP/halconf.h
+++ b/testhal/STM32/STM32F3xx/COMP/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F3xx/EEProm/halconf.h
+++ b/testhal/STM32/STM32F3xx/EEProm/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F3xx/OPAMP/halconf.h
+++ b/testhal/STM32/STM32F3xx/OPAMP/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F3xx/TIMCAP/halconf.h
+++ b/testhal/STM32/STM32F3xx/TIMCAP/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/EICU/halconf.h
+++ b/testhal/STM32/STM32F4xx/EICU/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/FSMC_NAND/halconf.h
+++ b/testhal/STM32/STM32F4xx/FSMC_NAND/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/FSMC_SDRAM/halconf.h
+++ b/testhal/STM32/STM32F4xx/FSMC_SDRAM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/FSMC_SRAM/halconf.h
+++ b/testhal/STM32/STM32F4xx/FSMC_SRAM/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/USB_HOST/halconf.h
+++ b/testhal/STM32/STM32F4xx/USB_HOST/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/USB_MSD/halconf.h
+++ b/testhal/STM32/STM32F4xx/USB_MSD/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F4xx/onewire/halconf.h
+++ b/testhal/STM32/STM32F4xx/onewire/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32F7xx/USB_MSD/halconf.h
+++ b/testhal/STM32/STM32F7xx/USB_MSD/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32H7xx/USB_HOST/halconf.h
+++ b/testhal/STM32/STM32H7xx/USB_HOST/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 

--- a/testhal/STM32/STM32L0xx/COMP/halconf.h
+++ b/testhal/STM32/STM32L0xx/COMP/halconf.h
@@ -29,7 +29,7 @@
 #define HALCONF_H
 
 #define _CHIBIOS_HAL_CONF_
-#define _CHIBIOS_HAL_CONF_VER_8_4_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
 
 #include "mcuconf.h"
 


### PR DESCRIPTION
Updates CI-covered HAL configurations for HAL 9.1 and fixes relocated Newlib syscalls paths for NRF52 and WB32.

All CI builds [pass](https://github.com/Belonit/ChibiOS-Contrib/actions/runs/30184967658/job/89747881095?pr=2).