### PR TITLE
Update CI actions for Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: fiam/arm-none-eabi-gcc@v1
+    - uses: actions/checkout@v6
+    - uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
         release: '10-2020-q4'
     - name: setup vars


### PR DESCRIPTION
Update the checkout and Arm GCC setup actions to Node.js 24-compatible versions.

The Arm GNU Toolchain remains pinned to 10-2020-q4.