### PR TITLE
AT32F402/405: fix invalid LDO voltage configuration

### DIFF
--- a/os/hal/ports/AT32/AT32F402_405/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F402_405/hal_lld.h
@@ -194,9 +194,9 @@
  * @name    PWC_LDOOV register bits definitions
  * @{
  */
-#define AT32_LDOOVSEL_LEV0          (0 << 0)             /**< LDOOVSEL level 0.                  */
-#define AT32_LDOOVSEL_LEV2          (2 << 0)             /**< LDOOVSEL level 2.                  */
-#define AT32_LDOOVSEL_LEV3          (3 << 0)             /**< LDOOVSEL level 3.                  */
+#define AT32_LDOOVSEL_LEV1          (1 << 0)             /**< LDOOVSEL level 1.1V.                */
+#define AT32_LDOOVSEL_LEV2          (2 << 0)             /**< LDOOVSEL level 1.2V.                */
+#define AT32_LDOOVSEL_LEV3          (3 << 0)             /**< LDOOVSEL level 1.3V.                */
 /** @} */
 
 /**
@@ -1064,12 +1064,12 @@
 #error "AT32 bus clock exceeding maximum frequency when LDO is 1.2V"
 #endif
 
-#elif AT32_LDOOVSEL == AT32_LDOOVSEL_LEV0
+#elif AT32_LDOOVSEL == AT32_LDOOVSEL_LEV1
 
 #if (AT32_HCLK > 108000000) ||                                              \
     (AT32_PCLK1 > AT32_HCLK) ||                                             \
     (AT32_PCLK2 > AT32_HCLK)
-#error "AT32 bus clock exceeding maximum frequency when LDO is 1.0V"
+#error "AT32 bus clock exceeding maximum frequency when LDO is 1.1V"
 #endif
 
 #else


### PR DESCRIPTION
Change the LDO configuration from 1.0V to 1.1V.

According to the official datasheet, the value corresponding to 1.0V is reserved and not supported:

00: Reserved
01: 1.1V
10: 1.2V
11: 1.3V